### PR TITLE
pmi: add support for pmi2

### DIFF
--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -1,0 +1,227 @@
+# -*- shell-script ; indent-tabs-mode:nil -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2014      Intel, Inc. All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+#
+# NOTE: this is a modified version of the opal_check_pmi.m4 file from
+# the Open MPI project.
+#
+
+# define an internal function for checking the existence
+# and validity of a PMI library
+#
+# OPAL_CHECK_PMI_LIB(installdir, libdir, pmi, function, [action-if-slurm], [action-if-valid], [action-if-not-valid])
+# --------------------------------------------------------
+AC_DEFUN([OPAL_CHECK_PMI_LIB],
+[
+    # save flags
+    opal_check_$3_save_CPPFLAGS=$CPPFLAGS
+    opal_check_$3_save_LDFLAGS=$LDFLAGS
+    opal_check_$3_save_LIBS=$LIBS
+    opal_check_$3_hdr_happy=
+    opal_check_$3_mycppflags=
+
+    # check for the header
+    AC_MSG_CHECKING([for $3.h in $1/include])
+    AS_IF([test -f $1/include/$3.h],
+          [AC_MSG_RESULT([found])
+           opal_check_$3_mycppflags="-I$1/include"],
+          [AC_MSG_RESULT([not found])
+           AC_MSG_CHECKING([for $3.h in $1/include/slurm])
+           AS_IF([test -f $1/include/slurm/$3.h],
+                 [AC_MSG_RESULT([found])
+                  opal_check_$3_mycppflags="-I$1/include/slurm"
+                  $5],
+                 [AC_MSG_RESULT([not found])
+                  opal_check_$3_hdr_happy=no])])
+
+    AS_IF([test "$opal_check_$3_hdr_happy" != "no"],
+          [CPPFLAGS="$CPPFLAGS $opal_check_$3_mycppflags"
+            AC_CHECK_HEADER([$3.h],
+                            [opal_check_$3_hdr_happy=yes
+                             $3_CPPFLAGS="$opal_check_$3_mycppflags"],
+                            [opal_check_$3_hdr_happy=no])])
+
+    # check for library and function
+    opal_check_$3_lib_happy=
+    LIBS="$LIBS -l$3"
+
+    # check for the library in the given location in case
+    # an exact path was given
+    AC_MSG_CHECKING([for lib$3 in $2])
+    files=`ls $2/lib$3.* 2> /dev/null | wc -l`
+    AS_IF([test "$files" -gt "0"],
+          [AC_MSG_RESULT([found])
+           LDFLAGS="$LDFLAGS -L$2"
+           AC_CHECK_LIB([$3], [$4],
+                        [opal_check_$3_lib_happy=yes
+                         pmi_LDFLAGS=-L$2
+                         pmi_LIBS=-l$3
+                         pmi_rpath=$2],
+                        [opal_check_$3_lib_happy=no])],
+          [opal_check_$3_lib_happy=no
+           AC_MSG_RESULT([not found])])
+
+    # check for presence of lib64 directory - if found, see if the
+    # desired library is present and matches our build requirements
+    files=`ls $2/lib64/lib$3.* 2> /dev/null | wc -l`
+    AS_IF([test "$opal_check_$3_lib_happy" != "yes"],
+          [AC_MSG_CHECKING([for lib$3 in $2/lib64])
+           AS_IF([test "$files" -gt "0"],
+                 [AC_MSG_RESULT([found])
+                  LDFLAGS="$LDFLAGS -L$2/lib64"
+                  AC_CHECK_LIB([$3], [$4],
+                               [opal_check_$3_lib_happy=yes
+                                pmi_LDFLAGS=-L$2/lib64
+                                pmi_LIBS=-l$3
+                                pmi_rpath=$2/lib64],
+                               [opal_check_$3_lib_happy=no])],
+                 [opal_check_$3_lib_happy=no
+                  AC_MSG_RESULT([not found])])])
+
+
+    # if we didn't find lib64, or the library wasn't present or correct,
+    # then try a lib directory if present
+    files=`ls $2/lib/lib$3.* 2> /dev/null | wc -l`
+    AS_IF([test "$opal_check_$3_lib_happy" != "yes"],
+          [AC_MSG_CHECKING([for lib$3 in $2/lib])
+           AS_IF([test "$files" -gt "0"],
+                 [AC_MSG_RESULT([found])
+                  LDFLAGS="$LDFLAGS -L$2/lib"
+                  AC_CHECK_LIB([$3], [$4],
+                               [opal_check_$3_lib_happy=yes
+                                pmi_LDFLAGS=-L$2/lib
+                                pmi_LIBS=-l$3
+                                pmirpath=$2/lib],
+                               [opal_check_$3_lib_happy=no])],
+                 [opal_check_$3_lib_happy=no
+                  AC_MSG_RESULT([not found])])])
+
+    # restore flags
+    CPPFLAGS=$opal_check_$3_save_CPPFLAGS
+    LDFLAGS=$opal_check_$3_save_LDFLAGS
+    LIBS=$opal_check_$3_save_LIBS
+
+    AS_IF([test "$opal_check_$3_hdr_happy" = "yes" && test "$opal_check_$3_lib_happy" = "yes"],
+          [$6], [$7])
+
+])
+
+# OPAL_CHECK_PMI()
+# --------------------------------------------------------
+AC_DEFUN([OPAL_CHECK_PMI],[
+    OPAL_VAR_SCOPE_PUSH([check_pmi_install_dir check_pmi_lib_dir default_pmi_loc default_pmi_libloc slurm_pmi_found])
+
+    AC_ARG_WITH([pmi],
+                [AC_HELP_STRING([--with-pmi(=DIR)],
+                                [Build PMI support, optionally adding DIR to the search path (default: no)])],
+                                [], with_pmi=no)
+
+    AC_ARG_WITH([pmi-libdir],
+                [AC_HELP_STRING([--with-pmi-libdir(=DIR)],
+                                [Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
+
+    check_pmi_install_dir=
+    check_pmi_lib_dir=
+    default_pmi_loc=
+    default_pmi_libloc=
+    slurm_pmi_found=
+
+    AC_MSG_CHECKING([if user requested PMI support])
+    AS_IF([test "$with_pmi" = "no"],
+          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([yes])
+           # cannot use OPAL_CHECK_PACKAGE as its backend header
+           # support appends "include" to the path, which won't
+           # work with slurm :-(
+           AS_IF([test ! -z "$with_pmi" && test "$with_pmi" != "yes"],
+                 [check_pmi_install_dir=$with_pmi
+                  default_pmi_loc=no],
+                 [check_pmi_install_dir=/usr
+                  default_pmi_loc=yes])
+           AS_IF([test ! -z "$with_pmi_libdir"],
+                 [check_pmi_lib_dir=$with_pmi_libdir
+		  default_pmi_libloc=no],
+                 [check_pmi_lib_dir=$check_pmi_install_dir
+		  AS_IF([test "$default_pmi_loc" = "no"],
+		        [default_pmi_libloc=no],
+			[default_pmi_libloc=yes])])
+
+           # check for pmi-1 lib */
+           slurm_pmi_found=no
+           OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+	                      [$check_pmi_lib_dir],
+                              [pmi], [PMI_Init],
+                              [slurm_pmi_found=yes],
+                              [opal_enable_pmi1=yes
+                               opal_pmi1_LIBS="-lpmi"],
+                              [opal_enable_pmi1=no])
+
+           # check for pmi2 lib */
+           slurm_pmi_found=no
+           OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+                              [$check_pmi_lib_dir],
+                              [pmi2], [PMI2_Init],
+                              [slurm_pmi_found=yes],
+                              [opal_enable_pmi2=yes
+                               opal_pmi2_LIBS="-lpmi2"],
+                              [opal_enable_pmi2=no])
+
+dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
+
+           AS_IF([test "$opal_enable_pmi2" = "no"],
+                 [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+                                     [$check_pmi_lib_dir],
+                                     [pmi], [PMI2_Init],
+                                     [slurm_pmi_found=yes],
+                                     [opal_enable_pmi2=yes
+                                      opal_pmi2_LIBS="-lpmi"],
+                                     [opal_enable_pmi2=no])],[])
+
+           # since support was explicitly requested, then we should error out
+           # if we didn't find the required support
+	   AC_MSG_CHECKING([can PMI support be built])
+           AS_IF([test "$opal_enable_pmi1" != "yes" && test "$opal_enable_pmi2" != "yes"],
+                 [AC_MSG_RESULT([no])
+                  AC_MSG_WARN([PMI support requested (via --with-pmi) but neither pmi.h])
+		  AC_MSG_WARN([nor pmi2.h were found under locations:])
+                  AC_MSG_WARN([    $check_pmi_install_dir])
+                  AC_MSG_WARN([    $check_pmi_install_dir/slurm])
+                  AC_MSG_WARN([Specified path: $with_pmi])
+		  AC_MSG_WARN([OR neither libpmi nor libpmi2 were found under:])
+                  AC_MSG_WARN([    $check_pmi_lib_dir/lib])
+                  AC_MSG_WARN([    $check_pmi_lib_dir/lib64])
+                  AC_MSG_WARN([Specified path: $with_pmi_libdir])
+                  AC_MSG_ERROR([Aborting])],
+                 [AC_MSG_RESULT([yes])])
+           ])
+
+           AS_IF([test "$opal_enable_pmi1" = "yes" && test "$opal_enable_pmi2" != "yes"],
+                 [$1="pmi1"],[])
+
+           AS_IF([test "$opal_enable_pmi2" = "yes"],
+                 [$1="pmi2"],[])
+
+    OPAL_VAR_SCOPE_POP
+])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -153,6 +153,29 @@ AC_DEFUN([OPAL_CHECK_PMI],[
     default_pmi_libloc=
     slurm_pmi_found=
 
+    # enable Portals4 PMI if using Portals4 provider else slurm PMI check
+    AS_IF([ test ! -z "$with_portals4"],[
+        AS_IF([test ! -z "$with_pmi" -a "$with_pmi" != "yes"],
+                [ompi_check_pmi_dir="$with_pmi"])
+        AS_IF([test ! -z "$with_pmi_libdir" -a "$with_pmi_libdir" != "yes"],
+                [ompi_check_pmi_libdir="$with_pmi_libdir"])
+
+        AS_IF([test -z "$with_pmi" -o "$with_pmi" = "yes"],
+                [ompi_check_pmi_dir="$with_portals4"])
+        OMPI_CHECK_PACKAGE([],
+                [portals4/pmi.h],
+                [portals_runtime],
+                [PMI_Init],
+                [],
+                [$ompi_check_pmi_dir],
+                [$ompi_check_pmi_libdir],
+                [AC_DEFINE([PMI_PORTALS4], [1],
+                        [Defined to 1 if PMI implementation is Portals4.])
+                 ompi_check_pmi_happy="yes"],
+                [ompi_check_pmi_happy="no"])], [
+
+      #else slurm PMI check
+
     AC_MSG_CHECKING([if user requested PMI support])
     AS_IF([test "$with_pmi" = "no"],
           [AC_MSG_RESULT([no])],
@@ -203,8 +226,7 @@ dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
                                      [slurm_pmi_found=yes],
                                      [opal_enable_pmi2=yes
                                       opal_pmi2_LIBS="-lpmi"],
-                                     [opal_enable_pmi2=no])],[])],
-                [opal_enable_pmi2=no])
+                                     [opal_enable_pmi2=no])],[])])
 
            # since support was explicitly requested, then we should error out
            # if we didn't find the required support
