### PR TITLE
Macro-ize types, add coverage for all non-atomic RMA operations

### DIFF
--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -82,169 +82,169 @@ void *shmem_align(size_t alignment, size_t size);
 void *shmem_realloc(void *ptr, size_t size);
 void shmem_free(void *ptr);
 
-#define SHMEM_DECLARE_FOR_RMA(decl) \
-  decl(float,      float);          \
-  decl(double,     double);         \
-  decl(longdouble, long double);    \
-  decl(char,       char);           \
-  decl(short,      short);          \
-  decl(int,        int);            \
-  decl(long,       long);           \
+#define SHMEM_DECLARE_FOR_RMA(decl,END) \
+  decl(float,      float) END           \
+  decl(double,     double) END          \
+  decl(longdouble, long double) END     \
+  decl(char,       char) END            \
+  decl(short,      short) END           \
+  decl(int,        int) END             \
+  decl(long,       long) END            \
   decl(longlong,   long long)
 
-#define SHMEM_DECLARE_FOR_AMO(decl) \
-  decl(int,        int);            \
-  decl(long,       long);           \
+#define SHMEM_DECLARE_FOR_AMO(decl,END) \
+  decl(int,        int) END             \
+  decl(long,       long) END            \
   decl(longlong,   long long)
 
-#define SHMEM_DECLARE_FOR_EXTENDED_AMO(decl) \
-  SHMEM_DECLARE_FOR_AMO(decl);               \
-  decl(float,  float);                       \
+#define SHMEM_DECLARE_FOR_EXTENDED_AMO(decl,END) \
+  SHMEM_DECLARE_FOR_AMO(decl,END) END            \
+  decl(float,  float) END                        \
   decl(double, double)
 
-#define SHMEM_DECLARE_FOR_INTS(decl) \
-  decl(short,    short);                \
-  decl(int,      int);                  \
-  decl(long,     long);                 \
+#define SHMEM_DECLARE_FOR_INTS(decl,END) \
+  decl(short,    short) END              \
+  decl(int,      int) END                \
+  decl(long,     long) END               \
   decl(longlong, long long)
 
-#define SHMEM_DECLARE_FOR_FLOATS(decl) \
-  decl(float,     float);              \
-  decl(double,     double);            \
+#define SHMEM_DECLARE_FOR_FLOATS(decl,END) \
+  decl(float,     float) END               \
+  decl(double,     double) END             \
   decl(longdouble, long double)
 
-#define SHMEM_DECLARE_FOR_CMPLX(decl) \
-  decl(complexf, float complex);      \
+#define SHMEM_DECLARE_FOR_CMPLX(decl,END) \
+  decl(complexf, float complex) END       \
   decl(complexd, double complex)
 
-#define SHMEM_DECLARE_FOR_SIZES(decl) \
-  decl(mem,  1); \
-  decl(8,    1*sizeof(uint8_t));   \
-  decl(16,   2*sizeof(uint8_t));  \
-  decl(32,   4*sizeof(uint8_t));  \
-  decl(64,   8*sizeof(uint8_t));  \
+#define SHMEM_DECLARE_FOR_SIZES(decl,END) \
+  decl(mem,  1) END                       \
+  decl(8,    1*sizeof(uint8_t)) END       \
+  decl(16,   2*sizeof(uint8_t)) END       \
+  decl(32,   4*sizeof(uint8_t)) END       \
+  decl(64,   8*sizeof(uint8_t)) END       \
   decl(128, 16*sizeof(uint8_t))
 
 /* 8.3: Elemental Data Put Routines */
 #define SHMEM_P(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_p(TYPE *addr, TYPE value, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_P);
+SHMEM_DECLARE_FOR_RMA(SHMEM_P,;);
 
 /* 8.3: Block Data Put Routines */
 #define SHMEM_PUT(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_put(TYPE *target, const TYPE *source, \
                                 size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_PUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT,;);
 
 #define SHMEM_PUT_N(SIZE,NBYTES) \
     void shmem_put##SIZE(void* target, const void *source, \
                          size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N,;);
 
 /* 8.3: Strided Put Routines */
 #define SHMEM_IPUT(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_iput(TYPE *target, const TYPE *source,  \
                                ptrdiff_t tst, ptrdiff_t sst,      \
                                size_t len, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_IPUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_IPUT,;);
 
 #define SHMEM_IPUT_N(SIZE,NBYTES) \
   void shmem_iput##SIZE(void *target, const void *source,         \
                         ptrdiff_t tst, ptrdiff_t sst, size_t len, \
                         int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_IPUT_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IPUT_N,;);
 
 /* 8.3: Elemental Data Get Routines */
 #define SHMEM_G(TYPENAME,TYPE) \
     TYPE shmem_##TYPENAME##_g(const TYPE *addr, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_G);
+SHMEM_DECLARE_FOR_RMA(SHMEM_G,;);
 
 /* 8.3: Block Data Get Routines */
 #define SHMEM_GET(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_get(TYPE *target, const TYPE *source, \
                                 size_t nelems,int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_GET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET,;);
 
 #define SHMEM_GET_N(SIZE,NBYTES) \
     void shmem_get##SIZE(void* target, const void *source, \
                          size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N,;);
 
 /* 8.3: Strided Get Routines */
 #define SHMEM_IGET(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_iget(TYPE *target, const TYPE *source, \
                                  ptrdiff_t tst, ptrdiff_t sst,     \
                                  size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_IGET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_IGET,;);
 
 #define SHMEM_IGET_N(SIZE,NBYTES) \
     void shmem_iget##SIZE(void* target, const void *source, \
                           ptrdiff_t tst, ptrdiff_t sst,     \
                           size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_IGET_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IGET_N,;);
 
 /* 8.4: Nonblocking remote memory access routines -- Put */
 #define SHMEM_PUT_NBI(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_put_nbi(TYPE *target, const TYPE *source,\
                                     size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_PUT_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT_NBI,;);
 
 #define SHMEM_PUT_N_NBI(SIZE,NBYTES) \
     void shmem_put##SIZE##_nbi(void* target, const void *source, \
                                size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N_NBI);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N_NBI,;);
 
 /* 8.4: Nonblocking remote memory access routines -- Get */
 #define SHMEM_GET_NBI(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_get_nbi(TYPE *target, const TYPE *source,\
                                     size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_GET_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET_NBI,;);
 
 #define SHMEM_GET_N_NBI(SIZE,NBYTES) \
     void shmem_get##SIZE##_nbi(void* target, const void *source, \
                                size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N_NBI);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N_NBI,;);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Swap */
 #define SHMEM_SWAP(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_swap(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SWAP);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SWAP,;);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Cswap */
 #define SHMEM_CSWAP(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_cswap(TYPE *target, TYPE cond, TYPE value, \
                                 int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_CSWAP);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CSWAP,;);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Add */
 #define SHMEM_FADD(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_fadd(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_FADD);
+SHMEM_DECLARE_FOR_AMO(SHMEM_FADD,;);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Increment */
 #define SHMEM_FINC(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_finc(TYPE *target, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_FINC);
+SHMEM_DECLARE_FOR_AMO(SHMEM_FINC,;);
 
 /* 8.4: Atomic Memory Operation Routines -- Add */
 #define SHMEM_ADD(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_add(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_ADD);
+SHMEM_DECLARE_FOR_AMO(SHMEM_ADD,;);
 
 /* 8.4: Atomic Memory Operation Routines -- Increment */
 #define SHMEM_INC(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_inc(TYPE *target, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_INC);
+SHMEM_DECLARE_FOR_AMO(SHMEM_INC,;);
 
 /* 8.4: Atomic fetch */
 #define SHMEM_FETCH(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_fetch(const TYPE *target, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_FETCH);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_FETCH,;);
 
 /* 8.4: Atomic set */
 #define SHMEM_SET(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_set(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SET);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SET,;);
 
 /* 8.5: Barrier Synchronization Routines */
 void shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync);
@@ -257,7 +257,7 @@ void shmem_barrier_all(void);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL,;);
 
 #define SHMEM_OR_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_or_to_all(TYPE *target, \
@@ -265,7 +265,7 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL);
                                     int PE_start, int logPE_stride, \
                                     int PE_size, TYPE *pWrk, \
                                     long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL,;);
 
 #define SHMEM_XOR_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_xor_to_all(TYPE *target, \
@@ -273,7 +273,7 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL,;);
 
 #define SHMEM_MIN_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_min_to_all(TYPE *target, \
@@ -281,8 +281,8 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_MIN_TO_ALL);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_MIN_TO_ALL,;);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL,;);
 
 #define SHMEM_MAX_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_max_to_all(TYPE *target, \
@@ -290,8 +290,8 @@ SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_MAX_TO_ALL);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_MAX_TO_ALL,;);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL,;);
 
 #define SHMEM_SUM_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_sum_to_all(TYPE *target, \
@@ -299,9 +299,9 @@ SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_SUM_TO_ALL);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_SUM_TO_ALL);
-SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_SUM_TO_ALL,;);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_SUM_TO_ALL,;);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL,;);
 
 #define SHMEM_PROD_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_prod_to_all(TYPE *target, \
@@ -309,9 +309,9 @@ SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL);
                                       int PE_start, int logPE_stride, \
                                       int PE_size, TYPE *pWrk, \
                                       long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_PROD_TO_ALL);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_PROD_TO_ALL);
