### PR TITLE
Clean up build warnings in perf suite

### DIFF
--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -196,7 +196,7 @@ void static command_line_arg_check(int argc, char *argv[],
                     "[-k (kilobytes/second)] [-b (bytes/second)] \n"\
                     "[-v (validate data stream)] \n");
         }
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
         shmem_finalize();
 #endif
         exit (-1);
@@ -208,7 +208,7 @@ void static inline only_even_PEs_check(int my_node, int num_pes) {
         if (my_node == 0) {
             fprintf(stderr, "can only use an even number of nodes\n");
         }
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
         shmem_finalize();
 #endif
         exit(77);
@@ -465,7 +465,7 @@ void static inline bw_init_data_stream(perf_metrics_t *metric_info,
     int i = 0;
 
     /*must be before data_init*/
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_init();
 #else
     start_pes(0);
@@ -509,7 +509,7 @@ void static inline bw_data_free(perf_metrics_t *metric_info) {
     aligned_buffer_free(metric_info->src);
     aligned_buffer_free(metric_info->dest);
 
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_finalize();
 #endif
 }

--- a/test/performance/shmem_perf_suite/common.h
+++ b/test/performance/shmem_perf_suite/common.h
@@ -54,7 +54,7 @@ static char * aligned_buffer_alloc(int len)
 
     alignment = getpagesize();
 
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     ptr1 = shmem_malloc(ptr_size + alignment + len);
 #else
     ptr1 = shmalloc(ptr_size + alignment + len);
@@ -88,7 +88,7 @@ static void aligned_buffer_free(char * ptr_aligned)
     memcpy(&temp_p, (ptr_aligned - ptr_size), ptr_size);
     ptr_org = (char *) temp_p;
 
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_free(ptr_org);
 #else
     shfree(ptr_org);

--- a/test/performance/shmem_perf_suite/latency_common.h
+++ b/test/performance/shmem_perf_suite/latency_common.h
@@ -100,7 +100,7 @@ void static inline command_line_arg_check(int argc, char *argv[],
                     "[-n trials (must be greater than 20)] "\
                     "[-v (validate results)]\n");
         }
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
         shmem_finalize();
 #endif
         exit (-1);
@@ -112,7 +112,7 @@ void static inline only_two_PEs_check(int my_node, int num_pes) {
         if (my_node == 0) {
             fprintf(stderr, "2-nodes only test\n");
         }
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
         shmem_finalize();
 #endif
         exit(77);
@@ -160,7 +160,7 @@ void static inline  multi_size_latency(perf_metrics_t data, char *argv[]) {
 
 void static inline latency_init_resources(int argc, char *argv[],
                                           perf_metrics_t *data) {
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_init();
 #else
     start_pes(0);
@@ -178,7 +178,7 @@ void static inline latency_init_resources(int argc, char *argv[],
     data->dest = aligned_buffer_alloc(data->max_len);
     init_array(data->dest, data->max_len, data->my_node);
 
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     data->target = shmem_malloc(sizeof(long));
 #else
     data->target = shmalloc(sizeof(long));
@@ -188,14 +188,14 @@ void static inline latency_init_resources(int argc, char *argv[],
 void static inline latency_free_resources(perf_metrics_t *data) {
     shmem_barrier_all();
 
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_free(data->target);
 #else
     shfree(data->target);
 #endif
     aligned_buffer_free(data->src);
     aligned_buffer_free(data->dest);
-#ifndef VERSION_1.0
+#ifndef VERSION_1_0
     shmem_finalize();
 #endif
 }


### PR DESCRIPTION
The C preprocessor doesn't allow "." characters in macro names.  Rename
VERSION_1.0 macro to VERSION_1_0.

Signed-off-by: James Dinan <james.dinan@intel.com>