@@ -229,6 +251,8 @@ dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
 
            AS_IF([test "$opal_enable_pmi2" = "yes"],
                  [$1="pmi2"],[])
-
+    ])
+    TEST_RUNNER='$(abs_top_builddir)/src/oshrun -np $(NPROCS)'
+    AC_SUBST(TEST_RUNNER)
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -142,6 +142,11 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                 [AC_HELP_STRING([--with-pmi-libdir(=DIR)],
                                 [Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
 
+    AC_ARG_ENABLE([pmi1],
+                [AS_HELP_STRING([--enable-pmi1],
+                                [If slurm has both PMI1 and PMI2, PMI2 will be used by default, override this for PMI1 if need-be (default: disabled)])],
+                                [], enable_pmi1=no)
+
     check_pmi_install_dir=
     check_pmi_lib_dir=
     default_pmi_loc=
@@ -179,8 +184,9 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                               [opal_enable_pmi1=no])
 
            # check for pmi2 lib */
+           AS_IF([test "$enable_pmi1" = "no"],
            slurm_pmi_found=no
-           OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+                [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
                               [$check_pmi_lib_dir],
                               [pmi2], [PMI2_Init],
                               [slurm_pmi_found=yes],
@@ -197,7 +203,8 @@ dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
                                      [slurm_pmi_found=yes],
                                      [opal_enable_pmi2=yes
                                       opal_pmi2_LIBS="-lpmi"],
-                                     [opal_enable_pmi2=no])],[])
+                                     [opal_enable_pmi2=no])],[])],
+                [opal_enable_pmi2=no])
 
            # since support was explicitly requested, then we should error out
            # if we didn't find the required support

