### PR TITLE
Travis: Update success check for UH C tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
     - make $TRAVIS_PAR_MAKE C_feature_tests F_feature_tests
     #- make C_feature_tests-run 2>&1 | tee uh-tests-c-feature-tests.log
     # Check for failures in the C tests
-    #- if grep -qi Fail uh-tests-c-feature-tests.log; then false; else true; fi
+    #- if grep "^(test_[0-9]\+) Running.*Failed$" uh-tests-c-feature-tests.log; then false; else true; fi
     #- make F_feature_tests-run 2>&1 | tee uh-tests-f-feature-tests.log
     # Check for failures in the Fortran tests
     #- if grep "^(test_[0-9]\+) Running.*Failed$" uh-tests-f-feature-tests.log; then false; else true; fi
@@ -128,7 +128,7 @@ script:
     - make $TRAVIS_PAR_MAKE C_feature_tests F_feature_tests
     - make C_feature_tests-run 2>&1 | tee uh-tests-c-feature-tests.log
     # Check for failures in the C tests
-    - if grep -qi Fail uh-tests-c-feature-tests.log; then false; else true; fi
+    - if grep "^(test_[0-9]\+) Running.*Failed$" uh-tests-c-feature-tests.log; then false; else true; fi
     - make F_feature_tests-run 2>&1 | tee uh-tests-f-feature-tests.log
     # Check for failures in the Fortran tests
     - if grep "^(test_[0-9]\+) Running.*Failed$" uh-tests-f-feature-tests.log; then false; else true; fi


### PR DESCRIPTION
UH C tests have been updated to use the testing harness.  Update Travis success check to match.