### PR TITLE
request FI_RMA_EVENT in caps

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -708,9 +708,9 @@ static inline int query_for_fabric(struct fi_info ** p_info, char *provname)
     fabric_attr.prov_name = provname;
 
     hints.caps	  = FI_RMA |     /* request rma capability
-
-					    implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
-	    FI_ATOMICS; /* request atomics capability */
+                                    implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
+                   FI_ATOMICS |  /* request atomics capability */
+                   FI_RMA_EVENT; /* want to use remote counters */
     hints.addr_format         = FI_FORMAT_UNSPEC;
     hints.mode		      = FI_CONTEXT;
     domain_attr.data_progress = FI_PROGRESS_AUTO;


### PR DESCRIPTION
Since sandia-shmem over ofi by defalt tries to
use remote counters, it needs to request FI_RMA_EVENT
caps.  According to the libfabric man pages, this secondary
capability is required in order for the app to be able to
rely on remote counters being supported by the provider.

there was also some white space cleanup here.
unfortunately it looks like some folks use tabs, others use spaces.

@jdinan 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>