### PR TITLE
Add received counter to transport interface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -190,7 +190,9 @@ CHECK_CMA(
 AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
-      [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])])
+      [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
+       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
+      ])
 
 AS_IF([test "$transport_portals4" != "yes" -a "$transport_xpmem" != "yes" -a "$transport_cma" != "yes" -a "$transport_ofi" != "yes"],
       [AC_MSG_ERROR([No transport found])])

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -79,7 +79,7 @@ shmem_internal_fence(void)
     } while(0)
 
 
-#if defined(ENABLE_HARD_POLLING) || defined(USE_ON_NODE_COMMS)
+#if defined(ENABLE_HARD_POLLING)
 
 #define SHMEM_WAIT(var, value)                           \
     do {                                                 \

--- a/src/transport.h
+++ b/src/transport.h
@@ -245,6 +245,28 @@ void shmem_transport_get_ct(shmem_transport_ct_t *ct, void
     RAISE_ERROR_STR("No path to peer");
 }
 
+/**
+ * Query the value of the transport's received messages counter.
+ */
+static inline
+uint64_t shmem_transport_received_cntr_get(void)
+{
+    RAISE_ERROR_STR("No remote peers");
+    return 0;
+}
+
+/**
+ * Wait for the transport's received messages counter to be greater than or
+ * equal to the given value.
+ *
+ * @param ge_val Function returns when received messages >= ge_val
+ */
+static inline
+void shmem_transport_received_cntr_wait(uint64_t ge_val)
+{
+    RAISE_ERROR_STR("No remote peers");
+}
+
 #endif /* Transport selection */
 
 #endif /* TRANSPORT_H */

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -336,20 +336,20 @@ static inline int allocate_recv_cntr_mr(void)
     // Bind counter with target memory region for incoming messages
 #ifndef ENABLE_HARD_POLLING
     ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
-		    &shmem_transport_ofi_target_cntrfd->fid,
-		    FI_REMOTE_WRITE | FI_REMOTE_READ);
+                     &shmem_transport_ofi_target_cntrfd->fid,
+                     FI_REMOTE_WRITE | FI_REMOTE_READ);
     if(ret!=0){
-	OFI_ERRMSG("mr_bind failed\n");
-	return ret;
+        OFI_ERRMSG("mr_bind failed\n");
+        return ret;
     }
 
     //bind to endpoint, incoming communication associated with endpoint now has defined resources
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
-		    &shmem_transport_ofi_target_mrfd->fid,
-		    FI_REMOTE_READ | FI_REMOTE_WRITE);
+                     &shmem_transport_ofi_target_mrfd->fid,
+                     FI_REMOTE_READ | FI_REMOTE_WRITE);
     if(ret!=0){
-	OFI_ERRMSG("ep_bind mr2epfd failed\n");
-	return ret;
+        OFI_ERRMSG("ep_bind mr2epfd failed\n");
+        return ret;
     }
 #endif /* ndef ENABLE_HARD_POLLING */
 
@@ -400,6 +400,7 @@ static inline int allocate_recv_cntr_mr(void)
         OFI_ERRMSG("ep_bind mr2epfd heap failed\n");
         return ret;
     }
+
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
                      &shmem_transport_ofi_target_data_mrfd->fid,
                      FI_REMOTE_READ | FI_REMOTE_WRITE);
@@ -541,7 +542,7 @@ static inline int atomic_limitations_check(void)
     /* Retrieve messaging limitations from OFI */
     /* ----------------------------------------*/
 
-    int i, ret = 0;
+    int i, j, ret = 0;
 
     init_dt_size();
 
@@ -560,7 +561,6 @@ static inline int atomic_limitations_check(void)
         RAISE_ERROR(-1);
     }
 
