### PR TITLE
Remove AC_PROG_CC_C99 from configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ fi
 AX_GCC_FUNC_ATTRIBUTE([noreturn])
 
 if test "$enable_picky" = "yes" -a "$GCC" = "yes" ; then
-  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic"
+  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -std=c99"
 else
   CFLAGS="$CFLAGS -Wall"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ AX_GCC_FUNC_ATTRIBUTE([noreturn])
 AX_GCC_BUILTIN([__builtin_trap])
 
 if test "$enable_picky" = "yes" -a "$GCC" = "yes" ; then
-  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -std=c99"
+  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -std=gnu99"
 else
   CFLAGS="$CFLAGS -Wall"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,6 @@ dnl check for programs
 
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
 AC_C_INLINE
 AC_PROG_CXX dnl required even with --disable-cxx due to automake conditionals
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])


### PR DESCRIPTION
Doesn't seem to be necessary to force -std=c99.