-SHMEM_DECLARE_FOR_CMPLX(SHMEM_PROD_TO_ALL);
+SHMEM_DECLARE_FOR_INTS(SHMEM_PROD_TO_ALL,;);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_PROD_TO_ALL,;);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_PROD_TO_ALL,;);
 
 /* 8.5: Collect Routines */
 void shmem_collect32(void *target, const void *source, size_t nlong,

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -433,13 +433,13 @@ using std::size_t;
                                size_t nelems, int pe) {        \
     shmem_##TYPENAME##_put(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT,)
 
 #define SHMEM_CXX_P(TYPENAME,TYPE) \
   static inline void shmem_p(TYPE* dest, TYPE value, int pe) { \
     shmem_##TYPENAME##_p(dest, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P,)
 
 #define SHMEM_CXX_IPUT(TYPENAME,TYPE) \
   static inline void shmem_iput(TYPE *target, const TYPE *source, \
@@ -447,7 +447,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P);
                                 size_t len, int pe) {             \
     shmem_##TYPENAME##_iput(target, source, tst, sst, len, pe);   \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT,)
 
 /* Blocking block, scalar, and block-strided get */
 #define SHMEM_CXX_GET(TYPENAME,TYPE) \
@@ -455,13 +455,13 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT);
                                size_t nelems, int pe) {        \
     shmem_##TYPENAME##_get(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET,)
 
 #define SHMEM_CXX_G(TYPENAME,TYPE) \
   static inline TYPE shmem_p(const TYPE* src, int pe) { \
     shmem_##TYPENAME##_g(src, pe);                      \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G,)
 
 #define SHMEM_CXX_IGET(TYPENAME,TYPE) \
   static inline void shmem_iget(TYPE *target, const TYPE *source, \
@@ -469,7 +469,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G);
                                 size_t len, int pe) {             \
     shmem_##TYPENAME##_iget(target, source, tst, sst, len, pe);   \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET,)
 
 /* Nonblocking block put/get */
 #define SHMEM_CXX_PUT_NBI(TYPENAME,TYPE) \
@@ -477,14 +477,14 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET);
                                    size_t nelems, int pe) {        \
     shmem_##TYPENAME##_put_nbi(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT_NBI,)
 
 #define SHMEM_CXX_GET_NBI(TYPENAME,TYPE) \
   static inline void shmem_get_nbi(TYPE* dest, const TYPE* source, \
                                    size_t nelems, int pe) {        \
     shmem_##TYPENAME##_get_nbi(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI,)
 
 
 /* Atomics with standard AMO types */
@@ -492,51 +492,51 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI);
   static inline void shmem_add(TYPE *target, TYPE value, int pe) { \
     shmem_##TYPENAME##_add(target, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_ADD);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_ADD,)
 
 #define SHMEM_CXX_CSWAP(TYPENAME,TYPE) \
   static inline TYPE shmem_cswap(TYPE *target, TYPE cond, TYPE value,\
                                  int pe) {                           \
     return shmem_##TYPENAME##_cswap(target, cond, value, pe);        \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_CSWAP);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_CSWAP,)
 
 #define SHMEM_CXX_FINC(TYPENAME,TYPE) \
   static inline TYPE shmem_finc(TYPE *target, int pe) { \
     return shmem_##TYPENAME##_finc(target, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FINC);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FINC,)
 
 #define SHMEM_CXX_INC(TYPENAME,TYPE) \
   static inline void shmem_inc(TYPE *target, int pe) { \
     shmem_##TYPENAME##_inc(target, pe);                            \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_INC);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_INC,)
 
 #define SHMEM_CXX_FADD(TYPENAME,TYPE) \
   static inline TYPE shmem_fadd(TYPE *target, TYPE value, int pe) { \
     return shmem_##TYPENAME##_fadd(target, value, pe);              \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FADD);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FADD,)
 
 /* Atomics with extended AMO types */
 #define SHMEM_CXX_SWAP(TYPENAME,TYPE) \
   static inline TYPE shmem_swap(TYPE *target, TYPE value, int pe) { \
     return shmem_##TYPENAME##_swap(target, value, pe);              \
   }
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_SWAP);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_SWAP,)
 
 #define SHMEM_CXX_FETCH(TYPENAME,TYPE) \
   static inline TYPE shmem_fetch(const TYPE *target, int pe) { \
     return shmem_##TYPENAME##_fetch(target, pe);              \
   }
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH,)
 
 #define SHMEM_CXX_SET(TYPENAME,TYPE) \
   static inline void shmem_set(TYPE *target, TYPE value, int pe) { \
     shmem_##TYPENAME##_set(target, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_SET);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_SET,)
 
 #undef SHMEM_CXX_PUT
 #undef SHMEM_CXX_P

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -82,7 +82,7 @@ void *shmem_align(size_t alignment, size_t size);
 void *shmem_realloc(void *ptr, size_t size);
 void shmem_free(void *ptr);
 
-#define SHMEM_DECLARE_FOR_RMA(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_RMA(decl,END) \
   decl(float,      float) END           \
   decl(double,     double) END          \
   decl(longdouble, long double) END     \
@@ -92,32 +92,32 @@ void shmem_free(void *ptr);
   decl(long,       long) END            \
   decl(longlong,   long long)
 
-#define SHMEM_DECLARE_FOR_AMO(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_AMO(decl,END) \
   decl(int,        int) END             \
   decl(long,       long) END            \
   decl(longlong,   long long)
 
-#define SHMEM_DECLARE_FOR_EXTENDED_AMO(decl,END) \
-  SHMEM_DECLARE_FOR_AMO(decl,END) END            \
+#define SHMEM_EVAL_MACRO_FOR_EXTENDED_AMO(decl,END) \
+  SHMEM_EVAL_MACRO_FOR_AMO(decl,END) END            \
   decl(float,  float) END                        \
   decl(double, double)
 
-#define SHMEM_DECLARE_FOR_INTS(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_INTS(decl,END) \
   decl(short,    short) END              \
   decl(int,      int) END                \
   decl(long,     long) END               \
   decl(longlong, long long)
 
-#define SHMEM_DECLARE_FOR_FLOATS(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_FLOATS(decl,END) \
   decl(float,     float) END               \
   decl(double,     double) END             \
   decl(longdouble, long double)
 
-#define SHMEM_DECLARE_FOR_CMPLX(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_CMPLX(decl,END) \
   decl(complexf, float complex) END       \
   decl(complexd, double complex)
 
-#define SHMEM_DECLARE_FOR_SIZES(decl,END) \
+#define SHMEM_EVAL_MACRO_FOR_SIZES(decl,END) \
   decl(mem,  1) END                       \
   decl(8,    1*sizeof(uint8_t)) END       \
   decl(16,   2*sizeof(uint8_t)) END       \
@@ -125,126 +125,142 @@ void shmem_free(void *ptr);
   decl(64,   8*sizeof(uint8_t)) END       \
   decl(128, 16*sizeof(uint8_t))
 
+#define SHMEM_DECLARE_FOR_RMA(decl) SHMEM_EVAL_MACRO_FOR_RMA(decl,;)
+#define SHMEM_DECLARE_FOR_AMO(decl) SHMEM_EVAL_MACRO_FOR_AMO(decl,;)
+#define SHMEM_DECLARE_FOR_EXTENDED_AMO(decl) SHMEM_EVAL_MACRO_FOR_EXTENDED_AMO(decl,;)
+#define SHMEM_DECLARE_FOR_INTS(decl) SHMEM_EVAL_MACRO_FOR_INTS(decl,;)
+#define SHMEM_DECLARE_FOR_FLOATS(decl) SHMEM_EVAL_MACRO_FOR_FLOATS(decl,;)
+#define SHMEM_DECLARE_FOR_CMPLX(decl) SHMEM_EVAL_MACRO_FOR_CMPLX(decl,;)
+#define SHMEM_DECLARE_FOR_SIZES(decl) SHMEM_EVAL_MACRO_FOR_SIZES(decl,;)
+
+#define SHMEM_DEFINE_FOR_RMA(decl) SHMEM_EVAL_MACRO_FOR_RMA(decl,)
+#define SHMEM_DEFINE_FOR_AMO(decl) SHMEM_EVAL_MACRO_FOR_AMO(decl,)
+#define SHMEM_DEFINE_FOR_EXTENDED_AMO(decl) SHMEM_EVAL_MACRO_FOR_EXTENDED_AMO(decl,)
+#define SHMEM_DEFINE_FOR_INTS(decl) SHMEM_EVAL_MACRO_FOR_INTS(decl,)
+#define SHMEM_DEFINE_FOR_FLOATS(decl) SHMEM_EVAL_MACRO_FOR_FLOATS(decl,)
+#define SHMEM_DEFINE_FOR_CMPLX(decl) SHMEM_EVAL_MACRO_FOR_CMPLX(decl,)
+#define SHMEM_DEFINE_FOR_SIZES(decl) SHMEM_EVAL_MACRO_FOR_SIZES(decl,)
+
 /* 8.3: Elemental Data Put Routines */
 #define SHMEM_P(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_p(TYPE *addr, TYPE value, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_P,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_P);
 
 /* 8.3: Block Data Put Routines */
 #define SHMEM_PUT(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_put(TYPE *target, const TYPE *source, \
                                 size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_PUT,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT);
 
 #define SHMEM_PUT_N(SIZE,NBYTES) \
     void shmem_put##SIZE(void* target, const void *source, \
                          size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N);
 
 /* 8.3: Strided Put Routines */
 #define SHMEM_IPUT(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_iput(TYPE *target, const TYPE *source,  \
                                ptrdiff_t tst, ptrdiff_t sst,      \
                                size_t len, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_IPUT,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_IPUT);
 
 #define SHMEM_IPUT_N(SIZE,NBYTES) \
   void shmem_iput##SIZE(void *target, const void *source,         \
                         ptrdiff_t tst, ptrdiff_t sst, size_t len, \
                         int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_IPUT_N,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IPUT_N);
 
 /* 8.3: Elemental Data Get Routines */
 #define SHMEM_G(TYPENAME,TYPE) \
     TYPE shmem_##TYPENAME##_g(const TYPE *addr, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_G,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_G);
 
 /* 8.3: Block Data Get Routines */
 #define SHMEM_GET(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_get(TYPE *target, const TYPE *source, \
                                 size_t nelems,int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_GET,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET);
 
 #define SHMEM_GET_N(SIZE,NBYTES) \
     void shmem_get##SIZE(void* target, const void *source, \
                          size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N);
 
 /* 8.3: Strided Get Routines */
 #define SHMEM_IGET(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_iget(TYPE *target, const TYPE *source, \
                                  ptrdiff_t tst, ptrdiff_t sst,     \
                                  size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_IGET,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_IGET);
 
 #define SHMEM_IGET_N(SIZE,NBYTES) \
     void shmem_iget##SIZE(void* target, const void *source, \
                           ptrdiff_t tst, ptrdiff_t sst,     \
                           size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_IGET_N,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IGET_N);
 
 /* 8.4: Nonblocking remote memory access routines -- Put */
 #define SHMEM_PUT_NBI(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_put_nbi(TYPE *target, const TYPE *source,\
                                     size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_PUT_NBI,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT_NBI);
 
 #define SHMEM_PUT_N_NBI(SIZE,NBYTES) \
     void shmem_put##SIZE##_nbi(void* target, const void *source, \
                                size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N_NBI,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N_NBI);
 
 /* 8.4: Nonblocking remote memory access routines -- Get */
 #define SHMEM_GET_NBI(TYPENAME,TYPE) \
     void shmem_##TYPENAME##_get_nbi(TYPE *target, const TYPE *source,\
                                     size_t nelems, int pe)
-SHMEM_DECLARE_FOR_RMA(SHMEM_GET_NBI,;);
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET_NBI);
 
 #define SHMEM_GET_N_NBI(SIZE,NBYTES) \
     void shmem_get##SIZE##_nbi(void* target, const void *source, \
                                size_t nelems, int pe)
-SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N_NBI,;);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N_NBI);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Swap */
 #define SHMEM_SWAP(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_swap(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SWAP,;);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SWAP);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Cswap */
 #define SHMEM_CSWAP(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_cswap(TYPE *target, TYPE cond, TYPE value, \
                                 int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_CSWAP,;);
+SHMEM_DECLARE_FOR_AMO(SHMEM_CSWAP);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Add */
 #define SHMEM_FADD(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_fadd(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_FADD,;);
+SHMEM_DECLARE_FOR_AMO(SHMEM_FADD);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Increment */
 #define SHMEM_FINC(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_finc(TYPE *target, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_FINC,;);
+SHMEM_DECLARE_FOR_AMO(SHMEM_FINC);
 
 /* 8.4: Atomic Memory Operation Routines -- Add */
 #define SHMEM_ADD(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_add(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_ADD,;);
+SHMEM_DECLARE_FOR_AMO(SHMEM_ADD);
 
 /* 8.4: Atomic Memory Operation Routines -- Increment */
 #define SHMEM_INC(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_inc(TYPE *target, int pe)
-SHMEM_DECLARE_FOR_AMO(SHMEM_INC,;);
+SHMEM_DECLARE_FOR_AMO(SHMEM_INC);
 
 /* 8.4: Atomic fetch */
 #define SHMEM_FETCH(TYPENAME,TYPE) \
   TYPE shmem_##TYPENAME##_fetch(const TYPE *target, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_FETCH,;);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_FETCH);
 
 /* 8.4: Atomic set */
 #define SHMEM_SET(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_set(TYPE *target, TYPE value, int pe)
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SET,;);
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SET);
 
 /* 8.5: Barrier Synchronization Routines */
 void shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync);
@@ -257,7 +273,7 @@ void shmem_barrier_all(void);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL);
 
 #define SHMEM_OR_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_or_to_all(TYPE *target, \
@@ -265,7 +281,7 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL,;);
                                     int PE_start, int logPE_stride, \
                                     int PE_size, TYPE *pWrk, \
                                     long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL);
 
 #define SHMEM_XOR_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_xor_to_all(TYPE *target, \
@@ -273,7 +289,7 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL,;);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL);
 
 #define SHMEM_MIN_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_min_to_all(TYPE *target, \
@@ -281,8 +297,8 @@ SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL,;);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_MIN_TO_ALL,;);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_MIN_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL);
 
 #define SHMEM_MAX_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_max_to_all(TYPE *target, \
@@ -290,8 +306,8 @@ SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL,;);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_MAX_TO_ALL,;);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_MAX_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL);
 
 #define SHMEM_SUM_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_sum_to_all(TYPE *target, \
@@ -299,9 +315,9 @@ SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL,;);
                                      int PE_start, int logPE_stride, \
                                      int PE_size, TYPE *pWrk, \
                                      long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_SUM_TO_ALL,;);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_SUM_TO_ALL,;);
-SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_SUM_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_SUM_TO_ALL);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL);
 
 #define SHMEM_PROD_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_prod_to_all(TYPE *target, \
@@ -309,9 +325,9 @@ SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL,;);
                                       int PE_start, int logPE_stride, \
                                       int PE_size, TYPE *pWrk, \
                                       long *pSync)
-SHMEM_DECLARE_FOR_INTS(SHMEM_PROD_TO_ALL,;);
-SHMEM_DECLARE_FOR_FLOATS(SHMEM_PROD_TO_ALL,;);
-SHMEM_DECLARE_FOR_CMPLX(SHMEM_PROD_TO_ALL,;);
+SHMEM_DECLARE_FOR_INTS(SHMEM_PROD_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_PROD_TO_ALL);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_PROD_TO_ALL);
 
 /* 8.5: Collect Routines */
 void shmem_collect32(void *target, const void *source, size_t nlong,
@@ -433,13 +449,13 @@ using std::size_t;
                                size_t nelems, int pe) {        \
     shmem_##TYPENAME##_put(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_PUT)
 
 #define SHMEM_CXX_P(TYPENAME,TYPE) \
   static inline void shmem_p(TYPE* dest, TYPE value, int pe) { \
     shmem_##TYPENAME##_p(dest, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_P)
 
 #define SHMEM_CXX_IPUT(TYPENAME,TYPE) \
   static inline void shmem_iput(TYPE *target, const TYPE *source, \
@@ -447,7 +463,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P,)
                                 size_t len, int pe) {             \
     shmem_##TYPENAME##_iput(target, source, tst, sst, len, pe);   \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_IPUT)
 
 /* Blocking block, scalar, and block-strided get */
 #define SHMEM_CXX_GET(TYPENAME,TYPE) \
@@ -455,13 +471,13 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT,)
                                size_t nelems, int pe) {        \
     shmem_##TYPENAME##_get(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_GET)
 
 #define SHMEM_CXX_G(TYPENAME,TYPE) \
   static inline TYPE shmem_p(const TYPE* src, int pe) { \
     shmem_##TYPENAME##_g(src, pe);                      \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_G)
 
 #define SHMEM_CXX_IGET(TYPENAME,TYPE) \
   static inline void shmem_iget(TYPE *target, const TYPE *source, \
@@ -469,7 +485,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G,)
                                 size_t len, int pe) {             \
     shmem_##TYPENAME##_iget(target, source, tst, sst, len, pe);   \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_IGET)
 
 /* Nonblocking block put/get */
 #define SHMEM_CXX_PUT_NBI(TYPENAME,TYPE) \
@@ -477,14 +493,14 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET,)
                                    size_t nelems, int pe) {        \
     shmem_##TYPENAME##_put_nbi(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT_NBI,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_PUT_NBI)
 
 #define SHMEM_CXX_GET_NBI(TYPENAME,TYPE) \
   static inline void shmem_get_nbi(TYPE* dest, const TYPE* source, \
                                    size_t nelems, int pe) {        \
     shmem_##TYPENAME##_get_nbi(dest, source, nelems, pe);          \
   }
-SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_GET_NBI)
 
 
 /* Atomics with standard AMO types */