-    int j;
     /* Binary OPS check */
     for(i=0; i<3; i++) {//DT
       for(j=0; j<3; j++) { //OPS
@@ -607,17 +607,22 @@ static inline int exchange_and_av_insert(struct fabric_info *info)
 
     ret = fi_getname((fid_t)shmem_transport_ofi_epfd, epname, &epnamelen);
     if(ret!=0 || (epnamelen > sizeof(epname))){
-	OFI_ERRMSG("PMI get rank failed\n");
-	return ret;
+        OFI_ERRMSG("fi_getname failed\n");
+        return ret;
     }
 
     alladdrs = malloc(info->npes * epnamelen);
     if(alladdrs==NULL){
-	OFI_ERRMSG("alladdrs is NULL\n");
-	return ret;
+        OFI_ERRMSG("alladdrs is NULL\n");
+        return ret;
     }
 
     ret = shmem_runtime_put("OFI", epname, epnamelen);
+    if (ret!=0) {
+        OFI_ERRMSG("shmem_runtime_put failed\n");
+        return ret;
+    }
+
     shmem_runtime_exchange();
     shmem_runtime_barrier();
 
@@ -715,7 +720,7 @@ static inline int query_for_fabric(struct fabric_info *info)
 
     fabric_attr.prov_name = info->prov_name;
 
-    hints.caps	  = FI_RMA |     /* request rma capability
+    hints.caps   = FI_RMA |     /* request rma capability
                                     implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
                    FI_ATOMICS |  /* request atomics capability */
                    FI_RMA_EVENT; /* want to use remote counters */
@@ -813,7 +818,7 @@ int shmem_transport_init(long eager_size)
 
     ret = query_for_fabric(&info);
     if(ret!=0)
-	return ret;
+        return ret;
 
     shmem_transport_ofi_bounce_buffer_size = eager_size;
 
@@ -841,7 +846,7 @@ int shmem_transport_init(long eager_size)
 
     ret = allocate_recv_cntr_mr();
     if(ret!=0)
-	return ret;
+        return ret;
 
     ret = publish_mr_info();
     if (ret != 0)
@@ -849,11 +854,11 @@ int shmem_transport_init(long eager_size)
 
     ret = atomic_limitations_check();
     if(ret!=0)
-	return ret;
+        return ret;
 
     ret = exchange_and_av_insert(&info);
     if(ret!=0)
-	return ret;
+        return ret;
 
     fi_freeinfo(info.fabrics);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -166,6 +166,7 @@ static inline int allocate_endpoints(struct fabric_info *info)
      * counter updates */
     info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | /*SEND ONLY */
                          FI_ATOMICS; /* request atomics capability */
+    info->p_info->caps |= FI_REMOTE_WRITE | FI_REMOTE_READ;
     info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE | FI_INJECT_COMPLETE;
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -900,4 +900,20 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
     RAISE_ERROR_STR("OFI transport does not currently support CT operations");
 }
 
+static inline
+uint64_t shmem_transport_received_cntr_get(void)
+{
+    return fi_cntr_read(shmem_transport_ofi_target_cntrfd);
+}
+
+static inline
+void shmem_transport_received_cntr_wait(uint64_t ge_val)
+{
+    int ret = fi_cntr_wait(shmem_transport_ofi_target_cntrfd, ge_val, -1);
+
+    if (ret) {
+        RAISE_ERROR(ret);
+    }
+}
+
 #endif /* TRANSPORT_OFI_H */

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -36,7 +36,9 @@ extern struct fid_ep*			shmem_transport_ofi_cntr_epfd;
 extern struct fid_stx*  		shmem_transport_ofi_stx;
 extern struct fid_av*             	shmem_transport_ofi_avfd;
 extern struct fid_cq*              	shmem_transport_ofi_put_nb_cqfd;
+#ifndef ENABLE_HARD_POLLING
 extern struct fid_cntr*            	shmem_transport_ofi_target_cntrfd;
+#endif
 extern struct fid_cntr*            	shmem_transport_ofi_put_cntrfd;
 extern struct fid_cntr*            	shmem_transport_ofi_get_cntrfd;
 #ifndef ENABLE_MR_SCALABLE
@@ -903,17 +905,26 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
 static inline
 uint64_t shmem_transport_received_cntr_get(void)
 {
+#ifndef ENABLE_HARD_POLLING
     return fi_cntr_read(shmem_transport_ofi_target_cntrfd);
+#else
+    RAISE_ERROR_STR("OFI transport configured for hard polling");
+    return 0;
+#endif
 }
 
 static inline
 void shmem_transport_received_cntr_wait(uint64_t ge_val)
 {
+#ifndef ENABLE_HARD_POLLING
     int ret = fi_cntr_wait(shmem_transport_ofi_target_cntrfd, ge_val, -1);
 
     if (ret) {
         RAISE_ERROR(ret);
     }
+#else
+    RAISE_ERROR_STR("OFI transport configured for hard polling");
+#endif
 }
 
 #endif /* TRANSPORT_OFI_H */

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -78,7 +78,9 @@ ptl_handle_le_t shmem_transport_portals4_le_h = PTL_INVALID_HANDLE;
 ptl_handle_le_t shmem_transport_portals4_data_le_h = PTL_INVALID_HANDLE;
 ptl_handle_le_t shmem_transport_portals4_heap_le_h = PTL_INVALID_HANDLE;
 #endif
+#ifndef ENABLE_HARD_POLLING
 ptl_handle_ct_t shmem_transport_portals4_target_ct_h = PTL_INVALID_HANDLE;
+#endif
 ptl_handle_ct_t shmem_transport_portals4_put_ct_h = PTL_INVALID_HANDLE;
 ptl_handle_ct_t shmem_transport_portals4_get_ct_h = PTL_INVALID_HANDLE;
 ptl_handle_eq_t shmem_transport_portals4_eq_h = PTL_INVALID_HANDLE;
@@ -174,9 +176,11 @@ cleanup_handles(void)
         PtlLEUnlink(shmem_transport_portals4_data_le_h);
     }
 #endif
