### PR TITLE
Update shmemx_wtime

### DIFF
--- a/src/query_c.c
+++ b/src/query_c.c
@@ -14,6 +14,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <sys/time.h>
 
 #define SHMEM_INTERNAL_INCLUDE

--- a/src/query_c.c
+++ b/src/query_c.c
@@ -14,8 +14,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
-#include <sys/time.h>
 
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
@@ -82,20 +80,7 @@ shmem_my_pe(void)
 double
 shmemx_wtime(void)
 {
-    double wtime = 0.0;
-
     SHMEM_ERR_CHECK_INITIALIZED();
 
-#ifdef CLOCK_MONOTONIC
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_nsec / 1000000000.0;
-#else
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_usec / 1000000.0;
-#endif
-    return wtime;
+    return shmem_internal_wtime();
 }

--- a/src/query_f.c
+++ b/src/query_f.c
@@ -59,20 +59,7 @@ fortran_double_precision_t FC_SHMEMX_WTIME(void);
 fortran_double_precision_t
 FC_SHMEMX_WTIME(void)
 {
-    double wtime = 0.0;
-
     SHMEM_ERR_CHECK_INITIALIZED();
 
-#ifdef CLOCK_MONOTONIC
-    struct timespec tv;
-    clock_gettime(CLOCK_MONOTONIC, &tv);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_nsec / 1000000000.0;
-#else
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_usec / 1000000.0;
-#endif
-    return wtime;
+    return shmem_internal_wtime();
 }

--- a/src/query_f.c
+++ b/src/query_f.c
@@ -12,6 +12,7 @@
 
 #include "config.h"
 
+#include <time.h>
 #include <sys/time.h>
 
 #include "shmemx.h"
@@ -58,11 +59,20 @@ fortran_double_precision_t FC_SHMEMX_WTIME(void);
 fortran_double_precision_t
 FC_SHMEMX_WTIME(void)
 {
-     double wtime;
-     struct timeval tv;
+    double wtime = 0.0;
 
-     gettimeofday(&tv, NULL);
-     wtime = tv.tv_sec;
-     wtime += (double)tv.tv_usec / 1000000.0;
-     return wtime;
+    SHMEM_ERR_CHECK_INITIALIZED();
+
+#ifdef CLOCK_MONOTONIC
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_nsec / 1000000000.0;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_usec / 1000000.0;
+#endif
+    return wtime;
 }

--- a/src/query_f.c
+++ b/src/query_f.c
@@ -12,9 +12,6 @@
 
 #include "config.h"
 
-#include <time.h>
-#include <sys/time.h>
-
 #include "shmemx.h"
 #include "shmem_internal.h"
 

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <time.h>
+#include <sys/time.h>
 
 #include "shmemx.h"
 #include "runtime.h"
@@ -222,6 +224,23 @@ int shmem_internal_collectives_init(int requested_crossover,
 /* internal allocation, without a barrier */
 void *shmem_internal_shmalloc(size_t size);
 void* shmem_internal_get_next(intptr_t incr);
+
+static inline double shmem_internal_wtime(void) {
+    double wtime = 0.0;
+
+#ifdef CLOCK_MONOTONIC
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_nsec / 1.0e9;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_usec / 1.0e6;
+#endif
+    return wtime;
+}
 
 /* Utility functions */
 long shmem_util_getenv_long(const char* name, int is_sized, long default_value);


### PR DESCRIPTION
Add higher resolution timing to Fortran bindings and include time.h to
ensure clock_gettime will be used when available.

Signed-off-by: James Dinan <james.dinan@intel.com>