### PR TITLE
OFI: enable USE_ON_NODE_COMMS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -189,7 +189,7 @@ CHECK_CMA(
    [transport_cma="no"])
 AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
-AS_IF([test "transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
+AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
        AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])


### PR DESCRIPTION
+added optional hostname exchange
+can be utilized by XPMEM for shared memory topology detection

resolves issue #164

Signed-off-by: kseager <kayla.seager@intel.com>