@@ -492,51 +508,51 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI,)
   static inline void shmem_add(TYPE *target, TYPE value, int pe) { \
     shmem_##TYPENAME##_add(target, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_ADD,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_ADD)
 
 #define SHMEM_CXX_CSWAP(TYPENAME,TYPE) \
   static inline TYPE shmem_cswap(TYPE *target, TYPE cond, TYPE value,\
                                  int pe) {                           \
     return shmem_##TYPENAME##_cswap(target, cond, value, pe);        \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_CSWAP,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_CSWAP)
 
 #define SHMEM_CXX_FINC(TYPENAME,TYPE) \
   static inline TYPE shmem_finc(TYPE *target, int pe) { \
     return shmem_##TYPENAME##_finc(target, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FINC,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_FINC)
 
 #define SHMEM_CXX_INC(TYPENAME,TYPE) \
   static inline void shmem_inc(TYPE *target, int pe) { \
     shmem_##TYPENAME##_inc(target, pe);                            \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_INC,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_INC)
 
 #define SHMEM_CXX_FADD(TYPENAME,TYPE) \
   static inline TYPE shmem_fadd(TYPE *target, TYPE value, int pe) { \
     return shmem_##TYPENAME##_fadd(target, value, pe);              \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FADD,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_FADD)
 
 /* Atomics with extended AMO types */
 #define SHMEM_CXX_SWAP(TYPENAME,TYPE) \
   static inline TYPE shmem_swap(TYPE *target, TYPE value, int pe) { \
     return shmem_##TYPENAME##_swap(target, value, pe);              \
   }
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_SWAP,)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_CXX_SWAP)
 
 #define SHMEM_CXX_FETCH(TYPENAME,TYPE) \
   static inline TYPE shmem_fetch(const TYPE *target, int pe) { \
     return shmem_##TYPENAME##_fetch(target, pe);              \
   }
-SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH,)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH)
 
 #define SHMEM_CXX_SET(TYPENAME,TYPE) \
   static inline void shmem_set(TYPE *target, TYPE value, int pe) { \
     shmem_##TYPENAME##_set(target, value, pe);                     \
   }
-SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_SET,)
+SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_SET)
 
 #undef SHMEM_CXX_PUT
 #undef SHMEM_CXX_P
@@ -732,6 +748,14 @@ long shmem_swap(long *target, long value, int pe);
 
 #ifndef SHMEM_INTERNAL_INCLUDE
 
+#undef SHMEM_EVAL_MACRO_FOR_RMA
+#undef SHMEM_EVAL_MACRO_FOR_AMO
+#undef SHMEM_EVAL_MACRO_FOR_EXTENDED_AMO
+#undef SHMEM_EVAL_MACRO_FOR_INTS
+#undef SHMEM_EVAL_MACRO_FOR_FLOATS
+#undef SHMEM_EVAL_MACRO_FOR_CMPLX
+#undef SHMEM_EVAL_MACRO_FOR_SIZES
+
 #undef SHMEM_DECLARE_FOR_RMA
 #undef SHMEM_DECLARE_FOR_AMO
 #undef SHMEM_DECLARE_FOR_EXTENDED_AMO
@@ -739,6 +763,14 @@ long shmem_swap(long *target, long value, int pe);
 #undef SHMEM_DECLARE_FOR_FLOATS
 #undef SHMEM_DECLARE_FOR_CMPLX
 #undef SHMEM_DECLARE_FOR_SIZES
+
+#undef SHMEM_DEFINE_FOR_RMA
+#undef SHMEM_DEFINE_FOR_AMO
+#undef SHMEM_DEFINE_FOR_EXTENDED_AMO
+#undef SHMEM_DEFINE_FOR_INTS
+#undef SHMEM_DEFINE_FOR_FLOATS
+#undef SHMEM_DEFINE_FOR_CMPLX
+#undef SHMEM_DEFINE_FOR_SIZES
 
 #endif
 

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -475,7 +475,7 @@ SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_GET)
 
 #define SHMEM_CXX_G(TYPENAME,TYPE) \
   static inline TYPE shmem_g(const TYPE* src, int pe) { \
-    shmem_##TYPENAME##_g(src, pe);                      \
+    return shmem_##TYPENAME##_g(src, pe);               \
   }
 SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_G)
 

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -82,341 +82,236 @@ void *shmem_align(size_t alignment, size_t size);
 void *shmem_realloc(void *ptr, size_t size);
 void shmem_free(void *ptr);
 
+#define SHMEM_DECLARE_FOR_RMA(decl) \
+  decl(float,      float);          \
+  decl(double,     double);         \
+  decl(longdouble, long double);    \
+  decl(char,       char);           \
+  decl(short,      short);          \
+  decl(int,        int);            \
+  decl(long,       long);           \
+  decl(longlong,   long long)
+
+#define SHMEM_DECLARE_FOR_AMO(decl) \
+  decl(int,        int);            \
+  decl(long,       long);           \
+  decl(longlong,   long long)
+
+#define SHMEM_DECLARE_FOR_EXTENDED_AMO(decl) \
+  SHMEM_DECLARE_FOR_AMO(decl);               \
+  decl(float,  float);                       \
+  decl(double, double)
+
+#define SHMEM_DECLARE_FOR_INTS(decl) \
+  decl(short,    short);                \
+  decl(int,      int);                  \
+  decl(long,     long);                 \
+  decl(longlong, long long)
+
+#define SHMEM_DECLARE_FOR_FLOATS(decl) \
+  decl(float,     float);              \
+  decl(double,     double);            \
+  decl(longdouble, long double)
+
+#define SHMEM_DECLARE_FOR_CMPLX(decl) \
+  decl(complexf, float complex);      \
+  decl(complexd, double complex)
+
+#define SHMEM_DECLARE_FOR_SIZES(decl) \
+  decl(mem,  1); \
+  decl(8,    1*sizeof(uint8_t));   \
+  decl(16,   2*sizeof(uint8_t));  \
+  decl(32,   4*sizeof(uint8_t));  \
+  decl(64,   8*sizeof(uint8_t));  \
+  decl(128, 16*sizeof(uint8_t))
+
 /* 8.3: Elemental Data Put Routines */
-void shmem_float_p(float *addr, float value, int pe);
-void shmem_double_p(double *addr, double value, int pe);
-void shmem_longdouble_p(long double *addr, long double value, int pe);
-void shmem_char_p(char *addr, char value, int pe);
-void shmem_short_p(short *addr, short value, int pe);
-void shmem_int_p(int *addr, int value, int pe);
-void shmem_long_p(long *addr, long value, int pe);
-void shmem_longlong_p(long long *addr, long long value, int pe);
+#define SHMEM_P(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_p(TYPE *addr, TYPE value, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_P);
 
 /* 8.3: Block Data Put Routines */
-void shmem_float_put(float *target, const float *source, size_t len, int pe);
-void shmem_double_put(double *target, const double *source, size_t len,
-                      int pe);
-void shmem_longdouble_put(long double *target, const long double *source,
-                          size_t len, int pe);
-void shmem_char_put(char *dest, const char *source, size_t nelems, int pe);
-void shmem_short_put(short *target, const short *source, size_t len, int pe);
-void shmem_int_put(int *target, const int *source, size_t len, int pe);
-void shmem_long_put(long *target, const long *source, size_t len, int pe);
-void shmem_longlong_put(long long *target, const long long *source,
-                        size_t len, int pe);
-void shmem_put8(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put16(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put32(void *target, const void *source, size_t len, int pe);
-void shmem_put64(void *target, const void *source, size_t len, int pe);
-void shmem_put128(void *target, const void *source, size_t len, int pe);
-void shmem_putmem(void *target, const void *source, size_t len, int pe);
+#define SHMEM_PUT(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_put(TYPE *target, const TYPE *source, \
+                                size_t nelems, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT);
+
+#define SHMEM_PUT_N(SIZE,NBYTES) \
+    void shmem_put##SIZE(void* target, const void *source, \
+                         size_t nelems, int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N);
 
 /* 8.3: Strided Put Routines */
-void shmem_float_iput(float *target, const float *source, ptrdiff_t tst,
-                      ptrdiff_t sst, size_t len, int pe);
-void shmem_double_iput(double *target, const double *source, ptrdiff_t tst,
-                       ptrdiff_t sst, size_t len, int pe);
-void shmem_longdouble_iput(long double *target, const long double *source,
-                           ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
-void shmem_short_iput(short *target, const short *source, ptrdiff_t tst,
-                      ptrdiff_t sst, size_t len, int pe);
-void shmem_int_iput(int *target, const int *source, ptrdiff_t tst,
-                    ptrdiff_t sst, size_t len, int pe);
-void shmem_long_iput(long *target, const long *source, ptrdiff_t tst,
-                     ptrdiff_t sst, size_t len, int pe);
-void shmem_longlong_iput(long long *target, const long long *source,
-                         ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
-void shmem_iput32(void *target, const void *source, ptrdiff_t tst,
-                  ptrdiff_t sst, size_t len, int pe);
-void shmem_iput64(void *target, const void *source, ptrdiff_t tst,
-                  ptrdiff_t sst, size_t len, int pe);
-void shmem_iput128(void *target, const void *source, ptrdiff_t tst,
-                   ptrdiff_t sst, size_t len, int pe);
+#define SHMEM_IPUT(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_iput(TYPE *target, const TYPE *source,  \
+                               ptrdiff_t tst, ptrdiff_t sst,      \
+                               size_t len, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_IPUT);
+
+#define SHMEM_IPUT_N(SIZE,NBYTES) \
+  void shmem_iput##SIZE(void *target, const void *source,         \
+                        ptrdiff_t tst, ptrdiff_t sst, size_t len, \
+                        int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IPUT_N);
 
 /* 8.3: Elemental Data Get Routines */
-float shmem_float_g(const float *addr, int pe);
-double shmem_double_g(const double *addr, int pe);
-long double shmem_longdouble_g(const long double *addr, int pe);
-char shmem_char_g(const char *addr, int pe);
-short shmem_short_g(const short *addr, int pe);
-int shmem_int_g(const int *addr, int pe);
-long shmem_long_g(const long *addr, int pe);
-long long shmem_longlong_g(const long long *addr, int pe);
+#define SHMEM_G(TYPENAME,TYPE) \
+    TYPE shmem_##TYPENAME##_g(const TYPE *addr, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_G);
 
 /* 8.3: Block Data Get Routines */
-void shmem_float_get(float *target, const float *source, size_t len, int pe);
-void shmem_double_get(double *target, const double *source, size_t len,
-                      int pe);
-void shmem_longdouble_get(long double *target, const long double *source,
-                          size_t len, int pe);
-void shmem_char_get(char *dest, const char *source, size_t nelems, int pe);
-void shmem_short_get(short *target, const short *source, size_t len, int pe);
-void shmem_int_get(int *target, const int *source, size_t len, int pe);
-void shmem_long_get(long *target, const long *source, size_t len, int pe);
-void shmem_longlong_get(long long *target, const long long *source,
-                        size_t len, int pe);
-void shmem_get8(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get16(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get32(void *target, const void *source, size_t len, int pe);
-void shmem_get64(void *target, const void *source, size_t len, int pe);
-void shmem_get128(void *target, const void *source, size_t len, int pe);
-void shmem_getmem(void *target, const void *source, size_t len, int pe);
+#define SHMEM_GET(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_get(TYPE *target, const TYPE *source, \
+                                size_t nelems,int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET);
+
+#define SHMEM_GET_N(SIZE,NBYTES) \
+    void shmem_get##SIZE(void* target, const void *source, \
+                         size_t nelems, int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N);
 
 /* 8.3: Strided Get Routines */
-void shmem_float_iget(float *target, const float *source, ptrdiff_t tst,
-                      ptrdiff_t sst, size_t len, int pe);
-void shmem_double_iget(double *target, const double *source, ptrdiff_t tst,
-                       ptrdiff_t sst, size_t len, int pe);
-void shmem_longdouble_iget(long double *target, const long double *source,
-                           ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
-void shmem_short_iget(short *target, const short *source, ptrdiff_t tst,
-                      ptrdiff_t sst, size_t len, int pe);
-void shmem_int_iget(int *target, const int *source, ptrdiff_t tst,
-                    ptrdiff_t sst, size_t len, int pe);
-void shmem_long_iget(long *target, const long *source, ptrdiff_t tst,
-                     ptrdiff_t sst, size_t len, int pe);
-void shmem_longlong_iget(long long *target, const long long *source,
-                         ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe);
-void shmem_iget32(void *target, const void *source, ptrdiff_t tst,
-                  ptrdiff_t sst, size_t len, int pe);
-void shmem_iget64(void *target, const void *source, ptrdiff_t tst,
-                  ptrdiff_t sst, size_t len, int pe);
-void shmem_iget128(void *target, const void *source, ptrdiff_t tst,
-                   ptrdiff_t sst, size_t len, int pe);
+#define SHMEM_IGET(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_iget(TYPE *target, const TYPE *source, \
+                                 ptrdiff_t tst, ptrdiff_t sst,     \
+                                 size_t nelems, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_IGET);
+
+#define SHMEM_IGET_N(SIZE,NBYTES) \
+    void shmem_iget##SIZE(void* target, const void *source, \
+                          ptrdiff_t tst, ptrdiff_t sst,     \
+                          size_t nelems, int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_IGET_N);
 
 /* 8.4: Nonblocking remote memory access routines -- Put */
