### PR TITLE
Add barrier to atexit handler

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -72,17 +72,16 @@ static char shmem_internal_my_hostname[HOST_NAME_MAX];
 
 
 static void
-shmem_internal_shutdown(int barrier_requested)
+shmem_internal_shutdown(void)
 {
     if (!shmem_internal_initialized ||
         shmem_internal_finalized) {
         return;
     }
+
+    shmem_internal_barrier_all();
+
     shmem_internal_finalized = 1;
-
-    if (barrier_requested)
-        shmem_internal_barrier_all();
-
     shmem_transport_fini();
 
 #ifdef USE_XPMEM
@@ -108,7 +107,7 @@ shmem_internal_shutdown_atexit(void)
         fprintf(stderr, "Warning: shutting down without a call to shmem_finalize()\n");
     }
 
-    shmem_internal_shutdown(0);
+    shmem_internal_shutdown();
 }
 
 
@@ -394,7 +393,7 @@ shmem_internal_nodename(void)
 
 void shmem_internal_finalize(void)
 {
-    shmem_internal_shutdown(1);
+    shmem_internal_shutdown();
 }
 
 


### PR DESCRIPTION
Necessary for compliance with OpenSHMEM v1.3 spec.