### PR TITLE
Clean up and extend fabric selection code

### DIFF
--- a/README
+++ b/README
@@ -154,10 +154,10 @@ options.
         doubling (recdbl) will fall back to ring if the PE set is not a
         power of two in size.
 
-    CMA_PUT_MAX (default: 8192)
+    SMA_CMA_PUT_MAX (default: 8192)
         '--with-cma', shmem put lengths <= CMA_PUT_MAX use process_vm_writev();
         otherwise use Portals4 transport put.
 
-    CMA_GET_MAX (default: 16384)
+    SMA_CMA_GET_MAX (default: 16384)
         '--with-cma', shmem get lengths <= CMA_GET_MAX use process_vm_readv();
         otherwise use Portals4 transport get.

--- a/README
+++ b/README
@@ -172,3 +172,9 @@ options.
         Shell-style wildcards, including * and ?, are allowed.  The fi_info
         utility included with libfabric can be used for assistance with
         identifying the desired fabric.
+
+    SMA_OFI_DOMAIN (default: auto)
+        The name of the fabric domain that should be used by the OFI transport.
+        Shell-style wildcards, including * and ?, are allowed.  The fi_info
+        utility included with libfabric can be used for assistance with
+        identifying the desired fabric domain.

--- a/README
+++ b/README
@@ -161,3 +161,14 @@ options.
     SMA_CMA_GET_MAX (default: 16384)
         '--with-cma', shmem get lengths <= CMA_GET_MAX use process_vm_readv();
         otherwise use Portals4 transport get.
+
+  OFI Transport Environment variables:
+
+    SMA_OFI_PROVIDER (default: auto)
+        The name of the provider that should be used by the OFI transport.
+
+    SMA_OFI_FABRIC (default: auto)
+        The name of the fabric that should be used by the OFI transport.
+        Shell-style wildcards, including * and ?, are allowed.  The fi_info
+        utility included with libfabric can be used for assistance with
+        identifying the desired fabric.

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,7 @@ AM_CONDITIONAL([USE_SHMEM_PMI], [test "$enable_pmi_simple" = "yes"])
 AM_CONDITIONAL([USE_PMI2], [test "$pmi_type" = "pmi2"])
 
 dnl check for header files
+AC_CHECK_HEADERS([fnmatch.h])
 
 dnl check for types
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -792,7 +792,11 @@ int shmem_transport_init(long eager_size)
     struct fabric_info info = {0};
 
     info.npes      = shmem_runtime_get_size();
+
     info.prov_name = shmem_util_getenv_str("OFI_PROVIDER");
+    if (NULL == info.prov_name)
+        info.prov_name = shmem_util_getenv_str("OFI_USE_PROVIDER");
+
     info.fabric_name = shmem_util_getenv_str("OFI_FABRIC");
     info.domain_name = shmem_util_getenv_str("OFI_DOMAIN");
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -35,7 +35,6 @@ struct fabric_info {
     struct fi_info *fabrics;
     struct fi_info *p_info;
     char *prov_name;
-    char *svc_name;
     char *fabric_name;
     int npes;
 };
@@ -734,12 +733,11 @@ static inline int query_for_fabric(struct fabric_info *info)
 
     /* find fabric provider to use that is able to support RMA and ATOMICS */
     ret = fi_getinfo( FI_VERSION(OFI_MAJOR_VERSION, OFI_MINOR_VERSION),
-                      NULL, info->svc_name, 0, &hints, &(info->fabrics));
+                      NULL, NULL, 0, &hints, &(info->fabrics));
 
     if(ret!=0){
-        OFI_ERRMSG("OFI transport did not find any valid fabric services (prov=%s, svc=%s)\n",
-                   info->prov_name != NULL ? info->prov_name : "<auto>",
-                   info->svc_name != NULL ? info->svc_name : "<auto>");
+        OFI_ERRMSG("OFI transport did not find any valid fabric services (provider=%s)\n",
+                   info->prov_name != NULL ? info->prov_name : "<auto>");
 	return ret;
     }
 