-void shmem_float_put_nbi(float *dest, const float *source, size_t nelems,
-                         int pe);
-void shmem_double_put_nbi(double *dest, const double *source, size_t nelems,
-                          int pe);
-void shmem_longdouble_put_nbi(long double *dest, const long double *source,
-                              size_t nelems, int pe);
-void shmem_putmem_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_char_put_nbi(char *dest, const char *source, size_t nelems, int pe);
-void shmem_short_put_nbi(short *dest, const short *source, size_t nelems,
-                         int pe);
-void shmem_int_put_nbi(int *dest, const int *source, size_t nelems, int pe);
-void shmem_long_put_nbi(long *dest, const long *source, size_t nelems, int pe);
-void shmem_longlong_put_nbi(long long *dest, const long long *source,
-                            size_t nelems, int pe);
-void shmem_put8_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put16_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put32_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put64_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_put128_nbi(void *dest, const void *source, size_t nelems, int pe);
+#define SHMEM_PUT_NBI(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_put_nbi(TYPE *target, const TYPE *source,\
+                                    size_t nelems, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_PUT_NBI);
+
+#define SHMEM_PUT_N_NBI(SIZE,NBYTES) \
+    void shmem_put##SIZE##_nbi(void* target, const void *source, \
+                               size_t nelems, int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_PUT_N_NBI);
 
 /* 8.4: Nonblocking remote memory access routines -- Get */
-void shmem_float_get_nbi(float *dest, const float *source, size_t nelems,
-                         int pe);
-void shmem_double_get_nbi(double *dest, const double *source, size_t nelems,
-                          int pe);
-void shmem_longdouble_get_nbi(long double *dest, const long double *source,
-                              size_t nelems, int pe);
-void shmem_getmem_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_char_get_nbi(char *dest, const char *source, size_t nelems, int pe);
-void shmem_short_get_nbi(short *dest, const short *source, size_t nelems,
-                         int pe);
-void shmem_int_get_nbi(int *dest, const int *source, size_t nelems, int pe);
-void shmem_long_get_nbi(long *dest, const long *source, size_t nelems, int pe);
-void shmem_longlong_get_nbi(long long *dest, const long long *source,
-                            size_t nelems, int pe);
-void shmem_get8_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get16_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get32_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get64_nbi(void *dest, const void *source, size_t nelems, int pe);
-void shmem_get128_nbi(void *dest, const void *source, size_t nelems, int pe);
+#define SHMEM_GET_NBI(TYPENAME,TYPE) \
+    void shmem_##TYPENAME##_get_nbi(TYPE *target, const TYPE *source,\
+                                    size_t nelems, int pe)
+SHMEM_DECLARE_FOR_RMA(SHMEM_GET_NBI);
+
+#define SHMEM_GET_N_NBI(SIZE,NBYTES) \
+    void shmem_get##SIZE##_nbi(void* target, const void *source, \
+                               size_t nelems, int pe)
+SHMEM_DECLARE_FOR_SIZES(SHMEM_GET_N_NBI);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Swap */
-float shmem_float_swap(float *target, float value, int pe);
-double shmem_double_swap(double *target, double value, int pe);
-int shmem_int_swap(int *target, int value, int pe);
-long shmem_long_swap(long *target, long value, int pe);
-long long shmem_longlong_swap(long long *target, long long value, int pe);
+#define SHMEM_SWAP(TYPENAME,TYPE) \
+  TYPE shmem_##TYPENAME##_swap(TYPE *target, TYPE value, int pe)
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SWAP);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Cswap */
-int shmem_int_cswap(int *target, int cond, int value, int pe);
-long shmem_long_cswap(long *target, long cond, long value, int pe);
-long long shmem_longlong_cswap(long long * target, long long cond,
-                          long long value, int pe);
+#define SHMEM_CSWAP(TYPENAME,TYPE) \
+  TYPE shmem_##TYPENAME##_cswap(TYPE *target, TYPE cond, TYPE value, \
+                                int pe)
+SHMEM_DECLARE_FOR_AMO(SHMEM_CSWAP);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Add */
-int shmem_int_fadd(int *target, int value, int pe);
-long shmem_long_fadd(long *target, long value, int pe);
-long long shmem_longlong_fadd(long long *target, long long value, int pe);
+#define SHMEM_FADD(TYPENAME,TYPE) \
+  TYPE shmem_##TYPENAME##_fadd(TYPE *target, TYPE value, int pe)
+SHMEM_DECLARE_FOR_AMO(SHMEM_FADD);
 
 /* 8.4: Atomic Memory fetch-and-operate Routines -- Fetch and Increment */
-int shmem_int_finc(int *target, int pe);
-long shmem_long_finc(long *target, int pe);
-long long shmem_longlong_finc(long long *target, int pe);
+#define SHMEM_FINC(TYPENAME,TYPE) \
+  TYPE shmem_##TYPENAME##_finc(TYPE *target, int pe)
+SHMEM_DECLARE_FOR_AMO(SHMEM_FINC);
 
 /* 8.4: Atomic Memory Operation Routines -- Add */
-void shmem_int_add(int *target, int value, int pe);
-void shmem_long_add(long *target, long value, int pe);
-void shmem_longlong_add(long long *target, long long value, int pe);
+#define SHMEM_ADD(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_add(TYPE *target, TYPE value, int pe)
+SHMEM_DECLARE_FOR_AMO(SHMEM_ADD);
 
 /* 8.4: Atomic Memory Operation Routines -- Increment */
-void shmem_int_inc(int *target, int pe);
-void shmem_long_inc(long *target, int pe);
-void shmem_longlong_inc(long long *target, int pe);
+#define SHMEM_INC(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_inc(TYPE *target, int pe)
+SHMEM_DECLARE_FOR_AMO(SHMEM_INC);
 
 /* 8.4: Atomic fetch */
-int shmem_int_fetch(const int *source, int pe);
-long shmem_long_fetch(const long *source, int pe);
-long long shmem_longlong_fetch(const long long *source, int pe);
-float shmem_float_fetch(const float *source, int pe);
-double shmem_double_fetch(const double *source, int pe);
+#define SHMEM_FETCH(TYPENAME,TYPE) \
+  TYPE shmem_##TYPENAME##_fetch(const TYPE *target, int pe)
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_FETCH);
 
 /* 8.4: Atomic set */
-void shmem_int_set(int *dest, int value, int pe);
-void shmem_long_set(long *dest, long value, int pe);
-void shmem_longlong_set(long long *dest, long long value, int pe);
-void shmem_float_set(float *dest, float value, int pe);
-void shmem_double_set(double *dest, double value, int pe);
+#define SHMEM_SET(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_set(TYPE *target, TYPE value, int pe)
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_SET);
 
 /* 8.5: Barrier Synchronization Routines */
 void shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync);
 void shmem_barrier_all(void);
 
 /* 8.5: Reduction Routines */