+#ifndef ENABLE_HARD_POLLING
     if (!PtlHandleIsEqual(shmem_transport_portals4_target_ct_h, PTL_INVALID_HANDLE)) {
         PtlCTFree(shmem_transport_portals4_target_ct_h);
     }
+#endif
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     if (PTL_PT_ANY != all_pt) {
         PtlPTFree(shmem_transport_portals4_ni_h, all_pt);
@@ -487,6 +491,7 @@ shmem_transport_startup(void)
     }
 #endif
 
+#ifndef ENABLE_HARD_POLLING
     /* target ct */
     ret = PtlCTAlloc(shmem_transport_portals4_ni_h, &shmem_transport_portals4_target_ct_h);
     if (PTL_OK != ret) {
@@ -496,6 +501,7 @@ shmem_transport_startup(void)
     }
 
     le.ct_handle = shmem_transport_portals4_target_ct_h;
+#endif
     le.uid = uid;
     le.options = PTL_LE_OP_PUT | PTL_LE_OP_GET | 
         PTL_LE_EVENT_LINK_DISABLE |

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -63,7 +63,9 @@ extern ptl_handle_md_t shmem_transport_portals4_put_volatile_md_h;
 extern ptl_handle_md_t shmem_transport_portals4_put_cntr_md_h;
 extern ptl_handle_md_t shmem_transport_portals4_put_event_md_h;
 extern ptl_handle_md_t shmem_transport_portals4_get_md_h;
+#ifndef ENABLE_HARD_POLLING
 extern ptl_handle_ct_t shmem_transport_portals4_target_ct_h;
+#endif
 extern ptl_handle_ct_t shmem_transport_portals4_put_ct_h;
 extern ptl_handle_ct_t shmem_transport_portals4_get_ct_h;
 extern ptl_handle_eq_t shmem_transport_portals4_eq_h;
@@ -1238,6 +1240,7 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
 static inline
 uint64_t shmem_transport_received_cntr_get(void)
 {
+#ifndef ENABLE_HARD_POLLING
     int ret;
     ptl_ct_event_t ct;
 
@@ -1252,12 +1255,17 @@ uint64_t shmem_transport_received_cntr_get(void)
     }
 
     return (uint64_t) ct.success;
+#else
+    RAISE_ERROR_STR("Portals transport configured for hard polling");
+    return 0;
+#endif
 }
 
 
 static inline
 void shmem_transport_received_cntr_wait(uint64_t ge_val)
 {
+#ifndef ENABLE_HARD_POLLING
     int ret;
     ptl_ct_event_t ct;
 
@@ -1271,6 +1279,9 @@ void shmem_transport_received_cntr_wait(uint64_t ge_val)
     if (0 != ct.failure) {
         RAISE_ERROR_STR("Target CT failure");
     }
+#else
+    RAISE_ERROR_STR("Portals transport configured for hard polling");
+#endif
 }
 
 #endif

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -1235,4 +1235,42 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
 }
 
 
+static inline
+uint64_t shmem_transport_received_cntr_get(void)
+{
+    int ret;
+    ptl_ct_event_t ct;
+
+    ret = PtlCTGet(shmem_transport_portals4_target_ct_h, &ct);
+
+    if (0 != ct.failure) {
+        RAISE_ERROR_STR("Target CT failure");
+    }
+
+    if (PTL_OK != ret) {
+        RAISE_ERROR(ret);
+    }
+
+    return (uint64_t) ct.success;
+}
+
+
+static inline
+void shmem_transport_received_cntr_wait(uint64_t ge_val)
+{
+    int ret;
+    ptl_ct_event_t ct;
+
+    ret = PtlCTWait(shmem_transport_portals4_target_ct_h,
+                    ge_val, &ct);
+
+    if (PTL_OK != ret) {
+        RAISE_ERROR(ret);
+    }
+
+    if (0 != ct.failure) {
+        RAISE_ERROR_STR("Target CT failure");
+    }
+}
+
 #endif


### PR DESCRIPTION
Add received counter get/wait API to the transport interface and push
Portal 4 and OFI calls in the wait implementation down into the
transport layer.

Signed-off-by: James Dinan <james.dinan@intel.com>