--- a/configure.ac
+++ b/configure.ac
@@ -192,9 +192,11 @@ AS_IF([test "$transport_portals4" != "yes" -a "$transport_xpmem" != "yes" -a "$t
 AC_ARG_ENABLE([pmi-simple], [AC_HELP_STRING([--enable-pmi-simple],
 			[build and run shmem-pmi support])])
 AS_IF([test "$enable_pmi_simple" = "yes"],
-     [TEST_RUNNER='$(abs_top_builddir)/src/oshrun -n $(NPROCS)' SHMEM_PMI="shmem_pmi"], [ORTE_CHECK_PMI([pmi]) SHMEM_PMI=""])
+     [TEST_RUNNER='$(abs_top_builddir)/src/oshrun -n $(NPROCS)' SHMEM_PMI="shmem_pmi"],
+     [OPAL_CHECK_PMI(pmi_type) SHMEM_PMI=""])
 AC_SUBST([SHMEM_PMI])
 AM_CONDITIONAL([USE_SHMEM_PMI], [test "$enable_pmi_simple" = "yes"])
+AM_CONDITIONAL([USE_PMI2], [test "$pmi_type" = "pmi2"])
 
 dnl check for header files
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,7 +20,6 @@ libsma_la_SOURCES = \
 	shmem_free_list.c \
 	shmem_atomic.h \
 	runtime.h \
-	runtime-pmi.c \
 	shmem_internal.h \
 	shmem_internal_op.h \
 	shmem_comm.h \
@@ -92,6 +91,15 @@ libsma_la_LIBADD = \
 	../shmem_pmi/simple_pmi.lo \
 	../shmem_pmi/simple_pmiutil.lo
 endif
+
+if USE_PMI2
+libsma_la_SOURCES += \
+	runtime-pmi2.c
+else
+libsma_la_SOURCES += \
+	runtime-pmi.c
+endif
+
 
 bin_SCRIPTS = oshcc oshc++ oshrun
 CLEANFILES += oshcc oshc++ oshrun


### PR DESCRIPTION
This commit adds support for using pmi2 and hence
the ability to use the Cray PMI.  Cray PMI is weird in
several ways:

1) the PMI_KVX functions only work when craypich is launched
   using hydra (only supported on single node)
2) Cray has PMI2 but doesn't install a libpmi2
3) Cray has PMI2 but doesn't define PMI2_SUCCESS.

Verified using a modified ofi-transport.c that some of the
perf test work using socket provider on cray.

More work is need to the ofi layer to get the GNI provider
to work with sandia shmem.

@kseager 
@jdinan 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>