-void shmem_short_and_to_all(short *target, const short *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            short *pWrk, long *pSync);
-void shmem_int_and_to_all(int *target, const int *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          int *pWrk, long *pSync);
-void shmem_long_and_to_all(long *target, const long *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           long *pWrk, long *pSync);
-void shmem_longlong_and_to_all(long long *target, const long long *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_AND_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_and_to_all(TYPE *target, \
+                                     const TYPE *source, int nreduce,\
+                                     int PE_start, int logPE_stride, \
+                                     int PE_size, TYPE *pWrk, \
+                                     long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_AND_TO_ALL);
 
-void shmem_short_or_to_all(short *target, const short *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           short *pWrk, long *pSync);
-void shmem_int_or_to_all(int *target, const int *source, int nreduce,
-                         int PE_start, int logPE_stride, int PE_size,
-                         int *pWrk, long *pSync);
-void shmem_long_or_to_all(long *target, const long *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          long *pWrk, long *pSync);
-void shmem_longlong_or_to_all(long long *target, const long long *source,
-                              int nreduce, int PE_start, int logPE_stride,
-                              int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_OR_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_or_to_all(TYPE *target, \
+                                    const TYPE *source, int nreduce,\
+                                    int PE_start, int logPE_stride, \
+                                    int PE_size, TYPE *pWrk, \
+                                    long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_OR_TO_ALL);
 
-void shmem_short_xor_to_all(short *target, const short *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            short *pWrk, long *pSync);
-void shmem_int_xor_to_all(int *target, const int *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          int *pWrk, long *pSync);
-void shmem_long_xor_to_all(long *target, const long *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           long *pWrk, long *pSync);
-void shmem_longlong_xor_to_all(long long *target, const long long *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_XOR_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_xor_to_all(TYPE *target, \
+                                     const TYPE *source, int nreduce,\
+                                     int PE_start, int logPE_stride, \
+                                     int PE_size, TYPE *pWrk, \
+                                     long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_XOR_TO_ALL);
 
-void shmem_float_min_to_all(float *target, const float *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            float *pWrk, long *pSync);
-void shmem_double_min_to_all(double *target, const double *source, int nreduce,
-                             int PE_start, int logPE_stride, int PE_size,
-                             double *pWrk, long *pSync);
-void shmem_longdouble_min_to_all(long double *target, const long double *source,
-                                 int nreduce, int PE_start, int logPE_stride,
-                                 int PE_size, long double *pWrk, long *pSync);
-void shmem_short_min_to_all(short *target, const short *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            short *pWrk, long *pSync);
-void shmem_int_min_to_all(int *target, const int *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          int *pWrk, long *pSync);
-void shmem_long_min_to_all(long *target, const long *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           long *pWrk, long *pSync);
-void shmem_longlong_min_to_all(long long *target, const long long *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_MIN_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_min_to_all(TYPE *target, \
+                                     const TYPE *source, int nreduce,\
+                                     int PE_start, int logPE_stride, \
+                                     int PE_size, TYPE *pWrk, \
+                                     long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_MIN_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MIN_TO_ALL);
 
-void shmem_float_max_to_all(float *target, const float *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            float *pWrk, long *pSync);
-void shmem_double_max_to_all(double *target, const double *source, int nreduce,
-                             int PE_start, int logPE_stride, int PE_size,
-                             double *pWrk, long *pSync);
-void shmem_longdouble_max_to_all(long double *target, const long double *source,
-                                 int nreduce, int PE_start, int logPE_stride,
-                                 int PE_size, long double *pWrk, long *pSync);
-void shmem_short_max_to_all(short *target, const short *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            short *pWrk, long *pSync);
-void shmem_int_max_to_all(int *target, const int *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          int *pWrk, long *pSync);
-void shmem_long_max_to_all(long *target, const long *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           long *pWrk, long *pSync);
-void shmem_longlong_max_to_all(long long *target, const long long *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_MAX_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_max_to_all(TYPE *target, \
+                                     const TYPE *source, int nreduce,\
+                                     int PE_start, int logPE_stride, \
+                                     int PE_size, TYPE *pWrk, \
+                                     long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_MAX_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_MAX_TO_ALL);
 
-void shmem_float_sum_to_all(float *target, const float *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            float *pWrk, long *pSync);
-void shmem_double_sum_to_all(double *target, const double *source, int nreduce,
-                             int PE_start, int logPE_stride, int PE_size,
-                             double *pWrk, long *pSync);
-void shmem_longdouble_sum_to_all(long double *target, const long double *source,
-                                 int nreduce, int PE_start, int logPE_stride,
-                                 int PE_size, long double *pWrk, long *pSync);
-void shmem_complexf_sum_to_all(float complex *target, const float complex *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, float complex *pWrk, long *pSync);
-void shmem_complexd_sum_to_all(double complex *target, const double complex *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, double complex *pWrk, long *pSync);
-void shmem_short_sum_to_all(short *target, const short *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            short *pWrk, long *pSync);
-void shmem_int_sum_to_all(int *target, const int *source, int nreduce,
-                          int PE_start, int logPE_stride, int PE_size,
-                          int *pWrk, long *pSync);
-void shmem_long_sum_to_all(long *target, const long *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           long *pWrk, long *pSync);
-void shmem_longlong_sum_to_all(long long *target, const long long *source,
-                               int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_SUM_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_sum_to_all(TYPE *target, \
+                                     const TYPE *source, int nreduce,\
+                                     int PE_start, int logPE_stride, \
+                                     int PE_size, TYPE *pWrk, \
+                                     long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_SUM_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_SUM_TO_ALL);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_SUM_TO_ALL);
 
-void shmem_float_prod_to_all(float *target, const float *source, int nreduce,
-                             int PE_start, int logPE_stride, int PE_size,
-                             float *pWrk, long *pSync);
-void shmem_double_prod_to_all(double *target, const double *source, int nreduce,
-                              int PE_start, int logPE_stride, int PE_size,
-                              double *pWrk, long *pSync);
-void shmem_longdouble_prod_to_all(long double *target, const long double *source,
-                                  int nreduce, int PE_start, int logPE_stride,
-                                  int PE_size, long double *pWrk, long *pSync);
-void shmem_complexf_prod_to_all(float complex *target, const float complex *source,
-                                int nreduce, int PE_start, int logPE_stride,
-                                int PE_size, float complex *pWrk, long *pSync);
-void shmem_complexd_prod_to_all(double complex *target,
-                                const double complex *source, int nreduce,
-                                int PE_start, int logPE_stride, int PE_size,
-                                double complex *pWrk, long *pSync);
-void shmem_short_prod_to_all(short *target, const short *source, int nreduce,
-                             int PE_start, int logPE_stride, int PE_size,
-                             short *pWrk, long *pSync);
-void shmem_int_prod_to_all(int *target, const int *source, int nreduce,
-                           int PE_start, int logPE_stride, int PE_size,
-                           int *pWrk, long *pSync);
-void shmem_long_prod_to_all(long *target, const long *source, int nreduce,
-                            int PE_start, int logPE_stride, int PE_size,
-                            long *pWrk, long *pSync);
-void shmem_longlong_prod_to_all(long long *target, const long long *source,
-                                int nreduce, int PE_start, int logPE_stride,
-                                int PE_size, long long *pWrk, long *pSync);
+#define SHMEM_PROD_TO_ALL(TYPENAME,TYPE) \
+  void shmem_##TYPENAME##_prod_to_all(TYPE *target, \
+                                      const TYPE *source, int nreduce,\
+                                      int PE_start, int logPE_stride, \
+                                      int PE_size, TYPE *pWrk, \
+                                      long *pSync)
+SHMEM_DECLARE_FOR_INTS(SHMEM_PROD_TO_ALL);
+SHMEM_DECLARE_FOR_FLOATS(SHMEM_PROD_TO_ALL);
+SHMEM_DECLARE_FOR_CMPLX(SHMEM_PROD_TO_ALL);
 
 /* 8.5: Collect Routines */
 void shmem_collect32(void *target, const void *source, size_t nlong,
@@ -492,6 +387,36 @@ void *shrealloc(void *ptr, size_t size) __attribute__ ((deprecated));
 void shfree(void *ptr) __attribute__ ((deprecated));
 void start_pes(int npes) __attribute__ ((deprecated));
 
+#undef SHMEM_P
+#undef SHMEM_PUT
+#undef SHMEM_PUT_N
+#undef SHMEM_IPUT
+#undef SHMEM_IPUT_N
+#undef SHMEM_G
+#undef SHMEM_GET
+#undef SHMEM_GET_N
+#undef SHMEM_IGET
+#undef SHMEM_IGET_N
+#undef SHMEM_PUT_NBI
+#undef SHMEM_PUT_N_NBI
+#undef SHMEM_GET_NBI
+#undef SHMEM_GET_N_NBI
+#undef SHMEM_SWAP
+#undef SHMEM_CSWAP
+#undef SHMEM_FADD
+#undef SHMEM_FINC
+#undef SHMEM_ADD
+#undef SHMEM_INC
+#undef SHMEM_FETCH
+#undef SHMEM_SET
+#undef SHMEM_AND_TO_ALL
+#undef SHMEM_OR_TO_ALL
+#undef SHMEM_XOR_TO_ALL
+#undef SHMEM_MIN_TO_ALL
+#undef SHMEM_MAX_TO_ALL
+#undef SHMEM_SUM_TO_ALL
+#undef SHMEM_PROD_TO_ALL
+
 /* C++ overloaded declarations */
 #ifdef __cplusplus
 } /* extern "C" */
@@ -503,301 +428,132 @@ using std::ptrdiff_t;
 using std::size_t;
 
 /* Blocking block, scalar, and block-strided put */
-static inline void shmem_put(float* dest, const float* source, size_t nelems, int pe) {
-    shmem_float_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(double* dest, const double* source, size_t nelems, int pe) {
-    shmem_double_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(long double* dest, const long double* source, size_t nelems, int pe) {
-    shmem_longdouble_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(char* dest, const char* source, size_t nelems, int pe) {
-    shmem_char_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(short* dest, const short* source, size_t nelems, int pe) {
-    shmem_short_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(int* dest, const int* source, size_t nelems, int pe) {
-    shmem_int_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(long* dest, const long* source, size_t nelems, int pe) {
-    shmem_long_put(dest, source, nelems, pe);
-}
-static inline void shmem_put(long long* dest, const long long* source, size_t nelems, int pe) {
-    shmem_longlong_put(dest, source, nelems, pe);
-}
+#define SHMEM_CXX_PUT(TYPENAME,TYPE) \
+  static inline void shmem_put(TYPE* dest, const TYPE* source, \
+                               size_t nelems, int pe) {        \
+    shmem_##TYPENAME##_put(dest, source, nelems, pe);          \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT);
 
-static inline void shmem_p(float *addr, float value, int pe) {
-    shmem_float_p(addr, value, pe);
-}
-static inline void shmem_p(double *addr, double value, int pe) {
-    shmem_double_p(addr, value, pe);
-}
-static inline void shmem_p(long double *addr, long double value, int pe) {
-    shmem_longdouble_p(addr, value, pe);
-}
-static inline void shmem_p(char *addr, char value, int pe) {
-    shmem_char_p(addr, value, pe);
-}
-static inline void shmem_p(short *addr, short value, int pe) {
-    shmem_short_p(addr, value, pe);
-}
-static inline void shmem_p(int *addr, int value, int pe) {
-    shmem_int_p(addr, value, pe);
-}
-static inline void shmem_p(long *addr, long value, int pe) {
-    shmem_long_p(addr, value, pe);
-}
-static inline void shmem_p(long long *addr, long long value, int pe) {
-    shmem_longlong_p(addr, value, pe);
-}
+#define SHMEM_CXX_P(TYPENAME,TYPE) \
+  static inline void shmem_p(TYPE* dest, TYPE value, int pe) { \
+    shmem_##TYPENAME##_p(dest, value, pe);                     \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_P);
 
-static inline void shmem_iput(float *target, const float *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_float_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(double *target, const double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_double_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(long double *target, const long double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_longdouble_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(short *target, const short *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_short_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(int *target, const int *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_int_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(long *target, const long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_long_iput(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iput(long long *target, const long long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_longlong_iput(target, source, tst, sst, len, pe);
-}
+#define SHMEM_CXX_IPUT(TYPENAME,TYPE) \
+  static inline void shmem_iput(TYPE *target, const TYPE *source, \
+                                ptrdiff_t tst, ptrdiff_t sst,     \
+                                size_t len, int pe) {             \
+    shmem_##TYPENAME##_iput(target, source, tst, sst, len, pe);   \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IPUT);
 
 /* Blocking block, scalar, and block-strided get */
-static inline void shmem_get(float *target, const float *source, size_t len, int pe) {
-    shmem_float_get(target, source, len, pe);
-}
-static inline void shmem_get(double *target, const double *source, size_t len, int pe) {
-    shmem_double_get(target, source, len, pe);
-}
-static inline void shmem_get(long double *target, const long double *source, size_t len, int pe) {
-    shmem_longdouble_get(target, source, len, pe);
-}
-static inline void shmem_get(char *dest, const char *source, size_t nelems, int pe) {
-    shmem_char_get(dest, source, nelems, pe);
-}
-static inline void shmem_get(short *target, const short *source, size_t len, int pe) {
-    shmem_short_get(target, source, len, pe);
-}
-static inline void shmem_get(int *target, const int *source, size_t len, int pe) {
-    shmem_int_get(target, source, len, pe);
-}
-static inline void shmem_get(long *target, const long *source, size_t len, int pe) {
-    shmem_long_get(target, source, len, pe);
-}
-static inline void shmem_get(long long *target, const long long *source, size_t len, int pe) {
-    shmem_longlong_get(target, source, len, pe);
-}
+#define SHMEM_CXX_GET(TYPENAME,TYPE) \
+  static inline void shmem_get(TYPE* dest, const TYPE* source, \
+                               size_t nelems, int pe) {        \
+    shmem_##TYPENAME##_get(dest, source, nelems, pe);          \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET);
 
-static inline float shmem_g(const float *addr, int pe) {
-    return shmem_float_g(addr, pe);
-}
-static inline double shmem_g(const double *addr, int pe) {
-    return shmem_double_g(addr, pe);
-}
-static inline long double shmem_g(const long double *addr, int pe) {
-    return shmem_longdouble_g(addr, pe);
-}
-static inline char shmem_g(const char *addr, int pe) {
-    return shmem_char_g(addr, pe);
-}
-static inline short shmem_g(const short *addr, int pe) {
-    return shmem_short_g(addr, pe);
-}
-static inline int shmem_g(const int *addr, int pe) {
-    return shmem_int_g(addr, pe);
-}
-static inline long shmem_g(const long *addr, int pe) {
-    return shmem_long_g(addr, pe);
-}
-static inline long long shmem_g(const long long *addr, int pe) {
-    return shmem_longlong_g(addr, pe);
-}
+#define SHMEM_CXX_G(TYPENAME,TYPE) \
+  static inline TYPE shmem_p(const TYPE* src, int pe) { \
+    shmem_##TYPENAME##_g(src, pe);                      \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_G);
 
-static inline void shmem_iget(float *target, const float *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_float_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(double *target, const double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_double_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(long double *target, const long double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_longdouble_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(short *target, const short *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_short_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(int *target, const int *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_int_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(long *target, const long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_long_iget(target, source, tst, sst, len, pe);
-}
-static inline void shmem_iget(long long *target, const long long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe) {
-    shmem_longlong_iget(target, source, tst, sst, len, pe);
-}
+#define SHMEM_CXX_IGET(TYPENAME,TYPE) \
+  static inline void shmem_iget(TYPE *target, const TYPE *source, \
+                                ptrdiff_t tst, ptrdiff_t sst,     \
+                                size_t len, int pe) {             \
+    shmem_##TYPENAME##_iget(target, source, tst, sst, len, pe);   \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_IGET);
 
 /* Nonblocking block put/get */
-static inline void shmem_put_nbi(float *dest, const float *source, size_t nelems, int pe) {
-    shmem_float_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(double *dest, const double *source, size_t nelems, int pe) {
-    shmem_double_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(long double *dest, const long double *source, size_t nelems, int pe) {
-    shmem_longdouble_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(char *dest, const char *source, size_t nelems, int pe) {
-    shmem_char_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(short *dest, const short *source, size_t nelems, int pe) {
-    shmem_short_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(int *dest, const int *source, size_t nelems, int pe) {
-    shmem_int_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(long *dest, const long *source, size_t nelems, int pe) {
-    shmem_long_put_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_put_nbi(long long *dest, const long long *source, size_t nelems, int pe) {
-    shmem_longlong_put_nbi(dest, source, nelems, pe);
-}
+#define SHMEM_CXX_PUT_NBI(TYPENAME,TYPE) \
+  static inline void shmem_put_nbi(TYPE* dest, const TYPE* source, \
+                                   size_t nelems, int pe) {        \
+    shmem_##TYPENAME##_put_nbi(dest, source, nelems, pe);          \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_PUT_NBI);
 
-static inline void shmem_get_nbi(float *dest, const float *source, size_t nelems, int pe) {
-    shmem_float_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(double *dest, const double *source, size_t nelems, int pe) {
-    shmem_double_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(long double *dest, const long double *source, size_t nelems, int pe) {
-    shmem_longdouble_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(char *dest, const char *source, size_t nelems, int pe) {
-    shmem_char_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(short *dest, const short *source, size_t nelems, int pe) {
-    shmem_short_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(int *dest, const int *source, size_t nelems, int pe) {
-    shmem_int_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(long *dest, const long *source, size_t nelems, int pe) {
-    shmem_long_get_nbi(dest, source, nelems, pe);
-}
-static inline void shmem_get_nbi(long long *dest, const long long *source, size_t nelems, int pe) {
-    shmem_longlong_get_nbi(dest, source, nelems, pe);
-}
+#define SHMEM_CXX_GET_NBI(TYPENAME,TYPE) \
+  static inline void shmem_get_nbi(TYPE* dest, const TYPE* source, \
+                                   size_t nelems, int pe) {        \
+    shmem_##TYPENAME##_get_nbi(dest, source, nelems, pe);          \
+  }
+SHMEM_DECLARE_FOR_RMA(SHMEM_CXX_GET_NBI);
+
 
 /* Atomics with standard AMO types */
-static inline void shmem_add(int *target, int value, int pe) {
-    shmem_int_add(target, value, pe);
-}
-static inline void shmem_add(long *target, long value, int pe) {
-    shmem_long_add(target, value, pe);
-}
-static inline void shmem_add(long long *target, long long value, int pe) {
-    shmem_longlong_add(target, value, pe);
-}
+#define SHMEM_CXX_ADD(TYPENAME,TYPE) \
+  static inline void shmem_add(TYPE *target, TYPE value, int pe) { \
+    shmem_##TYPENAME##_add(target, value, pe);                     \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_ADD);
 
-static inline int shmem_cswap(int *target, int cond, int value, int pe) {
-    return shmem_int_cswap(target, cond, value, pe);
-}
-static inline long shmem_cswap(long *target, long cond, long value, int pe) {
-    return shmem_long_cswap(target, cond, value, pe);
-}
-static inline long long shmem_cswap(long long * target, long long cond, long long value, int pe) {
-    return shmem_longlong_cswap(target, cond, value, pe);
-}
+#define SHMEM_CXX_CSWAP(TYPENAME,TYPE) \
+  static inline TYPE shmem_cswap(TYPE *target, TYPE cond, TYPE value,\
+                                 int pe) {                           \
+    return shmem_##TYPENAME##_cswap(target, cond, value, pe);        \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_CSWAP);
 
-static inline int shmem_finc(int *target, int pe) {
-    return shmem_int_finc(target, pe);
-}
-static inline long shmem_finc(long *target, int pe) {
-    return shmem_long_finc(target, pe);
-}
-static inline long long shmem_finc(long long *target, int pe) {
-    return shmem_longlong_finc(target, pe);
-}
+#define SHMEM_CXX_FINC(TYPENAME,TYPE) \
+  static inline TYPE shmem_finc(TYPE *target, int pe) { \
+    return shmem_##TYPENAME##_finc(target, pe);                     \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FINC);
 
-static inline void shmem_inc(int *target, int pe) {
-    shmem_int_inc(target, pe);
-}
-static inline void shmem_inc(long *target, int pe) {
-    shmem_long_inc(target, pe);
-}
-static inline void shmem_inc(long long *target, int pe) {
-    shmem_longlong_inc(target, pe);
-}
+#define SHMEM_CXX_INC(TYPENAME,TYPE) \
+  static inline void shmem_inc(TYPE *target, int pe) { \
+    shmem_##TYPENAME##_inc(target, pe);                            \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_INC);
 
-static inline int shmem_fadd(int *target, int value, int pe) {
-    return shmem_int_fadd(target, value, pe);
-}
-static inline long shmem_fadd(long *target, long value, int pe) {
-    return shmem_long_fadd(target, value, pe);
-}
-static inline long long shmem_fadd(long long *target, long long value, int pe) {
-    return shmem_longlong_fadd(target, value, pe);
-}
+#define SHMEM_CXX_FADD(TYPENAME,TYPE) \
+  static inline TYPE shmem_fadd(TYPE *target, TYPE value, int pe) { \
+    return shmem_##TYPENAME##_fadd(target, value, pe);              \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_FADD);
 
 /* Atomics with extended AMO types */
-static inline float shmem_swap(float *target, float value, int pe) {
-    return shmem_float_swap(target, value, pe);
-}
-static inline double shmem_swap(double *target, double value, int pe) {
-    return shmem_double_swap(target, value, pe);
-}
-static inline int shmem_swap(int *target, int value, int pe) {
-    return shmem_int_swap(target, value, pe);
-}
-static inline long shmem_swap(long *target, long value, int pe) {
-    return shmem_long_swap(target, value, pe);
-}
-static inline long long shmem_swap(long long *target, long long value, int pe) {
-    return shmem_longlong_swap(target, value, pe);
-}
+#define SHMEM_CXX_SWAP(TYPENAME,TYPE) \
+  static inline TYPE shmem_swap(TYPE *target, TYPE value, int pe) { \
+    return shmem_##TYPENAME##_swap(target, value, pe);              \
+  }
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_SWAP);
 
-static inline float shmem_fetch(const float *source, int pe) {
-    return shmem_float_fetch(source, pe);
-}
-static inline double shmem_fetch(const double *source, int pe) {
-    return shmem_double_fetch(source, pe);
-}
-static inline int shmem_fetch(const int *source, int pe) {
-    return shmem_int_fetch(source, pe);
-}
-static inline long shmem_fetch(const long *source, int pe) {
-    return shmem_long_fetch(source, pe);
-}
-static inline long long shmem_fetch(const long long *source, int pe) {
-    return shmem_longlong_fetch(source, pe);
-}
+#define SHMEM_CXX_FETCH(TYPENAME,TYPE) \
+  static inline TYPE shmem_fetch(const TYPE *target, int pe) { \
+    return shmem_##TYPENAME##_fetch(target, pe);              \
+  }
+SHMEM_DECLARE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH);
 
-static inline void shmem_set(float *dest, float value, int pe) {
-    shmem_float_set(dest, value, pe);
-}
-static inline void shmem_set(double *dest, double value, int pe) {
-    shmem_double_set(dest, value, pe);
-}
-static inline void shmem_set(int *dest, int value, int pe) {
-    shmem_int_set(dest, value, pe);
-}
-static inline void shmem_set(long *dest, long value, int pe) {
-    shmem_long_set(dest, value, pe);
-}
-static inline void shmem_set(long long *dest, long long value, int pe) {
-    shmem_longlong_set(dest, value, pe);
-}
+#define SHMEM_CXX_SET(TYPENAME,TYPE) \
+  static inline void shmem_set(TYPE *target, TYPE value, int pe) { \
+    shmem_##TYPENAME##_set(target, value, pe);                     \
+  }
+SHMEM_DECLARE_FOR_AMO(SHMEM_CXX_SET);
+
+#undef SHMEM_CXX_PUT
+#undef SHMEM_CXX_P
+#undef SHMEM_CXX_IPUT
+#undef SHMEM_CXX_GET
+#undef SHMEM_CXX_G
+#undef SHMEM_CXX_IGET
+#undef SHMEM_CXX_PUT_NBI
+#undef SHMEM_CXX_GET_NBI
+#undef SHMEM_CXX_ADD
+#undef SHMEM_CXX_CSWAP
+#undef SHMEM_CXX_FINC
+#undef SHMEM_CXX_INC
+#undef SHMEM_CXX_FADD
+#undef SHMEM_CXX_SWAP
+#undef SHMEM_CXX_FETCH
+#undef SHMEM_CXX_SET
 
 /* C11 Generic Macros */
 #elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(SHMEM_INTERNAL_INCLUDE))
@@ -974,4 +730,17 @@ static inline void shmem_set(long long *dest, long long value, int pe) {
 long shmem_swap(long *target, long value, int pe);
 #endif /* C11 */
 
+#ifndef SHMEM_INTERNAL_INCLUDE
+
+#undef SHMEM_DECLARE_FOR_RMA
+#undef SHMEM_DECLARE_FOR_AMO
+#undef SHMEM_DECLARE_FOR_EXTENDED_AMO
+#undef SHMEM_DECLARE_FOR_INTS
+#undef SHMEM_DECLARE_FOR_FLOATS
+#undef SHMEM_DECLARE_FOR_CMPLX
+#undef SHMEM_DECLARE_FOR_SIZES
+
+#endif
+
 #endif /* SHMEM_H */
+

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -474,7 +474,7 @@ SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_IPUT)
 SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_GET)
 
 #define SHMEM_CXX_G(TYPENAME,TYPE) \
-  static inline TYPE shmem_p(const TYPE* src, int pe) { \
+  static inline TYPE shmem_g(const TYPE* src, int pe) { \
     shmem_##TYPENAME##_g(src, pe);                      \
   }
 SHMEM_DEFINE_FOR_RMA(SHMEM_CXX_G)

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -552,7 +552,7 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_CXX_FETCH)
   static inline void shmem_set(TYPE *target, TYPE value, int pe) { \
     shmem_##TYPENAME##_set(target, value, pe);                     \
   }
-SHMEM_DEFINE_FOR_AMO(SHMEM_CXX_SET)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_CXX_SET)
 
 #undef SHMEM_CXX_PUT
 #undef SHMEM_CXX_P

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -477,6 +477,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N);
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
+    shmem_internal_get_wait();                                \
   }
 
 SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET);

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -331,7 +331,7 @@
     shmem_internal_put_small(addr, &value, sizeof(value), pe); \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P,)
 
 #define SHMEM_DEF_G(STYPE,TYPE) \
   TYPE shmem_##STYPE##_g(const TYPE *addr, int pe)   \
@@ -343,7 +343,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P);
     return tmp;                                      \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G,)
 
 #define SHMEM_DEF_PUT(STYPE,TYPE) \
   void shmem_##STYPE##_put(TYPE *target, const TYPE *source,     \
@@ -356,7 +356,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G);
     shmem_internal_put_wait(&completion);                        \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT,)
 
 #define SHMEM_DEF_PUT_N(NAME,SIZE) \
   void shmem_put##NAME(void *target, const void *source,       \
@@ -369,7 +369,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT);
     shmem_internal_put_wait(&completion);                      \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N,)
 
 #define SHMEM_DEF_PUT_NBI(STYPE,TYPE) \
   void shmem_##STYPE##_put_nbi(TYPE *target, const TYPE *source, \
@@ -380,7 +380,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N);
         pe);                                                     \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI,)
 
 #define SHMEM_DEF_PUT_N_NBI(NAME,SIZE) \
   void shmem_put##NAME##_nbi(void *target, const void *source, \
@@ -390,7 +390,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI);
     shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI,)
 
 #define SHMEM_DEF_GET(STYPE,TYPE) \
   void shmem_##STYPE##_get(TYPE *target,const TYPE *source,   \
@@ -402,7 +402,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI);
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET,)
 
 #define SHMEM_DEF_GET_N(NAME,SIZE) \
   void shmem_get##NAME(void *target, const void *source,   \
@@ -413,7 +413,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET);
     shmem_internal_get_wait();                             \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N,)
 
 #define SHMEM_DEF_GET_NBI(STYPE,TYPE) \
   void shmem_##STYPE##_get_nbi(TYPE *target, const TYPE *source, \
@@ -423,7 +423,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N);
     shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI,)
 
 #define SHMEM_DEF_GET_N_NBI(NAME,SIZE) \
   void shmem_get##NAME##_nbi(void *target, const void *source, \
@@ -433,7 +433,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI);
     shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI,)
 
 #define SHMEM_DEF_IPUT(STYPE,TYPE) \
   void shmem_##STYPE##_iput(TYPE *target, const TYPE *source, \
@@ -449,7 +449,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI);
     }                                                         \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT,)
 
 #define SHMEM_DEF_IPUT_N(NAME,SIZE) \
   void shmem_iput##NAME(void *target, const void *source,    \
@@ -464,7 +464,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT);
     }                                                        \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N,)
 
 #define SHMEM_DEF_IGET(STYPE,TYPE) \
   void shmem_##STYPE##_iget(TYPE *target, const TYPE *source, \
@@ -480,7 +480,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N);
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET);
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET,)
 
 #define SHMEM_DEF_IGET_N(NAME,SIZE) \
   void shmem_iget##NAME(void *target, const void *source, \
@@ -496,7 +496,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET);
     shmem_internal_get_wait();                            \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IGET_N);
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IGET_N,)
 
 void
 shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems, int pe)

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -331,7 +331,7 @@
     shmem_internal_put_small(addr, &value, sizeof(value), pe); \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_P)
 
 #define SHMEM_DEF_G(STYPE,TYPE) \
   TYPE shmem_##STYPE##_g(const TYPE *addr, int pe)   \
@@ -343,7 +343,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P,)
     return tmp;                                      \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_G)
 
 #define SHMEM_DEF_PUT(STYPE,TYPE) \
   void shmem_##STYPE##_put(TYPE *target, const TYPE *source,     \
@@ -356,7 +356,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G,)
     shmem_internal_put_wait(&completion);                        \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_PUT)
 
 #define SHMEM_DEF_PUT_N(NAME,SIZE) \
   void shmem_put##NAME(void *target, const void *source,       \
@@ -369,7 +369,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT,)
     shmem_internal_put_wait(&completion);                      \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_PUT_N)
 
 #define SHMEM_DEF_PUT_NBI(STYPE,TYPE) \
   void shmem_##STYPE##_put_nbi(TYPE *target, const TYPE *source, \
