### PR TITLE
Add support for trap-on-abort

### DIFF
--- a/README
+++ b/README
@@ -192,5 +192,11 @@ options.
         If defined, OFI will not abort if fabric provider doesn't support every data
         type x op combination, instead it will print a warning.
 
+  Debugging Environment variables:
+
     SMA_DEBUG (default: off)
         If defined enables debugging messages from OpenSHMEM runtime. 
+
+    SMA_TRAP_ON_ABORT (default: off)
+        If defined, generate a trap when aborting an OpenSHMEM program.  This
+        can be used to interface with a debugger or generate core files.

--- a/config/ax_gcc_builtin.m4
+++ b/config/ax_gcc_builtin.m4
@@ -1,0 +1,170 @@
+# ===========================================================================
+#      http://www.gnu.org/software/autoconf-archive/ax_gcc_builtin.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_GCC_BUILTIN(BUILTIN)
+#
+# DESCRIPTION
+#
+#   This macro checks if the compiler supports one of GCC's built-in
+#   functions; many other compilers also provide those same built-ins.
+#
+#   The BUILTIN parameter is the name of the built-in function.
+#
+#   If BUILTIN is supported define HAVE_<BUILTIN>. Keep in mind that since
+#   builtins usually start with two underscores they will be copied over
+#   into the HAVE_<BUILTIN> definition (e.g. HAVE___BUILTIN_EXPECT for
+#   __builtin_expect()).
+#
+#   The macro caches its result in the ax_cv_have_<BUILTIN> variable (e.g.
+#   ax_cv_have___builtin_expect).
+#
+#   The macro currently supports the following built-in functions:
+#
+#    __builtin_assume_aligned
+#    __builtin_bswap16
+#    __builtin_bswap32
+#    __builtin_bswap64
+#    __builtin_choose_expr
+#    __builtin___clear_cache
+#    __builtin_clrsb
+#    __builtin_clrsbl
+#    __builtin_clrsbll
+#    __builtin_clz
+#    __builtin_clzl
+#    __builtin_clzll
+#    __builtin_complex
+#    __builtin_constant_p
+#    __builtin_ctz
+#    __builtin_ctzl
+#    __builtin_ctzll
+#    __builtin_expect
+#    __builtin_ffs
+#    __builtin_ffsl
+#    __builtin_ffsll
+#    __builtin_fpclassify
+#    __builtin_huge_val
+#    __builtin_huge_valf
+#    __builtin_huge_vall
+#    __builtin_inf
+#    __builtin_infd128
+#    __builtin_infd32
+#    __builtin_infd64
+#    __builtin_inff
+#    __builtin_infl
+#    __builtin_isinf_sign
+#    __builtin_nan
+#    __builtin_nand128
+#    __builtin_nand32
+#    __builtin_nand64
+#    __builtin_nanf
+#    __builtin_nanl
+#    __builtin_nans
+#    __builtin_nansf
+#    __builtin_nansl
+#    __builtin_object_size
+#    __builtin_parity
+#    __builtin_parityl
+#    __builtin_parityll
+#    __builtin_popcount
+#    __builtin_popcountl
+#    __builtin_popcountll
+#    __builtin_powi
+#    __builtin_powif
+#    __builtin_powil
+#    __builtin_prefetch
+#    __builtin_trap
+#    __builtin_types_compatible_p
+#    __builtin_unreachable
+#
+#   Unsuppored built-ins will be tested with an empty parameter set and the
+#   result of the check might be wrong or meaningless so use with care.
+#
+# LICENSE
+#
+#   Copyright (c) 2013 Gabriele Svelto <gabriele.svelto@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 3
+
+AC_DEFUN([AX_GCC_BUILTIN], [
+    AS_VAR_PUSHDEF([ac_var], [ax_cv_have_$1])
+
+    AC_CACHE_CHECK([for $1], [ac_var], [
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
+            m4_case([$1],
+                [__builtin_assume_aligned], [$1("", 0)],
+                [__builtin_bswap16], [$1(0)],
+                [__builtin_bswap32], [$1(0)],
+                [__builtin_bswap64], [$1(0)],
+                [__builtin_choose_expr], [$1(0, 0, 0)],
+                [__builtin___clear_cache], [$1("", "")],
+                [__builtin_clrsb], [$1(0)],
+                [__builtin_clrsbl], [$1(0)],
+                [__builtin_clrsbll], [$1(0)],
+                [__builtin_clz], [$1(0)],
+                [__builtin_clzl], [$1(0)],
+                [__builtin_clzll], [$1(0)],
+                [__builtin_complex], [$1(0.0, 0.0)],
+                [__builtin_constant_p], [$1(0)],
+                [__builtin_ctz], [$1(0)],
+                [__builtin_ctzl], [$1(0)],
+                [__builtin_ctzll], [$1(0)],
+                [__builtin_expect], [$1(0, 0)],
+                [__builtin_ffs], [$1(0)],
+                [__builtin_ffsl], [$1(0)],
+                [__builtin_ffsll], [$1(0)],
+                [__builtin_fpclassify], [$1(0, 1, 2, 3, 4, 0.0)],
+                [__builtin_huge_val], [$1()],
+                [__builtin_huge_valf], [$1()],
+                [__builtin_huge_vall], [$1()],
+                [__builtin_inf], [$1()],
+                [__builtin_infd128], [$1()],
+                [__builtin_infd32], [$1()],
+                [__builtin_infd64], [$1()],
+                [__builtin_inff], [$1()],
+                [__builtin_infl], [$1()],
+                [__builtin_isinf_sign], [$1(0.0)],
+                [__builtin_nan], [$1("")],
+                [__builtin_nand128], [$1("")],
+                [__builtin_nand32], [$1("")],
+                [__builtin_nand64], [$1("")],
+                [__builtin_nanf], [$1("")],
+                [__builtin_nanl], [$1("")],
+                [__builtin_nans], [$1("")],
+                [__builtin_nansf], [$1("")],
+                [__builtin_nansl], [$1("")],
+                [__builtin_object_size], [$1("", 0)],
+                [__builtin_parity], [$1(0)],
+                [__builtin_parityl], [$1(0)],
+                [__builtin_parityll], [$1(0)],
+                [__builtin_popcount], [$1(0)],
+                [__builtin_popcountl], [$1(0)],
+                [__builtin_popcountll], [$1(0)],
+                [__builtin_powi], [$1(0, 0)],
+                [__builtin_powif], [$1(0, 0)],
+                [__builtin_powil], [$1(0, 0)],
+                [__builtin_prefetch], [$1("")],
+                [__builtin_trap], [$1()],
+                [__builtin_types_compatible_p], [$1(int, int)],
+                [__builtin_unreachable], [$1()],
+                [m4_warn([syntax], [Unsupported built-in $1, the test may fail])
+                 $1()]
+            )
+            ])],
+            [AS_VAR_SET([ac_var], [yes])],
+            [AS_VAR_SET([ac_var], [no])])
+    ])
+
+    AS_IF([test yes = AS_VAR_GET([ac_var])],
+        [AC_DEFINE_UNQUOTED(AS_TR_CPP(HAVE_$1), 1,
+            [Define to 1 if the system has the `$1' built-in function])], [])
+
+    AS_VAR_POPDEF([ac_var])
+])

--- a/configure.ac
+++ b/configure.ac
@@ -164,6 +164,7 @@ if test "$FC" != "" ; then
 fi
 
 AX_GCC_FUNC_ATTRIBUTE([noreturn])
+AX_GCC_BUILTIN([__builtin_trap])
 
 if test "$enable_picky" = "yes" -a "$GCC" = "yes" ; then
   CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic"

--- a/src/init.c
+++ b/src/init.c
@@ -344,9 +344,9 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("\tAlgorithm for collect.  Options are auto, linear\n");
             printf("SMA_FCOLLECT_ALGORITHM  %s\n", coll_type_str[shmem_internal_fcollect_type]);
             printf("\tAlgorithm for fcollect.  Options are auto, linear, ring, recdbl\n");
-            printf("SMA_DEBUG               %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
+            printf("SMA_DEBUG               %s\n", shmem_internal_debug ? "On" : "Off");
             printf("\tEnable debugging messages\n");
-            printf("SMA_TRAP_ON_ABORT       %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
+            printf("SMA_TRAP_ON_ABORT       %s\n", shmem_internal_trap_on_abort ? "On" : "Off");
             printf("\tGenerate trap if the program aborts or calls shmem_global_exit\n");
 #ifdef USE_CMA
             printf("SMA_CMA_PUT_MAX         %zu\n", shmem_transport_cma_put_max);

--- a/src/init.c
+++ b/src/init.c
@@ -55,6 +55,7 @@ int shmem_internal_global_exit_called = 0;
 
 int shmem_internal_thread_level;
 int shmem_internal_debug = 0;
+int shmem_internal_trap_on_abort = 0;
 
 #ifdef ENABLE_THREADS
 shmem_internal_mutex_t shmem_internal_mutex_alloc;
@@ -162,6 +163,7 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     eager_size = shmem_util_getenv_long("BOUNCE_SIZE", 1, 2048);
     heap_use_malloc = shmem_util_getenv_long("SYMMETRIC_HEAP_USE_MALLOC", 0, 0);
     shmem_internal_debug = (NULL != shmem_util_getenv_str("DEBUG")) ? 1 : 0;
+    shmem_internal_trap_on_abort = (NULL != shmem_util_getenv_str("TRAP_ON_ABORT")) ? 1 : 0;
 
     /* huge page support only on Linux for now, default is to use 2MB large pages */
 #ifdef __linux__
@@ -342,12 +344,14 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("\tAlgorithm for collect.  Options are auto, linear\n");
             printf("SMA_FCOLLECT_ALGORITHM  %s\n", coll_type_str[shmem_internal_fcollect_type]);
             printf("\tAlgorithm for fcollect.  Options are auto, linear, ring, recdbl\n");
+            printf("SMA_DEBUG               %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
+            printf("\tEnable debugging messages\n");
+            printf("SMA_TRAP_ON_ABORT       %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
+            printf("\tGenerate trap if the program aborts or calls shmem_global_exit\n");
 #ifdef USE_CMA
             printf("SMA_CMA_PUT_MAX         %zu\n", shmem_transport_cma_put_max);
             printf("SMA_CMA_GET_MAX         %zu\n", shmem_transport_cma_get_max);
 #endif /* USE_CMA */
-            printf("SMA_DEBUG               %s\n", (NULL != shmem_util_getenv_str("DEBUG")) ? "On" : "Off");
-            printf("\tEnable debugging messages.\n");
 
             shmem_transport_print_info();
             printf("\n");

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -151,7 +151,7 @@ shmem_runtime_abort(int exit_code, const char msg[])
 {
 
 #ifdef HAVE___BUILTIN_TRAP
-    if (shmem_util_getenv_str("TRAP_ON_ABORT") != NULL)
+    if (shmem_internal_trap_on_abort)
         __builtin_trap();
 #endif
 

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -29,6 +29,7 @@
 #endif
 
 #include "runtime.h"
+#include "shmem_internal.h"
 
 static int rank = -1;
 static int size = 0;
@@ -148,6 +149,12 @@ shmem_runtime_fini(void)
 void
 shmem_runtime_abort(int exit_code, const char msg[])
 {
+
+#ifdef HAVE___BUILTIN_TRAP
+    if (shmem_util_getenv_str("TRAP_ON_ABORT") != NULL)
+        __builtin_trap();
+#endif
+
     PMI_Abort(exit_code, msg);
 
     /* PMI_Abort should not return */

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -139,6 +139,12 @@ shmem_runtime_fini(void)
 void
 shmem_runtime_abort(int exit_code, const char msg[])
 {
+
+#ifdef HAVE___BUILTIN_TRAP
+    if (shmem_util_getenv_str("TRAP_ON_ABORT") != NULL)
+        __builtin_trap();
+#endif
+
     PMI2_Abort(exit_code, msg);
 
     /* PMI_Abort should not return */

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -141,7 +141,7 @@ shmem_runtime_abort(int exit_code, const char msg[])
 {
 
 #ifdef HAVE___BUILTIN_TRAP
-    if (shmem_util_getenv_str("TRAP_ON_ABORT") != NULL)
+    if (shmem_internal_trap_on_abort)
         __builtin_trap();
 #endif
 

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -33,6 +33,7 @@ extern int shmem_internal_initialized;
 extern int shmem_internal_finalized;
 extern int shmem_internal_thread_level;
 extern int shmem_internal_debug;
+extern int shmem_internal_trap_on_abort;
 
 extern void *shmem_internal_heap_base;
 extern long shmem_internal_heap_length;


### PR DESCRIPTION
Define SHMEM_TRAP_ON_ABORT and the abort routine will call the
__builtin_trap() GCC intrinsic.  Useful for generating core files and
interfacing with debuggers.

Signed-off-by: James Dinan <james.dinan@intel.com>