### PR TITLE
OFI: add error cq to cntr_ep

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -151,12 +151,12 @@ static int AMO_STANDARD_OPS[]=
 {
   SHM_INTERNAL_SUM
 };
-#define SIZEOF_AMO_FOPS 2
+#define SIZEOF_AMO_FOPS 1
 static int FETCH_AMO_STANDARD_OPS[]=
 {
   SHM_INTERNAL_SUM
 };
-#define SIZEOF_AMO_COPS 2
+#define SIZEOF_AMO_COPS 1
 static int COMPARE_AMO_STANDARD_OPS[]=
 {
   FI_CSWAP
@@ -345,6 +345,14 @@ static inline int bind_resources_to_and_enable_ep(void)
 		    &shmem_transport_ofi_put_nb_cqfd->fid, FI_SEND);
     if(ret!=0){
 	OFI_ERRMSG("ep_bind ep2cq_nb failed\n");
+	return ret;
+    }
+
+    /* attach CQ for error handling on cntr EP */
+    ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
+		    &shmem_transport_ofi_put_nb_cqfd->fid, FI_SELECTIVE_COMPLETION | FI_TRANSMIT);
+    if(ret!=0){
+	OFI_ERRMSG("ep_bind cntrep2cq_nb failed\n");
 	return ret;
     }
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -292,7 +292,12 @@ static inline int shmem_transport_quiet(void)
 	/* wait for put counter to meet outstanding count value    */
 	ret = fi_cntr_wait(shmem_transport_ofi_put_cntrfd,
 			shmem_transport_ofi_pending_put_counter,-1);
-	OFI_RET_CHECK(ret);
+    if(ret) {
+	    struct fi_cq_err_entry e = {0};
+        fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd,
+		           (void *)&e, 0);
+		RAISE_ERROR(e.err);
+    }
 
 	return ret;
 }
@@ -515,7 +520,12 @@ shmem_transport_get_wait(void)
 	/* wait for get counter to meet outstanding count value    */
 	ret = fi_cntr_wait(shmem_transport_ofi_get_cntrfd,
 			shmem_transport_ofi_pending_get_counter,-1);
-	OFI_RET_CHECK(ret);
+    if(ret) {
+	    struct fi_cq_err_entry e = {0};
+        fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd,
+		           (void *)&e, 0);
+		RAISE_ERROR(e.err);
+    }
 }
 
 


### PR DESCRIPTION
+OFI requirement
+additionally using cq for cntr error handling

Signed-off-by: kseager <kayla.seager@intel.com>

@sayantansur : we've already discussed, but if you could review and merge in, thanks! 

@hppritcha this looks like its fixes the unit test failures we were seeing