### PR TITLE
Fix handling of erroneous finalize calls

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -69,13 +69,16 @@ static char shmem_internal_my_hostname[HOST_NAME_MAX];
 
 
 static void
-shmem_internal_shutdown(void)
+shmem_internal_shutdown(int barrier_requested)
 {
     if (!shmem_internal_initialized ||
         shmem_internal_finalized) {
         return;
     }
     shmem_internal_finalized = 1;
+
+    if (barrier_requested)
+        shmem_internal_barrier_all();
 
     shmem_transport_fini();
 
@@ -102,7 +105,7 @@ shmem_internal_shutdown_atexit(void)
         fprintf(stderr, "Warning: shutting down without a call to shmem_finalize()\n");
     }
 
-    shmem_internal_shutdown();
+    shmem_internal_shutdown(0);
 }
 
 
@@ -355,8 +358,7 @@ shmem_internal_nodename(void)
 
 void shmem_internal_finalize(void)
 {
-    shmem_internal_barrier_all();
-    shmem_internal_shutdown();
+    shmem_internal_shutdown(1);
 }
 
 


### PR DESCRIPTION
Fix handling of calls to finalize when the library is uninitialized or
already finalized.

Signed-off-by: James Dinan <james.dinan@intel.com>