### PR TITLE
OFI: added SMA_OFI_ATOMIC_CHECKS_WARN

### DIFF
--- a/README
+++ b/README
@@ -180,5 +180,5 @@ options.
         identifying the desired fabric domain.
 
     SMA_OFI_ATOMIC_CHECKS_WARN (default: off)
-        OFI will not abort if fabric provider doesn't support every data type x op
-        combination, instead it will print a warning.
+        If defined, OFI will not abort if fabric provider doesn't support every data
+        type x op combination, instead it will print a warning.

--- a/README
+++ b/README
@@ -178,3 +178,7 @@ options.
         Shell-style wildcards, including * and ?, are allowed.  The fi_info
         utility included with libfabric can be used for assistance with
         identifying the desired fabric domain.
+
+    SMA_OFI_ATOMIC_CHECKS_WARN (default: off)
+        OFI will not abort if fabric provider doesn't support every data type x op
+        combination, instead it will print a warning.

--- a/src/collectives_c.c
+++ b/src/collectives_c.c
@@ -480,7 +480,7 @@ shmem_longlong_min_to_all(long long *target, const long long *source,
 
     shmem_internal_op_to_all(target, source, nreduce, sizeof(long long),
                     PE_start, logPE_stride, PE_size,
-                    pWrk, pSync, SHM_INTERNAL_MIN, SHM_INTERNAL_LONG);
+                    pWrk, pSync, SHM_INTERNAL_MIN, SHM_INTERNAL_LONG_LONG);
 }
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -298,9 +298,6 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("SMA_INFO                %s\n",
                    (NULL != shmem_util_getenv_str("INFO")) ? "Set" : "Not set");
             printf("\tIf set, print this help message at startup\n");
