### PR TITLE
Add support for SMA_DEBUG env var

### DIFF
--- a/README
+++ b/README
@@ -191,3 +191,6 @@ options.
     SMA_OFI_ATOMIC_CHECKS_WARN (default: off)
         If defined, OFI will not abort if fabric provider doesn't support every data
         type x op combination, instead it will print a warning.
+
+    SMA_DEBUG (default: off)
+        If defined enables debugging messages from OpenSHMEM runtime. 

--- a/src/init.c
+++ b/src/init.c
@@ -54,6 +54,7 @@ int shmem_internal_initialized_with_start_pes = 0;
 int shmem_internal_global_exit_called = 0;
 
 int shmem_internal_thread_level;
+int shmem_internal_debug = 0;
 
 #ifdef ENABLE_THREADS
 shmem_internal_mutex_t shmem_internal_mutex_alloc;
@@ -161,6 +162,7 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     heap_size = shmem_util_getenv_long("SYMMETRIC_SIZE", 1, 512 * 1024 * 1024);
     eager_size = shmem_util_getenv_long("BOUNCE_SIZE", 1, 2048);
     heap_use_malloc = shmem_util_getenv_long("SYMMETRIC_HEAP_USE_MALLOC", 0, 0);
+
     /* huge page support only on Linux for now, default is to use 2MB large pages */
 #ifdef __linux__
     if (heap_use_malloc == 0) {
@@ -172,6 +174,11 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     }
 #endif
 
+    shmem_internal_debug = (NULL != shmem_util_getenv_str("DEBUG")) ? 1 : 0;
+    if (shmem_internal_debug > 0){
+
+      DEBUG_STR("Debug info test\n");
+    }
 
     /* Find symmetric data */
 #ifdef __APPLE__
@@ -345,7 +352,8 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("SMA_CMA_PUT_MAX         %s\n", shmem_transport_cma_put_max);
             printf("SMA_CMA_GET_MAX         %s\n", shmem_transport_cma_get_max);
 #endif /* USE_CMA */
-
+            printf("SMA_DEBUG               %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
+            printf("\tValue for runtime debug information.\n");
             shmem_transport_print_info();
             printf("\n");
             fflush(NULL);

--- a/src/init.c
+++ b/src/init.c
@@ -162,6 +162,7 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     heap_size = shmem_util_getenv_long("SYMMETRIC_SIZE", 1, 512 * 1024 * 1024);
     eager_size = shmem_util_getenv_long("BOUNCE_SIZE", 1, 2048);
     heap_use_malloc = shmem_util_getenv_long("SYMMETRIC_HEAP_USE_MALLOC", 0, 0);
+    shmem_internal_debug = (NULL != shmem_util_getenv_str("DEBUG")) ? 1 : 0;
 
     /* huge page support only on Linux for now, default is to use 2MB large pages */
 #ifdef __linux__
@@ -173,12 +174,6 @@ shmem_internal_init(int tl_requested, int *tl_provided)
                                                                     2 * 1024 * 1024);
     }
 #endif
-
-    shmem_internal_debug = (NULL != shmem_util_getenv_str("DEBUG")) ? 1 : 0;
-    if (shmem_internal_debug > 0){
-
-      DEBUG_STR("Debug info test\n");
-    }
 
     /* Find symmetric data */
 #ifdef __APPLE__
@@ -353,7 +348,7 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("SMA_CMA_GET_MAX         %s\n", shmem_transport_cma_get_max);
 #endif /* USE_CMA */
             printf("SMA_DEBUG               %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
-            printf("\tValue for runtime debug information.\n");
+            printf("\tEnable debugging messages.\n");
 
             shmem_transport_print_info();
             printf("\n");

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -60,8 +60,10 @@ extern int shmem_internal_debug;
 
 #define DEBUG_STR(str)                                                  \
     do {                                                                \
-        fprintf(stderr, "[%03d] DEBUG: %s:%d: %s\n",                    \
-                shmem_internal_debug, __FILE__, __LINE__, str);         \
+        if(shmem_internal_debug) {                                      \
+            fprintf(stderr, "[%03d] DEBUG: %s:%d: %s\n",                \
+                    shmem_internal_my_pe, __FILE__, __LINE__, str);     \
+        }                                                               \
     } while(0)
 
 #ifdef ENABLE_ERROR_CHECKING

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -27,6 +27,7 @@ extern int shmem_internal_num_pes;
 extern int shmem_internal_initialized;
 extern int shmem_internal_finalized;
 extern int shmem_internal_thread_level;
+extern int shmem_internal_debug;
 
 #define RAISE_WARN(ret)                                                 \
     do {                                                                \
@@ -56,6 +57,12 @@ extern int shmem_internal_thread_level;
         fprintf(stderr, "[%03d] WARN: %s:%d: %s\n",                    \
                 shmem_internal_my_pe, __FILE__, __LINE__, str);         \
     } while (0)
+
+#define DEBUG_STR(str)                                                  \
+    do {                                                                \
+        fprintf(stderr, "[%03d] DEBUG: %s:%d: %s\n",                    \
+                shmem_internal_debug, __FILE__, __LINE__, str);         \
+    } while(0)
 
 #ifdef ENABLE_ERROR_CHECKING
 #define SHMEM_ERR_CHECK_INITIALIZED()                                   \


### PR DESCRIPTION
Added support for SMA_DEBUG environment variable & shmem_internal_debug
variable.  Also added change to README.

Closes #41

Signed-off-by: Richard North III <richard.north.iii@intel.com>