### PR TITLE
add support for large page sheap for linux

### DIFF
--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -28,6 +28,8 @@ extern void *shmem_internal_heap_base;
 extern long shmem_internal_heap_length;
 extern void *shmem_internal_data_base;
 extern long shmem_internal_data_length;
+extern int shmem_internal_heap_use_huge_pages;
+extern long shmem_internal_heap_huge_page_size;
 
 #ifdef USE_ON_NODE_COMMS
 extern char *shmem_internal_location_array;

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -28,6 +28,13 @@ extern int shmem_internal_initialized;
 extern int shmem_internal_finalized;
 extern int shmem_internal_thread_level;
 
+#define RAISE_WARN(ret)                                                 \
+    do {                                                                \
+        fprintf(stderr, "[%03d] ERROR: %s:%d return code %d\n",         \
+                shmem_internal_my_pe, __FILE__, __LINE__, (int) ret);   \
+    } while (0)
+
+
 #define RAISE_ERROR(ret)                                                \
     do {                                                                \
         fprintf(stderr, "[%03d] ERROR: %s:%d return code %d\n",         \
@@ -43,6 +50,12 @@ extern int shmem_internal_thread_level;
         shmem_runtime_abort(1, PACKAGE_NAME " exited in error");        \
     } while (0)
 
+
+#define RAISE_WARN_STR(str)                                             \
+    do {                                                                \
+        fprintf(stderr, "[%03d] ERROR: %s:%d: %s\n",                    \
+                shmem_internal_my_pe, __FILE__, __LINE__, str);         \
+    } while (0)
 
 #ifdef ENABLE_ERROR_CHECKING
 #define SHMEM_ERR_CHECK_INITIALIZED()                                   \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -30,7 +30,7 @@ extern int shmem_internal_thread_level;
 
 #define RAISE_WARN(ret)                                                 \
     do {                                                                \
-        fprintf(stderr, "[%03d] ERROR: %s:%d return code %d\n",         \
+        fprintf(stderr, "[%03d] WARN: %s:%d return code %d\n",         \
                 shmem_internal_my_pe, __FILE__, __LINE__, (int) ret);   \
     } while (0)
 
@@ -53,7 +53,7 @@ extern int shmem_internal_thread_level;
 
 #define RAISE_WARN_STR(str)                                             \
     do {                                                                \
-        fprintf(stderr, "[%03d] ERROR: %s:%d: %s\n",                    \
+        fprintf(stderr, "[%03d] WARN: %s:%d: %s\n",                    \
                 shmem_internal_my_pe, __FILE__, __LINE__, str);         \
     } while (0)
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1004,8 +1004,9 @@ static inline int query_for_fabric(struct fabric_info *info)
     domain_attr.mr_mode       = FI_MR_BASIC; /* VA space is pre-allocated */
 #endif
     domain_attr.threading     = FI_THREAD_ENDPOINT; /* we promise to serialize access
-						       to endpoints. we have only one
-						       thread active at a time */
+                                                       to endpoints. we have only one
+                                                       thread active at a time */
+
     hints.domain_attr         = &domain_attr;
     ep_attr.type              = FI_EP_RDM; /* reliable connectionless */
     hints.fabric_attr	      = &fabric_attr;
@@ -1033,6 +1034,8 @@ static inline int query_for_fabric(struct fabric_info *info)
         info->p_info = NULL;
 
         for (cur_fabric = info->fabrics; cur_fabric; cur_fabric = cur_fabric->next) {
+		fprintf(stderr,"cur_fabric->domain_attr->threading = %d\n",
+			cur_fabric->domain_attr->threading);
             if (info->fabric_name == NULL ||
                 fnmatch(info->fabric_name, cur_fabric->fabric_attr->name, 0) == 0) {
                 if (info->domain_name == NULL ||

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1034,8 +1034,6 @@ static inline int query_for_fabric(struct fabric_info *info)
         info->p_info = NULL;
 
         for (cur_fabric = info->fabrics; cur_fabric; cur_fabric = cur_fabric->next) {
-		fprintf(stderr,"cur_fabric->domain_attr->threading = %d\n",
-			cur_fabric->domain_attr->threading);
             if (info->fabric_name == NULL ||
                 fnmatch(info->fabric_name, cur_fabric->fabric_attr->name, 0) == 0) {
                 if (info->domain_name == NULL ||


### PR DESCRIPTION
With this commit, support is added to to SOS
for allowing the symmetric heap to be backed by
large pages on Linux.

This feature is not reliant on THP feature in Linux.

The use of default large page size (2MB) is triggered
by setting the

SMA_SYMMETRIC_HEAP_USE_HUGE_PAGES

environment variable.

For systems that support multiple large pages (such
as the synthetic large pages available on Cray systems),
there is an additional env. variable

SMA_SYMMETRIC_HEAP_PAGE_SIZE

It is aware of MB, GB, etc. syntax.  So, to use the
128MB large pages on Cray system the env. variable
would be set as

export SMA_SYMMETRIC_HEAP_PAGE_SIZE=128MB

@jdinan 
@kseager 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>