-            printf("SMA_OFI_ATOMIC_CHECKS_WARN  %s\n",
-                   (NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN")) ? "Set" : "Not set");
-            printf("\tIf set, change aborting atomic checks to warnings\n");
             printf("SMA_SYMMETRIC_SIZE      %ld\n", heap_size);
             printf("\tSymmentric heap size\n");
             printf("SMA_COLL_CROSSOVER      %d\n", crossover);

--- a/src/init.c
+++ b/src/init.c
@@ -298,6 +298,9 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("SMA_INFO                %s\n",
                    (NULL != shmem_util_getenv_str("INFO")) ? "Set" : "Not set");
             printf("\tIf set, print this help message at startup\n");
+            printf("SMA_OFI_ATOMIC_CHECKS_WARN  %s\n",
+                   (NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN")) ? "Set" : "Not set");
+            printf("\tIf set, change aborting atomic checks to warnings\n");
             printf("SMA_SYMMETRIC_SIZE      %ld\n", heap_size);
             printf("\tSymmentric heap size\n");
             printf("SMA_COLL_CROSSOVER      %d\n", crossover);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -104,10 +104,20 @@ static int SHM_DT_INT[]=
   SHM_INTERNAL_SHORT, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
 };
 
+static char * SHM_NAMED_DT_INT[]=
+{
+  "Short", "Int", "Long",
+};
+
 static int SHM_DT_CMP[]=
 {
   SHM_INTERNAL_SHORT, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
   SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE
+};
+
+static char * SHM_NAMED_DT_CMP[]=
+{
+  "Short", "Int", "Long", "Float", "Double",
 };
 
 static int SHM_BOPS[]=
@@ -556,7 +566,8 @@ static inline int atomic_limitations_check(void)
     int i, j, ret = 0;
     long atomicwarn = 0;
 
-    atomicwarn = shmem_util_getenv_long("OFI_ATOMIC_CHECKS_WARN", 0, 0);
+    if(NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
+        atomicwarn = 1;
 
     init_dt_size();
 
@@ -581,12 +592,10 @@ static inline int atomic_limitations_check(void)
         ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_INT[i], SHM_BOPS[j],
                         &atomic_size);
         if(ret!=0 || atomic_size == 0) {
-            fprintf(stderr, "Atomic Support: data size %d not "\
-                    "supported with %s ", SHMEM_Dtsize[SHM_DT_INT[i]],
-                    SHM_NAMED_BOPS[j]);
-            if(atomicwarn) {
-                fprintf(stderr, "WARNING\n");
-            } else {
+            fprintf(stderr, "%s OFI detected no support for atomic '%s'"
+                    "on type '%s'\n", (atomicwarn ? "Warning" : "Error"),
+                    SHM_NAMED_BOPS[j], SHM_NAMED_DT_INT[i]);
+            if(!atomicwarn) {
                 OFI_ERRMSG("Error: atomicvalid ret=%d atomic_size=%d \n",
                             ret, (int)atomic_size);
 	            return ret;
@@ -601,12 +610,10 @@ static inline int atomic_limitations_check(void)
         ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_CMP[i], SHM_OPS[j],
                         &atomic_size);
         if(ret!=0 || atomic_size == 0) {
-            fprintf(stderr, "Atomic Support: data size %d not "\
-                    "supported with %s \n", SHMEM_Dtsize[SHM_DT_CMP[i]],
-                    SHM_NAMED_OPS[j]);
-            if(atomicwarn) {
-                fprintf(stderr, "WARNING\n");
-            } else {
+            fprintf(stderr, "%s OFI detected no support for atomic '%s'"
+                    "on type '%s'\n", (atomicwarn ? "Warning" : "Error"),
+                    SHM_NAMED_OPS[j], SHM_NAMED_DT_CMP[i]);
+            if(!atomicwarn) {
                 OFI_ERRMSG("Error: atomicvalid ret=%d atomic_size=%d \n",
                             ret, (int)atomic_size);
 	            return ret;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -99,57 +99,123 @@ static inline void init_dt_size(void)
   SHMEM_Dtsize[FI_LONG_DOUBLE_COMPLEX] = sizeof(long double complex);
 }
 
-#define SIZEOF_DT_INT 4
-
-static int SHM_DT_INT[]=
+static char * SHMEM_DtName[FI_DATATYPE_LAST]=
 {
-  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_SHORT
+  "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64"
+  "float", "double", "float complex", "double complex", "long double",
+  "long double complex"
 };
 
-static char * SHM_NAMED_DT_INT[]=
+static char * SHMEM_OpName[FI_ATOMIC_OP_LAST]=
 {
-  "Int", "Long", "Long Long", "Short"
+  "MIN", "MAX", "SUM", "PROD", "LOR", "LAND", "BOR", "BAND", "LXOR",
+  "BXOR", "ATOMIC WRITE", "ATOMIC READ", "CSWAP", "CSWAP_NE", "CSWAP_LE",
+  "CSWAP_LT", "CSWAP_GE", "CSWAP_GT", "MSWAP"
 };
 
-#define SIZEOF_DT_CMP 6
 
-static int SHM_DT_CMP[]=
+/* Cover OpenSHMEM atomics API */
+
+#define SIZEOF_AMO_DT 5
+static int DT_AMO_STANDARD[]=
 {
-  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_FLOAT,
-  SHM_INTERNAL_DOUBLE, SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_SHORT
+  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
+  SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
+};
+#define SIZEOF_AMO_OPS 1
+static int AMO_STANDARD_OPS[]=
+{
+  SHM_INTERNAL_SUM
+};
+#define SIZEOF_AMO_FOPS 2
+static int FETCH_AMO_STANDARD_OPS[]=
+{
+  SHM_INTERNAL_SUM
+};
+#define SIZEOF_AMO_COPS 2
+static int COMPARE_AMO_STANDARD_OPS[]=
+{
+  FI_CSWAP
 };
 
-static char * SHM_NAMED_DT_CMP[]=
+
+#define SIZEOF_AMO_EX_DT 8
+static int DT_AMO_EXTENDED[]=
 {
-  "Int", "Long", "Float", "Double", "Long Long", "Short"
+  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
+  SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64,
+  SHM_INTERNAL_FORTRAN_INTEGER
+};
+#define SIZEOF_AMO_EX_OPS 1
+static int AMO_EXTENDED_OPS[]=
+{
+  FI_ATOMIC_WRITE
+};
+#define SIZEOF_AMO_EX_FOPS 2
+static int FETCH_AMO_EXTENDED_OPS[]=
+{
+  FI_ATOMIC_WRITE, FI_ATOMIC_READ
 };
 
-#define SIZEOF_BOPS 3
 
-static int SHM_BOPS[]=
+/* Cover one-sided implementation of reduction */
+
+#define SIZEOF_RED_DT 6
+static int DT_REDUCE_BITWISE[]=
+{
+  SHM_INTERNAL_SHORT, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
+  SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
+};
+#define SIZEOF_RED_OPS 3
+static int REDUCE_BITWISE_OPS[]=
 {
   SHM_INTERNAL_BAND, SHM_INTERNAL_BOR, SHM_INTERNAL_BXOR
 };
 
-static char * SHM_NAMED_BOPS[]=
+
+#define SIZEOF_REDC_DT 8
+static int DT_REDUCE_COMPARE[]=
 {
-  "Bitwise AND", "Bitwise OR", "Bitwise XOR"
+  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_SHORT,
+  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
+  SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
+};
+#define SIZEOF_REDC_OPS 2
+static int REDUCE_COMPARE_OPS[]=
+{
+  SHM_INTERNAL_MAX, SHM_INTERNAL_MIN
 };
 
-#define SIZEOF_OPS 8
 
-static int SHM_OPS[]=
+#define SIZEOF_REDA_DT 10
+static int DT_REDUCE_ARITH[]=
 {
-  SHM_INTERNAL_MIN,  SHM_INTERNAL_MAX, SHM_INTERNAL_PROD,
-  SHM_INTERNAL_SUM, FI_ATOMIC_WRITE, FI_ATOMIC_READ, FI_CSWAP,
+  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_FLOAT_COMPLEX,
+  SHM_INTERNAL_DOUBLE_COMPLEX, SHM_INTERNAL_SHORT, SHM_INTERNAL_INT,
+  SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32,
+  SHM_INTERNAL_INT64
+};
+#define SIZEOF_REDA_OPS 2
+static int REDUCE_ARITH_OPS[]=
+{
+  SHM_INTERNAL_SUM, SHM_INTERNAL_PROD
+};
+
+/* Internal to SHMEM implementation atomic requirement */
+/*Locking implementation requirement */
+#define SIZEOF_INTERNAL_REQ_DT 1
+static int DT_INTERNAL_REQ[]=
+{
+  SHM_INTERNAL_INT
+};
+#define SIZEOF_INTERNAL_REQ_OPS 1
+static int INTERNAL_REQ_OPS[]=
+{
   FI_MSWAP
 };
 
-static char * SHM_NAMED_OPS[]=
-{
-  "MIN", "MAX", "PROD", "SUM", "WRITE", "READ", "CSWAP",
-  "MSWAP"
-};
+
+
 
 int shmem_transport_have_long_double = 1;
 
@@ -567,8 +633,8 @@ static int populate_mr_tables(void)
 }
 
 static inline int atomicvalid_rtncheck(int ret, int atomic_size, long atomicwarn,
-                                    char strOP[], char strDT[]) {
-
+                                    char strOP[], char strDT[])
+{
     if(ret != 0 || atomic_size == 0) {
         fprintf(stderr, "%s OFI detected no support for atomic '%s'"
                "on type '%s'\n", (atomicwarn ? "Warning" : "Error"),
@@ -583,7 +649,65 @@ static inline int atomicvalid_rtncheck(int ret, int atomic_size, long atomicwarn
     return 0;
 }
 
+static inline int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
+                                    int OPS[], long atomicwarn)
+{
+    int i, j, ret = 0;
+    size_t atomic_size;
 
+    for(i=0; i<DT_MAX; i++) {
+      for(j=0; j<OPS_MAX; j++) {
+        ret = fi_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                        OPS[j], &atomic_size);
+         if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
+                            SHMEM_OpName[OPS[j]],
+                            SHMEM_DtName[DT[i]]))
+           return ret;
+      }
+    }
+
+    return 0;
+}
+
+static inline int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
+                                    int OPS[], long atomicwarn)
+{
+    int i, j, ret = 0;
+    size_t atomic_size;
+
+    for(i=0; i<DT_MAX; i++) {
+      for(j=0; j<OPS_MAX; j++) {
+        ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                        OPS[j], &atomic_size);
+         if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
+                            SHMEM_OpName[OPS[j]],
+                            SHMEM_DtName[DT[i]]))
+           return ret;
+      }
+    }
+
+    return 0;
+}
+
+static inline int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
+                                    int OPS[], long atomicwarn)
+{
+    int i, j, ret = 0;
+    size_t atomic_size;
+
+    for(i=0; i<DT_MAX; i++) {
+      for(j=0; j<OPS_MAX; j++) {
+        ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                        OPS[j], &atomic_size);
+         if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
+                            SHMEM_OpName[OPS[j]],
+                            SHMEM_DtName[DT[i]]))
+           return ret;
+      }
+    }
+
+    return 0;
+}
 static inline int atomic_limitations_check(void)
 {
 
@@ -591,94 +715,108 @@ static inline int atomic_limitations_check(void)
     /* Retrieve messaging limitations from OFI */
     /* ----------------------------------------*/
 
-    int i, j, ret = 0;
+    int j = 0, ret = 0;
     long atomicwarn = 0;
+    size_t atomic_size;
 
     if(NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
         atomicwarn = 1;
 
     init_dt_size();
 
-    /*RETRIEVE atomic max size for ATOMIC_NB case */
-    size_t atomic_size;
+    /*Retrieve atomic max size */
     ret = fi_atomicvalid(shmem_transport_ofi_epfd, FI_INT64, FI_SUM,
 			&atomic_size);
     if(ret!=0 || (atomic_size == 0)){ //not supported
 	    OFI_ERRMSG("atomicvalid failed: cannot determine max atomic size for transport\n");
 	    return ret;
     }
-    shmem_transport_ofi_max_atomic_size = atomic_size * (sizeof(long));
+    shmem_transport_ofi_max_atomic_size = atomic_size * (sizeof(int64_t));
 
     if(shmem_transport_ofi_max_atomic_size > shmem_transport_ofi_max_msg_size) {
         OFI_ERRMSG("Error: OFI provider max atomic size is larger than max message size\n");
         RAISE_ERROR(-1);
     }
 
-    /* Binary OPS check */
-    for(i=0; i<SIZEOF_DT_INT; i++) {//DT
-      for(j=0; j<SIZEOF_BOPS; j++) { //OPS
-        ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_INT[i], SHM_BOPS[j],
-                        &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                            SHM_NAMED_BOPS[j], SHM_NAMED_DT_INT[i]))
-           return ret;
-      }
-    }
-
-    /* OTHER OPS check */
-    for(i=0; i<SIZEOF_DT_CMP; i++) {//DT
-      for(j=0; j<4; j++) { //OPS
-        ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_CMP[i], SHM_OPS[j],
-                        &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                            SHM_NAMED_OPS[j], SHM_NAMED_DT_CMP[i]))
-           return ret;
-      }
-    }
-
-    for(i=0; i<3; i++) {//DT does not include short
-      ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_INT[i], FI_CSWAP,
-                        &atomic_size);
-      if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                        "FI_CSWAP", SHM_NAMED_DT_INT[i]))
+    /* Standard OPS check */
+    ret = atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_OPS, DT_AMO_STANDARD,
+                      AMO_STANDARD_OPS, atomicwarn);
+    if(ret)
         return ret;
 