@@ -380,7 +380,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N,)
         pe);                                                     \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_PUT_NBI)
 
 #define SHMEM_DEF_PUT_N_NBI(NAME,SIZE) \
   void shmem_put##NAME##_nbi(void *target, const void *source, \
@@ -390,7 +390,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI,)
     shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI)
 
 #define SHMEM_DEF_GET(STYPE,TYPE) \
   void shmem_##STYPE##_get(TYPE *target,const TYPE *source,   \
@@ -402,7 +402,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI,)
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_GET)
 
 #define SHMEM_DEF_GET_N(NAME,SIZE) \
   void shmem_get##NAME(void *target, const void *source,   \
@@ -413,7 +413,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET,)
     shmem_internal_get_wait();                             \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_GET_N)
 
 #define SHMEM_DEF_GET_NBI(STYPE,TYPE) \
   void shmem_##STYPE##_get_nbi(TYPE *target, const TYPE *source, \
@@ -423,7 +423,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N,)
     shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_GET_NBI)
 
 #define SHMEM_DEF_GET_N_NBI(NAME,SIZE) \
   void shmem_get##NAME##_nbi(void *target, const void *source, \
@@ -433,7 +433,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI,)
     shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_GET_N_NBI)
 
 #define SHMEM_DEF_IPUT(STYPE,TYPE) \
   void shmem_##STYPE##_iput(TYPE *target, const TYPE *source, \
@@ -449,7 +449,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI,)
     }                                                         \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_IPUT)
 
 #define SHMEM_DEF_IPUT_N(NAME,SIZE) \
   void shmem_iput##NAME(void *target, const void *source,    \
@@ -464,7 +464,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT,)
     }                                                        \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_IPUT_N)
 
 #define SHMEM_DEF_IGET(STYPE,TYPE) \
   void shmem_##STYPE##_iget(TYPE *target, const TYPE *source, \
