### PR TITLE
Drop fabric info update after free

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -816,9 +816,6 @@ int shmem_transport_init(long eager_size)
 
     fi_freeinfo(p_info);
 
-    if(provname)
-      p_info->fabric_attr->prov_name = NULL;
-
     return 0;
 }
 


### PR DESCRIPTION
Drop a statement that had no effect and was invalid because it accessed
a pointer after the corresponding object was freed.

Signed-off-by: James Dinan <james.dinan@intel.com>