-      ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_INT[i], FI_SUM,
-                        &atomic_size);
-      if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                        "FI_SUM", SHM_NAMED_DT_INT[i]))
+    ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_FOPS,
+                    DT_AMO_STANDARD, FETCH_AMO_STANDARD_OPS, atomicwarn);
+    if(ret)
         return ret;
-    }
 
-    ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, SHM_INTERNAL_INT, FI_MSWAP,
-                        &atomic_size);
-     if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                        "FI_MSWAP", "Int"))
-       return ret;
+    ret = compare_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_COPS,
+                    DT_AMO_STANDARD, COMPARE_AMO_STANDARD_OPS, atomicwarn);
+    if(ret)
+        return ret;
 
-    for(i=0; i<5; i++) {//DT
-      for(j=4; j<6; j++) { //OPS
-        ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, SHM_DT_CMP[i], SHM_OPS[j],
-                        &atomic_size);
-        if(atomicvalid_rtncheck(ret, atomic_size, atomicwarn,
-                            SHM_NAMED_OPS[j], SHM_NAMED_DT_CMP[i]))
-          return ret;
-      }
-    }
+    /* Extended OPS check */
+    ret = atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_OPS, DT_AMO_EXTENDED,
+                      AMO_EXTENDED_OPS, atomicwarn);
+    if(ret)
+        return ret;
+
+    ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_FOPS,
+                    DT_AMO_EXTENDED, FETCH_AMO_EXTENDED_OPS, atomicwarn);
+    if(ret)
+        return ret;
+
+    /* Reduction OPS check */
+    ret = atomicvalid_DTxOP(SIZEOF_RED_DT, SIZEOF_RED_OPS, DT_REDUCE_BITWISE,
+                      REDUCE_BITWISE_OPS, atomicwarn);
+    if(ret)
+        return ret;
+
+    ret = atomicvalid_DTxOP(SIZEOF_REDC_DT, SIZEOF_REDC_OPS, DT_REDUCE_COMPARE,
+                      REDUCE_COMPARE_OPS, atomicwarn);
+    if(ret)
+        return ret;
+
+    ret = atomicvalid_DTxOP(SIZEOF_REDA_DT, SIZEOF_REDA_OPS, DT_REDUCE_ARITH,
+                      REDUCE_ARITH_OPS, atomicwarn);
+    if(ret)
+        return ret;
+
+    /* Internal atomic requirement */
+    ret = compare_atomicvalid_DTxOP(SIZEOF_INTERNAL_REQ_DT, SIZEOF_INTERNAL_REQ_OPS,
+                    DT_INTERNAL_REQ, INTERNAL_REQ_OPS, atomicwarn);
+    if(ret)
+        return ret;
 
     /* LONG DOUBLE limitation is common */