@@ -480,7 +480,7 @@ SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N,)
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET,)
+SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_IGET)
 
 #define SHMEM_DEF_IGET_N(NAME,SIZE) \
   void shmem_iget##NAME(void *target, const void *source, \
@@ -496,7 +496,7 @@ SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET,)
     shmem_internal_get_wait();                            \
   }
 
-SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IGET_N,)
+SHMEM_DEFINE_FOR_SIZES(SHMEM_DEF_IGET_N)
 
 void
 shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems, int pe)

--- a/src/data_c.c
+++ b/src/data_c.c
@@ -324,1047 +324,196 @@
 
 #endif /* ENABLE_PROFILING */
 
+#define SHMEM_DEF_P(STYPE,TYPE) \
+  void shmem_##STYPE##_p(TYPE *addr, TYPE value, int pe)       \
+  {                                                            \
+    SHMEM_ERR_CHECK_INITIALIZED();                             \
+    shmem_internal_put_small(addr, &value, sizeof(value), pe); \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_P);
+
+#define SHMEM_DEF_G(STYPE,TYPE) \
+  TYPE shmem_##STYPE##_g(const TYPE *addr, int pe)   \
+  {                                                  \
+    TYPE tmp;                                        \
+    SHMEM_ERR_CHECK_INITIALIZED();                   \
+    shmem_internal_get(&tmp, addr, sizeof(tmp), pe); \
+    shmem_internal_get_wait();                       \
+    return tmp;                                      \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_G);
+
+#define SHMEM_DEF_PUT(STYPE,TYPE) \
+  void shmem_##STYPE##_put(TYPE *target, const TYPE *source,     \
+                           size_t nelems, int pe)                \
+  {                                                              \
+    long completion = 0;                                         \
+    SHMEM_ERR_CHECK_INITIALIZED();                               \
+    shmem_internal_put_nb(target, source, sizeof(TYPE) * nelems, \
+                          pe, &completion);                      \
+    shmem_internal_put_wait(&completion);                        \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT);
+
+#define SHMEM_DEF_PUT_N(NAME,SIZE) \
+  void shmem_put##NAME(void *target, const void *source,       \
+                       size_t nelems, int pe)                  \
+  {                                                            \
+    long completion = 0;                                       \
+    SHMEM_ERR_CHECK_INITIALIZED();                             \
+    shmem_internal_put_nb(target, source, (SIZE) * nelems, pe, \
+                          &completion);                        \
+    shmem_internal_put_wait(&completion);                      \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N);
+
+#define SHMEM_DEF_PUT_NBI(STYPE,TYPE) \
+  void shmem_##STYPE##_put_nbi(TYPE *target, const TYPE *source, \
+                               size_t nelems, int pe)            \
+  {                                                              \
+    SHMEM_ERR_CHECK_INITIALIZED();                               \
+    shmem_internal_put_nbi(target, source, sizeof(TYPE)*nelems,  \
+        pe);                                                     \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_PUT_NBI);
+
+#define SHMEM_DEF_PUT_N_NBI(NAME,SIZE) \
+  void shmem_put##NAME##_nbi(void *target, const void *source, \
+                             size_t nelems, int pe)            \
+  {                                                            \
+    SHMEM_ERR_CHECK_INITIALIZED();                             \
+    shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_PUT_N_NBI);
+
+#define SHMEM_DEF_GET(STYPE,TYPE) \
+  void shmem_##STYPE##_get(TYPE *target,const TYPE *source,   \
+                           size_t nelems, int pe)             \
+  {                                                           \
+    SHMEM_ERR_CHECK_INITIALIZED();                            \
+    shmem_internal_get(target, source, sizeof(TYPE) * nelems, \
+        pe);                                                  \
+    shmem_internal_get_wait();                                \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET);
+
+#define SHMEM_DEF_GET_N(NAME,SIZE) \
+  void shmem_get##NAME(void *target, const void *source,   \
+                       size_t nelems, int pe)              \
+  {                                                        \
+    SHMEM_ERR_CHECK_INITIALIZED();                         \
+    shmem_internal_get(target, source, (SIZE)*nelems, pe); \
+    shmem_internal_get_wait();                             \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N);
+
+#define SHMEM_DEF_GET_NBI(STYPE,TYPE) \
+  void shmem_##STYPE##_get_nbi(TYPE *target, const TYPE *source, \
+                              size_t nelems, int pe)             \
+  {                                                              \
+    SHMEM_ERR_CHECK_INITIALIZED();                               \
+    shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_GET_NBI);
+
+#define SHMEM_DEF_GET_N_NBI(NAME,SIZE) \
+  void shmem_get##NAME##_nbi(void *target, const void *source, \
+                             size_t nelems, int pe)            \
+  {                                                            \
+    SHMEM_ERR_CHECK_INITIALIZED();                             \
+    shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_GET_N_NBI);
+
+#define SHMEM_DEF_IPUT(STYPE,TYPE) \
+  void shmem_##STYPE##_iput(TYPE *target, const TYPE *source, \
+                            ptrdiff_t tst, ptrdiff_t sst,     \
+                            size_t nelems, int pe)            \
+  {                                                           \
+    SHMEM_ERR_CHECK_INITIALIZED();                            \
+    for ( ; nelems > 0 ; --nelems) {                          \
+      shmem_internal_put_small(target, source, sizeof(TYPE),  \
+          pe);                                                \
+      target += tst;                                          \
+      source += sst;                                          \
+    }                                                         \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IPUT);
+
+#define SHMEM_DEF_IPUT_N(NAME,SIZE) \
+  void shmem_iput##NAME(void *target, const void *source,    \
+                        ptrdiff_t tst, ptrdiff_t sst,        \
+                        size_t nelems, int pe)               \
+  {                                                          \
+    SHMEM_ERR_CHECK_INITIALIZED();                           \
+    for ( ; nelems > 0 ; --nelems) {                         \
+      shmem_internal_put_small(target, source, (SIZE), pe);  \
+      target = (uint8_t*)target + tst*(SIZE);                \
+      source = (uint8_t*)source + sst*(SIZE);                \
+    }                                                        \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IPUT_N);
+
+#define SHMEM_DEF_IGET(STYPE,TYPE) \
+  void shmem_##STYPE##_iget(TYPE *target, const TYPE *source, \
+                            ptrdiff_t tst, ptrdiff_t sst,     \
+                            size_t nelems, int pe)            \
+  {                                                           \
+    SHMEM_ERR_CHECK_INITIALIZED();                            \
+    for ( ; nelems > 0 ; --nelems) {                          \
+      shmem_internal_get(target, source, sizeof(TYPE), pe);   \
+      target += tst;                                          \
+      source += sst;                                          \
+    }                                                         \
+  }
+
+SHMEM_DECLARE_FOR_RMA(SHMEM_DEF_IGET);
+
+#define SHMEM_DEF_IGET_N(NAME,SIZE) \
+  void shmem_iget##NAME(void *target, const void *source, \
+                        ptrdiff_t tst, ptrdiff_t sst,     \
+                        size_t nelems, int pe)            \
+  {                                                       \
+    SHMEM_ERR_CHECK_INITIALIZED();                        \
+    for ( ; nelems > 0 ; --nelems) {                      \
+      shmem_internal_get(target, source, (SIZE), pe);     \
+      target = (uint8_t*)target + tst*(SIZE);             \
+      source = (uint8_t*)source + sst*(SIZE);             \
+    }                                                     \
+    shmem_internal_get_wait();                            \
+  }
+
+SHMEM_DECLARE_FOR_SIZES(SHMEM_DEF_IGET_N);
 
 void
