### PR TITLE
Use -std=gnu11 when available, gnu99 otherwise

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,51 +159,33 @@ AC_PROG_CXX dnl required even with --disable-cxx due to automake conditionals
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
 AC_PATH_PROG([PERL],[perl])
 
-# start -std check
+# start gnu11/gnu99 check
 ORIG_CFLAGS=$CFLAGS
+WRAPPER_CC=$CC
+AC_SUBST(WRAPPER_CC)
 
-AC_CACHE_CHECK([if -std=gnu11 works], [shmem_cv_c11_works],
-               [AC_LANG_PUSH([C])
-                CFLAGS="-pedantic-errors -std=gnu11"
-                AC_COMPILE_IFELSE(
-                  [AC_LANG_PROGRAM([[
+AC_MSG_CHECKING([if -std=gnu11 works])
+
+AC_LANG_PUSH([C])
+CFLAGS="-pedantic-errors -std=gnu11"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
                    void g(int i){}
                    #define f(X) _Generic((X), default: g)(X)
                    ]], [[
-                   f(1);
-                   ]]
-                  )],
-                  [shmem_cv_c11_works="yes"], [shmem_cv_c11_works="no"])
-               ])
+                        f(1);
+                        ]]
+                   )],
+                   [shmem_cv_c11_works="yes"], [shmem_cv_c11_works="no"])
 AS_IF([test "$shmem_cv_c11_works" = "no"],
-      [AC_MSG_WARN([C program does not compile with -std=gnu11.])])
-
-if test "$shmem_cv_c11_works" = "no" ; then
-  AC_CACHE_CHECK([if -std=gnu99 works], [shmem_cv_c99_works],
-                 [AC_LANG_PUSH([C])
-                  CFLAGS="-pedantic-errors -std=gnu99"
-                  AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,
-                    [[
-                      for(int i=0; i<2; i++){}
-                    ]])],
-                    [shmem_cv_c99_works="yes"], [shmem_cv_c99_works="no"])
-                 ])
-  AS_IF([test "$shmem_cv_c99_works" = "no"],
-        [AC_MSG_WARN([C program does not compile with -std=gnu99.])])
-fi
-
-if test "$shmem_cv_c11_works" = "yes" ; then
-  CFLAGS="-std=gnu11 $ORIG_CFLAGS "
-else
-  AC_MSG_WARN([C flag -std=gnu11 not supported.])
-  if test "$shmem_cv_c99_works" = "yes" ; then
-    CFLAGS="-std=gnu99 $ORIG_CFLAGS "
-  else
-    CFLAGS="$ORIG_CFLAGS"
-    AC_MSG_WARN([A compiler that supports either -std=gnu11 or -std=gnu99 is required.])
-  fi
-fi
-# end -std check
+      [AC_MSG_RESULT([no])
+      AC_MSG_WARN([No C11 support detected, unable to test _Generic bindings.])
+      CFLAGS="-std=gnu99 $ORIG_CFLAGS"
+      ],
+      [AC_MSG_RESULT([yes])
+      CFLAGS="-std=gnu11 $ORIG_CFLAGS"]
+      )
+AC_LANG_POP([C])
+# end gnu11/gnu99 check
 
 
 AC_PATH_PROG([M4], [m4], [false])

--- a/configure.ac
+++ b/configure.ac
@@ -161,9 +161,8 @@ AC_PATH_PROG([PERL],[perl])
 
 # start gnu11/gnu99 check
 ORIG_CFLAGS=$CFLAGS
-WRAPPER_CC=$CC
-AC_SUBST(WRAPPER_CC)
-
+WRAPPER_COMPILER_CC=$CC
+AC_SUBST([WRAPPER_COMPILER_CC])
 AC_MSG_CHECKING([if -std=gnu11 works])
 
 AC_LANG_PUSH([C])