@@ -762,9 +760,8 @@ static inline int query_for_fabric(struct fabric_info *info)
     }
 
     if(NULL == info->p_info) {
-        OFI_ERRMSG("OFI transport did not find a valid fabric service (prov=%s, svc=%s, fabric=%s)\n",
+        OFI_ERRMSG("OFI transport did not find a valid fabric service (prov=%s, fabric=%s)\n",
                    info->prov_name != NULL ? info->prov_name : "<auto>",
-                   info->svc_name != NULL ? info->svc_name : "<auto>",
                    info->fabric_name != NULL ? info->fabric_name : "<auto>");
 	return ret;
     }
@@ -790,7 +787,6 @@ int shmem_transport_init(long eager_size)
 
     info.npes      = shmem_runtime_get_size();
     info.prov_name = shmem_util_getenv_str("OFI_USE_PROVIDER");
-    info.svc_name  = shmem_util_getenv_str("OFI_SERVICE");
     info.fabric_name = shmem_util_getenv_str("OFI_FABRIC");
 
     ret = query_for_fabric(&info);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -733,24 +733,26 @@ static inline int query_for_fabric(struct fabric_info *info)
     info->p_info = info->fabrics;
 
     if(ret!=0){
-	OFI_ERRMSG("getinfo didn't find any providers\n");
+        OFI_ERRMSG("OFI transport did not find any valid fabric services (prov=%s, svc=%s)\n",
+                   info->prov_name != NULL ? info->prov_name : "<auto>",
+                   info->svc_name != NULL ? info->svc_name : "<auto>");
 	return ret;
     }
 
     if(NULL == info->p_info) {
-	OFI_ERRMSG("pinfo is null\n");
+        OFI_ERRMSG("OFI transport did not find any valid fabrics\n");
 	return ret;
     }
 
-    if(info->p_info->ep_attr->max_msg_size) {
-	shmem_transport_ofi_max_msg_size = info->p_info->ep_attr->max_msg_size;
+    if(info->p_info->ep_attr->max_msg_size > 0) {
+        shmem_transport_ofi_max_msg_size = info->p_info->ep_attr->max_msg_size;
     } else {
-	OFI_ERRMSG("provider hasn't set max_msg_size\n");
+        OFI_ERRMSG("OFI provider did not set max_msg_size\n");
 	return 1;
     }
 
-    if(info->p_info->tx_attr->inject_size > shmem_transport_ofi_max_buffered_send)
-	shmem_transport_ofi_max_buffered_send = info->p_info->tx_attr->inject_size;
+    shmem_internal_assertp(info->p_info->tx_attr->inject_size >= shmem_transport_ofi_max_buffered_send);
+    shmem_transport_ofi_max_buffered_send = info->p_info->tx_attr->inject_size;
 
     return ret;
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -30,6 +30,7 @@ struct fabric_info {
     struct fi_info *p_info;
     char *prov_name;
     char *svc_name;
+    char *fabric_name;
     int npes;
 };
 
@@ -729,9 +730,6 @@ static inline int query_for_fabric(struct fabric_info *info)
     ret = fi_getinfo( FI_VERSION(OFI_MAJOR_VERSION, OFI_MINOR_VERSION),
                       NULL, info->svc_name, 0, &hints, &(info->fabrics));
 
-    /* Select the first fabric in the list */
-    info->p_info = info->fabrics;
-
     if(ret!=0){
         OFI_ERRMSG("OFI transport did not find any valid fabric services (prov=%s, svc=%s)\n",
                    info->prov_name != NULL ? info->prov_name : "<auto>",
@@ -739,8 +737,29 @@ static inline int query_for_fabric(struct fabric_info *info)
 	return ret;
     }
 
+    /* If the user supplied a fabric name, lookup the address and use it to
+     * query for fabric.  Otherwise, select the first fabric in the list. */
+    if (info->fabric_name != NULL) {
+        struct fi_info *cur_fabric;
+
+        info->p_info = NULL;
+
+        for (cur_fabric = info->fabrics; cur_fabric; cur_fabric = cur_fabric->next) {
+            if (strcmp(info->fabric_name, cur_fabric->fabric_attr->name) == 0) {
+                info->p_info = cur_fabric;
+                break;
+            }
+        }
+    }
+    else {
+        info->p_info = info->fabrics;
+    }
+
     if(NULL == info->p_info) {
-        OFI_ERRMSG("OFI transport did not find any valid fabrics\n");
+        OFI_ERRMSG("OFI transport did not find a valid fabric service (prov=%s, svc=%s, fabric=%s)\n",
+                   info->prov_name != NULL ? info->prov_name : "<auto>",
+                   info->svc_name != NULL ? info->svc_name : "<auto>",
+                   info->fabric_name != NULL ? info->fabric_name : "<auto>");
 	return ret;
     }
 
@@ -766,6 +785,7 @@ int shmem_transport_init(long eager_size)
     info.npes      = shmem_runtime_get_size();
     info.prov_name = shmem_util_getenv_str("OFI_USE_PROVIDER");
     info.svc_name  = shmem_util_getenv_str("OFI_SERVICE");
+    info.fabric_name = shmem_util_getenv_str("OFI_FABRIC");
 
     ret = query_for_fabric(&info);
     if(ret!=0)

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -786,7 +786,7 @@ int shmem_transport_init(long eager_size)
     struct fabric_info info = {0};
 
     info.npes      = shmem_runtime_get_size();
-    info.prov_name = shmem_util_getenv_str("OFI_USE_PROVIDER");
+    info.prov_name = shmem_util_getenv_str("OFI_PROVIDER");
     info.fabric_name = shmem_util_getenv_str("OFI_FABRIC");
 
     ret = query_for_fabric(&info);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -17,6 +17,12 @@
 #include <unistd.h>
 #include <stdint.h>
 
+#if HAVE_FNMATCH_H
+#include <fnmatch.h>
+#else
+#define fnmatch(P, S, F) strcmp(P, S)
+#endif
+
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
 #include "shmem_internal.h"
@@ -745,7 +751,7 @@ static inline int query_for_fabric(struct fabric_info *info)
         info->p_info = NULL;
 
         for (cur_fabric = info->fabrics; cur_fabric; cur_fabric = cur_fabric->next) {
-            if (strcmp(info->fabric_name, cur_fabric->fabric_attr->name) == 0) {
+            if (fnmatch(info->fabric_name, cur_fabric->fabric_attr->name, 0) == 0) {
                 info->p_info = cur_fabric;
                 break;
             }


### PR DESCRIPTION
* Adds support for SMA_OFI_FABRIC env var to allow users to specify the fabric name (```fabric_attr->name```).  Shell-style wildcards can be used (e.g. SMA_OFI_FABRIC="en*").
* Removes support for the SMA_OFI_SERVICE env var, which is not anticipated to be useful for configuring the fabric with SHMEM.

This change is leading libfabric by a bit, but I think it's stable enough to merge.  In the future, I anticipate also adding a similar SMA_OFI_DOMAIN option to allow users to also specify the desired fabric domain.