### PR TITLE
Move/add barriers in shmem_free and shmem_realloc

### DIFF
--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -293,11 +293,11 @@ shmem_free(void *ptr)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
 
+    shmem_internal_barrier_all();
+
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     dlfree(ptr);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
-
-    shmem_internal_barrier_all();
 }
 
 
@@ -307,6 +307,8 @@ shmem_realloc(void *ptr, size_t size)
     void *ret;
 
     SHMEM_ERR_CHECK_INITIALIZED();
+
+    shmem_internal_barrier_all();
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     ret = dlrealloc(ptr, size);

--- a/src/symmetric_heap_f.c
+++ b/src/symmetric_heap_f.c
@@ -79,12 +79,12 @@ FC_SHPDEALLOC(void **addr, fortran_integer_t *errcode, fortran_integer_t *want_a
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC_HEAP(*addr);
 
+    shmem_internal_barrier_all();
+
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     dlfree(*addr);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
     *errcode = 0;
-
-    shmem_internal_barrier_all();
 }
 
 
@@ -108,6 +108,8 @@ FC_SHPCLMOVE(void **addr, fortran_integer_t *length, fortran_integer_t *errcode,
             return;
         }
     }
+
+    shmem_internal_barrier_all();
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     ret = dlrealloc(*addr, *length * 4); /* length is number of 32 bit words */


### PR DESCRIPTION
Moving the exit barrier call in shmem_free to the entry eliminates a nasty race condition.  Similarly, shmem_realloc needs a barrier at entry.