@@ -179,7 +178,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 AS_IF([test "$shmem_cv_c11_works" = "no"],
       [AC_MSG_RESULT([no])
       AC_MSG_WARN([No C11 support detected, unable to test _Generic bindings.])
-      CFLAGS="-std=gnu99 $ORIG_CFLAGS"
+      CFLAGS="$ORIG_CFLAGS"
+      AC_PROG_CC_C99
       ],
       [AC_MSG_RESULT([yes])
       CFLAGS="-std=gnu11 $ORIG_CFLAGS"]

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,53 @@ AC_PROG_CXX dnl required even with --disable-cxx due to automake conditionals
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
 AC_PATH_PROG([PERL],[perl])
 
+# start -std check
+ORIG_CFLAGS=$CFLAGS
+
+AC_CACHE_CHECK([if -std=gnu11 works], [shmem_cv_c11_works],
+               [AC_LANG_PUSH([C])
+                CFLAGS="-pedantic-errors -std=gnu11"
+                AC_COMPILE_IFELSE(
+                  [AC_LANG_PROGRAM([[
+                   void g(int i){}
+                   #define f(X) _Generic((X), default: g)(X)
+                   ]], [[
+                   f(1);
+                   ]]
+                  )],
+                  [shmem_cv_c11_works="yes"], [shmem_cv_c11_works="no"])
+               ])
+AS_IF([test "$shmem_cv_c11_works" = "no"],
+      [AC_MSG_WARN([C program does not compile with -std=gnu11.])])
+
+if test "$shmem_cv_c11_works" = "no" ; then
+  AC_CACHE_CHECK([if -std=gnu99 works], [shmem_cv_c99_works],
+                 [AC_LANG_PUSH([C])
+                  CFLAGS="-pedantic-errors -std=gnu99"
+                  AC_COMPILE_IFELSE([AC_LANG_PROGRAM(,
+                    [[
+                      for(int i=0; i<2; i++){}
+                    ]])],
+                    [shmem_cv_c99_works="yes"], [shmem_cv_c99_works="no"])
+                 ])
+  AS_IF([test "$shmem_cv_c99_works" = "no"],
+        [AC_MSG_WARN([C program does not compile with -std=gnu99.])])
+fi
+
+if test "$shmem_cv_c11_works" = "yes" ; then
+  CFLAGS="-std=gnu11 $ORIG_CFLAGS "
+else
+  AC_MSG_WARN([C flag -std=gnu11 not supported.])
+  if test "$shmem_cv_c99_works" = "yes" ; then
+    CFLAGS="-std=gnu99 $ORIG_CFLAGS "
+  else
+    CFLAGS="$ORIG_CFLAGS"
+    AC_MSG_WARN([A compiler that supports either -std=gnu11 or -std=gnu99 is required.])
+  fi
+fi
+# end -std check
+
+
 AC_PATH_PROG([M4], [m4], [false])
 AS_IF([test "$M4" = "false"],
       [AC_MSG_ERROR([Could not find 'm4' macro processor])])
@@ -176,7 +223,7 @@ AX_GCC_FUNC_ATTRIBUTE([noreturn])
 AX_GCC_BUILTIN([__builtin_trap])
 
 if test "$enable_picky" = "yes" -a "$GCC" = "yes" ; then
-  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -std=gnu99"
+  CFLAGS="$CFLAGS -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic"
 else
   CFLAGS="$CFLAGS -Wall"
 fi

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,7 +130,7 @@ EXTRA_DIST = shmem_compiler_script.in \
              shmem_launcher_script.in
 
 do_subst = sed -e 's|[@]PERL[@]|$(PERL)|g' \
-               -e 's|[@]CC[@]|$(CC)|g' \
+               -e 's|[@]WRAPPER_COMPILER_CC[@]|$(CC)|g' \
                -e 's|[@]CXX[@]|$(CXX)|g' \
                -e 's|[@]FC[@]|$(FC)|g' \
                -e 's|[@]WRAPPER_COMPILER_INCLUDEDIR[@]|$(includedir)|g' \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,7 +130,7 @@ EXTRA_DIST = shmem_compiler_script.in \
              shmem_launcher_script.in
 
 do_subst = sed -e 's|[@]PERL[@]|$(PERL)|g' \
-               -e 's|[@]WRAPPER_COMPILER_CC[@]|$(CC)|g' \
+               -e 's|[@]WRAPPER_COMPILER_CC[@]|$(WRAPPER_COMPILER_CC)|g' \
                -e 's|[@]CXX[@]|$(CXX)|g' \
                -e 's|[@]FC[@]|$(FC)|g' \
                -e 's|[@]WRAPPER_COMPILER_INCLUDEDIR[@]|$(includedir)|g' \

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -107,7 +107,7 @@ my $includedir = "@WRAPPER_COMPILER_INCLUDEDIR@";
 my $libdir = "@WRAPPER_COMPILER_LIBDIR@";
 
 my $lang = "@LANG@";
-my $CC = "@CC@";
+my $CC = "@WRAPPER_CC@";
 my $CXX = "@CXX@";
 my $FC = "@FC@";
 my $extra_ldflags = "@WRAPPER_COMPILER_EXTRA_LDFLAGS@";

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -107,7 +107,7 @@ my $includedir = "@WRAPPER_COMPILER_INCLUDEDIR@";
 my $libdir = "@WRAPPER_COMPILER_LIBDIR@";
 
 my $lang = "@LANG@";
-my $CC = "@WRAPPER_CC@";
+my $CC = "@WRAPPER_COMPILER_CC@";
 my $CXX = "@CXX@";
 my $FC = "@FC@";
 my $extra_ldflags = "@WRAPPER_COMPILER_EXTRA_LDFLAGS@";


### PR DESCRIPTION
Addresses #309 & #310 by compile-checking for gnu11/gnu99 support and setting -std in CFLAGS instead of CC.