### PR TITLE
Update recdbl psync atomic to use SUM/INT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,9 +217,9 @@ AC_CHECK_SIZEOF([void*])
 C_LOG_MAXPES=32
 C_BCAST_SYNC_SIZE=1
 C_REDUCE_SYNC_SIZE=`$PERL -e "print $C_BCAST_SYNC_SIZE + 2 + $C_LOG_MAXPES"`
-C_BARRIER_SYNC_SIZE=`$PERL -e "use POSIX; print ceil($ac_cv_sizeof_int * 8 / $ac_cv_sizeof_long)"`
+C_BARRIER_SYNC_SIZE=`$PERL -e "use POSIX; print $ac_cv_sizeof_int * 8 * ($ac_cv_sizeof_int / $ac_cv_sizeof_long)"`
 tree_sync_size=`$PERL -e "print $C_BCAST_SYNC_SIZE + 3"`
-recdbl_sync_size=`$PERL -e "use POSIX; print ceil($ac_cv_sizeof_int * 8 / $ac_cv_sizeof_long)"`
+recdbl_sync_size=`$PERL -e "use POSIX; print $ac_cv_sizeof_int * 8 * ($ac_cv_sizeof_int / $ac_cv_sizeof_long)"`
 AS_IF([test $tree_sync_size -lt $recdbl_sync_size],
       [C_COLLECT_SYNC_SIZE=$recdbl_sync_size], [C_COLLECT_SYNC_SIZE=$tree_sync_size])
 C_ALLTOALL_SYNC_SIZE=1


### PR DESCRIPTION
The recursive doubling collectives used atomic sum on signed byte in
their psync updates.  This added a dependence on the transport layer
supporting atomic sum on byte, which caused a portability issue for the
GNI provider.

This update replaces signed byte with signed int, which results in a
larger psync; however, it still fits in a cache line on systems with
32-bit integers.

Signed-off-by: James Dinan <james.dinan@intel.com>