### PR TITLE
Check return code from asprintf

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -74,8 +74,12 @@ long
 shmem_util_getenv_long(const char* name, int is_sized, long default_value)
 {
     char *env_name, *env_value;
+    int ret;
 
-    asprintf(&env_name, "SMA_%s", name);
+    ret = asprintf(&env_name, "SMA_%s", name);
+    if (ret < 0) {
+        RAISE_ERROR(ret);
+    }
     env_value = getenv(env_name);
     free(env_name);
     if (env_value != NULL) {
@@ -86,7 +90,10 @@ shmem_util_getenv_long(const char* name, int is_sized, long default_value)
         }
     }
 
-    asprintf(&env_name, "SHMEM_%s", name);
+    ret = asprintf(&env_name, "SHMEM_%s", name);
+    if (ret < 0) {
+        RAISE_ERROR(ret);
+    }
     env_value = getenv(env_name);
     free(env_name);
     if (env_value != NULL) {


### PR DESCRIPTION
Quiets build warnings, "ignoring return value of ‘asprintf’, declared
with attribute warn_unused_result", and is generally a good idea.

Signed-off-by: James Dinan <james.dinan@intel.com>