-shmem_float_p(float *addr, float value, int pe)
+shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems, int pe)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_double_p(double *addr, double value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_longdouble_p(long double *addr, long double value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_char_p(char *addr, char value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_short_p(short *addr, short value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_int_p(int *addr, int value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);    
-}
-
-
-void
-shmem_long_p(long *addr, long value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-void
-shmem_longlong_p(long long *addr, long long value, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_small(addr, &value, sizeof(value), pe);
-}
-
-
-float
-shmem_float_g(const float *addr, int pe)
-{
-    float tmp = 0.0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-double
-shmem_double_g(const double *addr, int pe)
-{
-    double tmp = 0.0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-long double
-shmem_longdouble_g(const long double *addr, int pe)
-{
-    long double tmp = 0.0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-char
-shmem_char_g(const char *addr, int pe)
-{
-    char tmp = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-short
-shmem_short_g(const short *addr, int pe)
-{
-    short tmp = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-int
-shmem_int_g(const int *addr, int pe)
-{
-    int tmp = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-long
-shmem_long_g(const long *addr, int pe)
-{
-    long tmp = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-long long
-shmem_longlong_g(const long long *addr, int pe)
-{
-    long long tmp = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(&tmp, addr, sizeof(tmp), pe);
-    shmem_internal_get_wait();
-    return tmp;
-}
-
-
-void
-shmem_float_put(float *target, const float *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(float) * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_double_put(double *target, const double *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(double) * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_longdouble_put(long double *target, const long double *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(long double) * len, pe,
-                          &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_char_put(char *dest, const char *source, size_t nelems, int pe)
-{
-  long completion = 0;
-
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nb(dest, source, sizeof(char)*nelems, pe, &completion);
-  shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_short_put(short *target, const short *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(short) * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_int_put(int *target, const int *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(int) * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_long_put(long *target, const long *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(long) * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_longlong_put(long long *target, const long long *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, sizeof(long long) * len, pe,
-                          &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_put8(void *dest, const void *source, size_t nelems, int pe)
-{
-  long completion = 0;
-
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nb(dest, source, nelems, pe, &completion);
-  shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_put16(void *dest, const void *source, size_t nelems, int pe)
-{
-  long completion = 0;
-
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nb(dest, source, 2 * nelems, pe, &completion);
-  shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_put32(void *target, const void *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, 4 * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_put64(void *target, const void *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, 8 * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_put128(void *target, const void *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, 16 * len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_putmem(void *target, const void *source, size_t len, int pe)
-{
-    long completion = 0;
-
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_put_nb(target, source, len, pe, &completion);
-    shmem_internal_put_wait(&completion);
-}
-
-
-void
-shmem_float_put_nbi(float *dest, const float *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(float)*nelems, pe);
-}
-
-
-void
-shmem_double_put_nbi(double *dest, const double *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(double)*nelems, pe);
-}
-
-
-void
-shmem_longdouble_put_nbi(long double *dest, const long double *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(long double)*nelems, pe);
-}
-
-
-void
-shmem_char_put_nbi(char *dest, const char *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(char)*nelems, pe);
-}
-
-
-void
-shmem_putmem_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, nelems, pe);
-}
-
-
-void
-shmem_short_put_nbi(short *dest, const short *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(short)*nelems, pe);
-}
-
-
-void
-shmem_int_put_nbi(int *dest, const int *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(int)*nelems, pe);
-}
-
-
-void
-shmem_long_put_nbi(long *dest, const long *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(long)*nelems, pe);
-}
-
-
-void
-shmem_longlong_put_nbi(long long *dest, const long long *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, sizeof(long long)*nelems, pe);
-}
-
-
-void
-shmem_put8_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, nelems, pe);
-}
-
-
-void
-shmem_put16_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, 2 * nelems, pe);
-}
-
-
-void
-shmem_put32_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, 4*nelems, pe);
-}
-
-
-void
-shmem_put64_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, 8*nelems, pe);
-}
-
-
-void
-shmem_put128_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_put_nbi(dest, source, 16*nelems, pe);
-}
-
-
-void
-shmem_float_get(float *target, const float *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(float) * len, pe);
+    shmem_internal_get_ct(ct, target, source, nelems, pe);
     shmem_internal_get_wait();
 }
-
-
-void
-shmem_double_get(double *target, const double *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(double) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_longdouble_get(long double *target, const long double *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(long double) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-
-void
-shmem_char_get(char *target, const char *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(char) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-
-void
-shmem_short_get(short *target, const short *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(short) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_int_get(int *target, const int *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(int) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_long_get(long *target, const long *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(long) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_longlong_get(long long *target, const long long *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, sizeof(long long) * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_get8(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, nelems, pe);
-  shmem_internal_get_wait();
-}
-
-
-void
-shmem_get16(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, 2 * nelems, pe);
-  shmem_internal_get_wait();
-}
-
-
-void
-shmem_get32(void *target, const void *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, 4 * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_get64(void *target, const void *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, 8 * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_get128(void *target, const void *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, 16 * len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_getmem(void *target, const void *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get(target, source, len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_float_get_nbi(float *dest, const float *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(float)*nelems, pe);
-}
-
-
-void
-shmem_double_get_nbi(double *dest, const double *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(double)*nelems, pe);
-}
-
-
-void
-shmem_longdouble_get_nbi(long double *dest, const long double *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(long double)*nelems, pe);
-}
-
-
-void
-shmem_char_get_nbi(char *dest, const char *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(char)*nelems, pe);
-}
-
-
-void
-shmem_getmem_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, nelems, pe);
-}
-
-
-void
-shmem_short_get_nbi(short *dest, const short *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(short)*nelems, pe);
-}
-
-
-void
-shmem_int_get_nbi(int *dest, const int *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(int)*nelems, pe);
-}
-
-
-void
-shmem_long_get_nbi(long *dest, const long *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(long)*nelems, pe);
-}
-
-
-void
-shmem_longlong_get_nbi(long long *dest, const long long *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, sizeof(long long)*nelems, pe);
-}
-
-
-void
-shmem_get8_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, nelems, pe);
-}
-
-
-void
-shmem_get16_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, 2 * nelems, pe);
-}
-
-
-void
-shmem_get32_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, 4*nelems, pe);
-}
-
-
-void
-shmem_get64_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, 8*nelems, pe);
-}
-
-
-void
-shmem_get128_nbi(void *dest, const void *source, size_t nelems, int pe)
-{
-  SHMEM_ERR_CHECK_INITIALIZED();
-
-  shmem_internal_get(dest, source, 16*nelems, pe);
-}
-
-
-void
-shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    shmem_internal_get_ct(ct, target, source, len, pe);
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_float_iput(float *target, const float *source, ptrdiff_t tst, ptrdiff_t sst,
-                 size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(float), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_double_iput(double *target, const double *source, ptrdiff_t tst,
-                  ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(double), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_longdouble_iput(long double *target, const long double *source,
-                      ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(long double), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_short_iput(short *target, const short *source, ptrdiff_t tst, ptrdiff_t sst,
-                 size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(short), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_int_iput(int *target, const int *source, ptrdiff_t tst, ptrdiff_t sst,
-               size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(int), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_long_iput(long *target, const long *source, ptrdiff_t tst,
-                ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(long), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_longlong_iput(long long *target, const long long *source, ptrdiff_t tst,
-                    ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(long long), pe);
-	target += tst;
-	source += sst;
-    }
-}
-
-
-void
-shmem_iput32(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst,
-             size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(uint32_t), pe);
-	target = (uint32_t*)target + tst;
-	source = (uint32_t*)source + sst;
-    }
-}
-
-
-void
-shmem_iput64(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst,
-             size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, sizeof(uint64_t), pe);
-	target = (uint64_t*)target + tst;
-	source = (uint64_t*)source + sst;
-    }
-}
-
-
-void
-shmem_iput128(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    tst *= 16;
-    sst *= 16;
-    for ( ; len > 0 ; --len) {
-        shmem_internal_put_small(target, source, 16, pe);
-	target = (uint8_t*)target + tst;
-	source = (uint8_t*)source + sst;
-    }
-}
-
-
-void
-shmem_float_iget(float *target, const float *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(float), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_double_iget(double *target, const double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(double), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_longdouble_iget(long double *target, const long double *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(long double), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_short_iget(short *target, const short *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(short), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_int_iget(int *target, const int *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(int), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_long_iget(long *target, const long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(long), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_longlong_iget(long long *target, const long long *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(long long), pe);
-	target += tst;
-	source += sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_iget32(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(uint32_t), pe);
-	target = (uint32_t*)target + tst;
-	source = (uint32_t*)source + sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_iget64(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, sizeof(uint64_t), pe);
-	target = (uint64_t*)target + tst;
-	source = (uint64_t*)source + sst;
-    }
-    shmem_internal_get_wait();
-}
-
-
-void
-shmem_iget128(void *target, const void *source, ptrdiff_t tst, ptrdiff_t sst, size_t len, int pe)
-{
-    SHMEM_ERR_CHECK_INITIALIZED();
-
-    tst *= 16;
-    sst *= 16;
-    for ( ; len > 0 ; --len ) {
-        shmem_internal_get(target, source, 16, pe);
-	target = (uint8_t*)target + tst;
-	source = (uint8_t*)source + sst;
-    }
-    shmem_internal_get_wait();
-}
-
 
 void shmemx_putmem_ct(shmemx_ct_t ct, void *target, const void *source,
-                     size_t len, int pe)
+                     size_t nelems, int pe)
 {
     long completion = 0;
 
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_put_ct_nb(ct, target, source, len, pe, &completion);
+    shmem_internal_put_ct_nb(ct, target, source, nelems, pe, &completion);
     shmem_internal_put_wait(&completion);
 }
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -74,7 +74,8 @@ TESTS = \
 	c11_test_shmem_put \
 	c11_test_shmem_set \
 	get_nbi \
-	put_nbi
+	put_nbi \
+	rma_coverage
 
 if USE_PORTALS4
 TESTS += \
@@ -116,6 +117,9 @@ AM_LDFLAGS = $(LIBTOOL_WRAPPER_LDFLAGS)
 
 pi_SOURCES = pi.c
 pi_LDADD = $(top_builddir)/src/libsma.la
+
+rma_coverage_SOURCES = rma_coverage.c
+rma_coverage_LDADD = $(top_builddir)/src/libsma.la
 
 hello_SOURCES = hello.c
 hello_LDADD = $(top_builddir)/src/libsma.la

--- a/test/unit/rma_coverage.c
+++ b/test/unit/rma_coverage.c
@@ -94,7 +94,7 @@
       return ret;                                                      \
   }
 
-SHMEM_DECLARE_FOR_RMA(DECLARE_TEST);
+SHMEM_DECLARE_FOR_RMA(DECLARE_TEST,)
 
 int main(int argc, char* argv[]) {
     int verbose = 0;
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
         errors += (TYPENAME##_rmaTest(nextpe,verbose)); \
     } while(0)
 
-    SHMEM_DECLARE_FOR_RMA(RUN_TEST);
+    SHMEM_DECLARE_FOR_RMA(RUN_TEST,;);
 
     shmem_finalize();
 

--- a/test/unit/rma_coverage.c
+++ b/test/unit/rma_coverage.c
@@ -94,7 +94,7 @@
       return ret;                                                      \
   }
 
-SHMEM_DECLARE_FOR_RMA(DECLARE_TEST,)
+SHMEM_DEFINE_FOR_RMA(DECLARE_TEST)
 
 int main(int argc, char* argv[]) {
     int verbose = 0;
@@ -117,7 +117,7 @@ int main(int argc, char* argv[]) {
         errors += (TYPENAME##_rmaTest(nextpe,verbose)); \
     } while(0)
 
-    SHMEM_DECLARE_FOR_RMA(RUN_TEST,;);
+    SHMEM_DECLARE_FOR_RMA(RUN_TEST);
 
     shmem_finalize();
 

--- a/test/unit/rma_coverage.c
+++ b/test/unit/rma_coverage.c
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2015 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ * *	Redistribution and use in source and binary forms, with or
+ *	without modification, are permitted provided that the following
+ *	conditions are met:
+ *
+ *	- Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define SHMEM_INTERNAL_INCLUDE
+#include <shmem.h>
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CHUNK_SIZE 10
+#define ARR_SIZE (4*(CHUNK_SIZE))
+
+#define DECLARE_TEST(TYPENAME,TYPE) \
+  TYPE TYPENAME##_shared[ARR_SIZE];                                    \
+                                                                       \
+  int TYPENAME##_rmaTest(int target_pe, int verbose) {                 \
+      TYPE* shared = TYPENAME##_shared;                                \
+      TYPE myvals[ARR_SIZE];                                           \
+      TYPE result[ARR_SIZE];                                           \
+      size_t i;                                                        \
+                                                                       \
+      for(i = 0; i < ARR_SIZE; ++i) {                                  \
+          myvals[i] = (TYPE)rand();                                    \
+      }                                                                \
+                                                                       \
+      shmem_##TYPENAME##_put(shared, myvals, CHUNK_SIZE, target_pe);   \
+      for(i = 0; i < CHUNK_SIZE; ++i) {                                \
+          shmem_##TYPENAME##_p(&shared[CHUNK_SIZE+i],                  \
+              myvals[CHUNK_SIZE+i], target_pe);                        \
+      }                                                                \
+      shmem_##TYPENAME##_iput(shared+2*CHUNK_SIZE,myvals+2*CHUNK_SIZE, \
+          1, 2, CHUNK_SIZE/2, target_pe);                              \
+      shmem_##TYPENAME##_iput(shared+2*CHUNK_SIZE+CHUNK_SIZE/2,        \
+          myvals+2*CHUNK_SIZE+1, 1, 2, CHUNK_SIZE/2, target_pe);       \
+      shmem_##TYPENAME##_put_nbi(shared+3*CHUNK_SIZE,                  \
+          myvals+3*CHUNK_SIZE, CHUNK_SIZE, target_pe);                 \
+                                                                       \
+      shmem_quiet();                                                   \
+      shmem_barrier_all();                                             \
+                                                                       \
+      shmem_##TYPENAME##_get(result,shared,CHUNK_SIZE,target_pe);      \
+      for(i = 0; i < CHUNK_SIZE; ++i) {                                \
+          result[CHUNK_SIZE+i] = shmem_##TYPENAME##_g(                 \
+                                  &shared[CHUNK_SIZE+i], target_pe);   \
+      }                                                                \
+      shmem_##TYPENAME##_iget(result+2*CHUNK_SIZE, shared+2*CHUNK_SIZE,\
+          2, 1, CHUNK_SIZE/2, target_pe);                              \
+      shmem_##TYPENAME##_iget(result+2*CHUNK_SIZE+1,                   \
+          shared+2*CHUNK_SIZE+CHUNK_SIZE/2, 2, 1, CHUNK_SIZE/2,        \
+          target_pe);                                                  \
+      shmem_##TYPENAME##_get_nbi(result+3*CHUNK_SIZE,                  \
+          shared+3*CHUNK_SIZE, CHUNK_SIZE, target_pe);                 \
+                                                                       \
+      shmem_quiet();                                                   \
+      shmem_barrier_all();                                             \
+      int ret = 0;                                                     \
+      for(i = 0; i < ARR_SIZE; ++i) {                                  \
+          if(result[i] != myvals[i]) {                                 \
+              ++ret;                                                   \
+              if(verbose) {                                            \
+                  fprintf(stderr,"result[%lu] != myvals[%lu]", i, i);  \
+              }                                                        \
+          }                                                            \
+      }                                                                \
+      if(verbose) {                                                    \
+          fprintf(stderr,"%s (type '%s') %s: %d\n",#TYPENAME,          \
+                  #TYPE,ret ? "Failed" : "Succeeded",ret);             \
+      }                                                                \
+      return ret;                                                      \
+  }
+
+SHMEM_DECLARE_FOR_RMA(DECLARE_TEST);
+
+int main(int argc, char* argv[]) {
+    int verbose = 0;
+    if(argc > 1) {
+        verbose = !strcmp("-v",argv[1]);
+    }
+
+    int errors = 0;
+
+    int me, myshmem_n_pes;
+    shmem_init();
+    myshmem_n_pes = shmem_n_pes();
+    me = shmem_my_pe();
+
+    srand(1+me);
+
+    int nextpe = (me+1)%myshmem_n_pes;
+
+#define RUN_TEST(TYPENAME,TYPE) do { \
+        errors += (TYPENAME##_rmaTest(nextpe,verbose)); \
+    } while(0)
+
+    SHMEM_DECLARE_FOR_RMA(RUN_TEST);
+
+    shmem_finalize();
+
+    return errors;
+}
+


### PR DESCRIPTION
There is a lot of duplicated code in `shmem.h` and `data_c.c`, in which the only change between each version is the type each function operates on. This is hard to change and error prone (for example, #203 -- `shmem_char_iput` and `shmem_char_iget` are not declared or implemented). This pull request adds a few utility macros for the typeclasses in the OpenSHMEM 1.3 Spec. For example, to declare the function

    void shmem_<TYPENAME>_p(<TYPE> *addr, <TYPE> value, int pe);

where \<TYPE\> is allowed to be any RMA type, as specified in 8.3.2, we currently have:

    void shmem_float_p(float *addr, float value, int pe);
    void shmem_double_p(double *addr, double value, int pe);
    void shmem_longdouble_p(long double *addr, long double value, int pe);
    void shmem_char_p(char *addr, char value, int pe);
    void shmem_short_p(short *addr, short value, int pe);
    void shmem_int_p(int *addr, int value, int pe);
    void shmem_long_p(long *addr, long value, int pe);
    void shmem_longlong_p(long long *addr, long long value, int pe);

With the new macro system, this becomes:

    #define SHMEM_P(TYPENAME,TYPE) \
      void shmem_##TYPENAME##_p(TYPE *addr, TYPE value, int pe)
    SHMEM_DECLARE_FOR_RMA(SHMEM_P);

which more clearly expresses the intent, and is less error-prone.

The implementation is unified, as well:

    #define SHMEM_DEF_P(STYPE,TYPE) \
      void shmem_##STYPE##_p(TYPE *addr, TYPE value, int pe)       \
      {                                                            \
        SHMEM_ERR_CHECK_INITIALIZED();                             \
        shmem_internal_put_small(addr, &value, sizeof(value), pe); \
      }
    
    SHMEM_DEFINE_FOR_RMA(SHMEM_DEF_P)

This also adds the `rma_coverage` test, which calls `shmem_*_{put,iput,p,get,iget,g}` for all types that `SHMEM_DEFINE_FOR_RMA` provides. It might be a good idea to have redefine `DEFINE_FOR_RMA` within the test to make sure that `SHMEM_DEFINE_FOR_RMA` does not have any bugs in it, but if a type is missing from `SHMEM_DEFINE_FOR_RMA`, all functions of that type will be missing, and will be caught by another test. For example, to exclude `shmem_char_iput` and `shmem_char_iget`, you must either remove `iput` and `iget` for all types, or exclude all RMA operations on `char`, and either `rma_coverage` or one of the C11 tests fail.