### PR TITLE
Only define complex API if complex type exists

### DIFF
--- a/mpp/pshmem.h
+++ b/mpp/pshmem.h
@@ -327,12 +327,14 @@ void pshmem_double_sum_to_all(double *target, const double *source, int nreduce,
 void pshmem_longdouble_sum_to_all(long double *target, const long double *source,
                                  int nreduce, int PE_start, int logPE_stride,
                                  int PE_size, long double *pWrk, long *pSync);
-void pshmem_complexf_sum_to_all(float complex *target, const float complex *source,
+#if SHMEM_HAVE_COMPLEX
+void pshmem_complexf_sum_to_all(float shmem_complex_t *target, const float shmem_complex_t *source,
                                int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, float complex *pWrk, long *pSync);
-void pshmem_complexd_sum_to_all(double complex *target, const double complex *source,
+                               int PE_size, float shmem_complex_t *pWrk, long *pSync);
+void pshmem_complexd_sum_to_all(double shmem_complex_t *target, const double shmem_complex_t *source,
                                int nreduce, int PE_start, int logPE_stride,
-                               int PE_size, double complex *pWrk, long *pSync);
+                               int PE_size, double shmem_complex_t *pWrk, long *pSync);
+#endif
 void pshmem_short_sum_to_all(short *target, const short *source, int nreduce,
                             int PE_start, int logPE_stride, int PE_size, 
                             short *pWrk, long *pSync);
@@ -355,13 +357,15 @@ void pshmem_double_prod_to_all(double *target, const double *source, int nreduce
 void pshmem_longdouble_prod_to_all(long double *target, const long double *source,
                                   int nreduce, int PE_start, int logPE_stride,
                                   int PE_size, long double *pWrk, long *pSync);
-void pshmem_complexf_prod_to_all(float complex *target, const float complex *source,
+#if SHMEM_HAVE_COMPLEX
+void pshmem_complexf_prod_to_all(float shmem_complex_t *target, const float shmem_complex_t *source,
                                 int nreduce, int PE_start, int logPE_stride,
-                                int PE_size, float complex *pWrk, long *pSync);
-void pshmem_complexd_prod_to_all(double complex *target, 
-                                const double complex *source, int nreduce,
+                                int PE_size, float shmem_complex_t *pWrk, long *pSync);
+void pshmem_complexd_prod_to_all(double shmem_complex_t *target,
+                                const double shmem_complex_t *source, int nreduce,
                                 int PE_start, int logPE_stride, int PE_size, 
-                                double complex *pWrk, long *pSync);
+                                double shmem_complex_t *pWrk, long *pSync);
+#endif
 void pshmem_short_prod_to_all(short *target, const short *source, int nreduce, 
                              int PE_start, int logPE_stride, int PE_size, 
                              short *pWrk, long *pSync);

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -17,9 +17,18 @@
 #define SHMEM_H
 
 #include <stddef.h>
-#include <complex.h>
+
 #ifdef __cplusplus
-#define complex _Complex
+#  define shmem_complex_t _Complex
+#  define SHMEM_HAVE_COMPLEX 1
+#else
+#  define shmem_complex_t complex
+#  ifdef complex
+#    define SHMEM_HAVE_COMPLEX 1
+#  endif
+#endif
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -114,8 +123,8 @@ void shmem_free(void *ptr);
   decl(longdouble, long double)
 
 #define SHMEM_EVAL_MACRO_FOR_CMPLX(decl,END) \
-  decl(complexf, float complex) END       \
-  decl(complexd, double complex)
+  decl(complexf, float shmem_complex_t) END       \
+  decl(complexd, double shmem_complex_t)
 
 #define SHMEM_EVAL_MACRO_FOR_SIZES(decl,END) \
   decl(8,    1*sizeof(uint8_t)) END       \
@@ -320,7 +329,9 @@ SHMEM_DECLARE_FOR_FLOATS(SHMEM_C_MAX_TO_ALL);
                                      long *pSync)
 SHMEM_DECLARE_FOR_INTS(SHMEM_C_C_SUM_TO_ALL);
 SHMEM_DECLARE_FOR_FLOATS(SHMEM_C_C_SUM_TO_ALL);
+#if SHMEM_HAVE_COMPLEX
 SHMEM_DECLARE_FOR_CMPLX(SHMEM_C_C_SUM_TO_ALL);
+#endif
 
 #define SHMEM_C_PROD_TO_ALL(TYPENAME,TYPE) \
   void shmem_##TYPENAME##_prod_to_all(TYPE *target, \
@@ -330,7 +341,9 @@ SHMEM_DECLARE_FOR_CMPLX(SHMEM_C_C_SUM_TO_ALL);
                                       long *pSync)
 SHMEM_DECLARE_FOR_INTS(SHMEM_C_PROD_TO_ALL);
 SHMEM_DECLARE_FOR_FLOATS(SHMEM_C_PROD_TO_ALL);
+#if SHMEM_HAVE_COMPLEX
 SHMEM_DECLARE_FOR_CMPLX(SHMEM_C_PROD_TO_ALL);
+#endif
 
 /* 8.5: Collect Routines */
 void shmem_collect32(void *target, const void *source, size_t nlong,
@@ -436,12 +449,10 @@ void start_pes(int npes) __attribute__ ((deprecated));
 #undef SHMEM_C_C_SUM_TO_ALL
 #undef SHMEM_C_PROD_TO_ALL
 
+
 /* C++ overloaded declarations */
 #ifdef __cplusplus
 } /* extern "C" */
-#ifdef complex
-#undef complex
-#endif
 
 /* Blocking block, scalar, and block-strided put */
 #define SHMEM_CXX_PUT(TYPENAME,TYPE) \
@@ -771,6 +782,9 @@ long shmem_swap(long *target, long value, int pe);
 #undef SHMEM_DEFINE_FOR_FLOATS
 #undef SHMEM_DEFINE_FOR_CMPLX
 #undef SHMEM_DEFINE_FOR_SIZES
+
+#undef shmem_complex_t
+#undef SHMEM_HAVE_COMPLEX
 
 #endif
 

--- a/mpp/shmem.h.in
+++ b/mpp/shmem.h.in
@@ -783,9 +783,6 @@ long shmem_swap(long *target, long value, int pe);
 #undef SHMEM_DEFINE_FOR_CMPLX
 #undef SHMEM_DEFINE_FOR_SIZES
 
-#undef shmem_complex_t
-#undef SHMEM_HAVE_COMPLEX
-
 #endif
 
 #endif /* SHMEM_H */

--- a/src/collectives_c.c
+++ b/src/collectives_c.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <strings.h>
 #include <string.h>
+#include <complex.h>
 
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"

--- a/src/shmem_internal_op.h
+++ b/src/shmem_internal_op.h
@@ -18,6 +18,7 @@
  */
 
 #include <stdint.h>
+#include <complex.h>
 #include "transport.h"
 
 #define FUNC_OP_CREATE(type_name, c_type, op_name, calc)                    \

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -11,6 +11,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <complex.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>


### PR DESCRIPTION
This eliminates the inclusion of complex.h in shmem.h, which caused
issued for some applications because it creates a conflict with
variables named 'I'.

Signed-off-by: James Dinan <james.dinan@intel.com>