-    for(j=0; j<4; j++) { //OPS
-      ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_INTERNAL_LONG_DOUBLE, SHM_OPS[j],
-                &atomic_size);
+    for(j=0; j<SIZEOF_REDC_OPS; j++) { //OPS
+      ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_INTERNAL_LONG_DOUBLE,
+                REDUCE_COMPARE_OPS[j], &atomic_size);
       if(ret!=0 || atomic_size == 0) {
 	    shmem_transport_have_long_double = 0;
 		break;
 	  } else if((atomic_size*sizeof(long double)) !=
                                     shmem_transport_ofi_max_atomic_size) {
-        fprintf(stderr, "Error OFI detected no support for atomic '%d'"
-               "on type %d\n", SHM_OPS[j], SHM_INTERNAL_LONG_DOUBLE);
+        fprintf(stderr, "Error OFI detected no support for atomic '%s'"
+               "on type %d\n", SHMEM_OpName[REDUCE_COMPARE_OPS[j]],
+                SHM_INTERNAL_LONG_DOUBLE);
             OFI_ERRMSG("Error: atomicvalid ret=%d atomic_size=%d \n",
-                       ret, atomic_size);
+                       ret, (int)atomic_size);
+      }
+    }
+
+    for(j=0; j<SIZEOF_REDA_OPS; j++) { //OPS
+      ret = fi_atomicvalid(shmem_transport_ofi_epfd, SHM_INTERNAL_LONG_DOUBLE,
+                REDUCE_ARITH_OPS[j], &atomic_size);
+      if(ret!=0 || atomic_size == 0) {
+	    shmem_transport_have_long_double = 0;
+		break;
+	  } else if((atomic_size*sizeof(long double)) !=
+                                    shmem_transport_ofi_max_atomic_size) {
+        fprintf(stderr, "Error OFI detected no support for atomic '%s'"
+               "on type %d\n", SHMEM_OpName[REDUCE_ARITH_OPS[j]],
+                SHM_INTERNAL_LONG_DOUBLE);
+            OFI_ERRMSG("Error: atomicvalid ret=%d atomic_size=%d \n",
+                       ret, (int)atomic_size);
       }
     }
 


### PR DESCRIPTION
+environment variable option for enabling atomic limitation warnings vs. errors
+small clean-up of atomic valid output message
+initial atomic size check uses FI_SUM instead of FI_MAX since sum is more portable

Signed-off-by: kseager <kayla.seager@intel.com>