### PR TITLE
Improve debugging messages for OFI

### DIFF
--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -74,18 +74,28 @@ extern long shmem_internal_heap_huge_page_size;
 
 #define RAISE_ERROR_MSG(...)                                            \
     do {                                                                \
-        fprintf(stderr, "[%03d] ERROR: %s:%d:\n",                       \
-                shmem_internal_my_pe, __FILE__, __LINE__);              \
-        fprintf(stderr, __VA_ARGS__);                                   \
+        char str[256];                                                  \
+        size_t off;                                                     \
+        off = snprintf(str, sizeof(str), "[%03d] ERROR: %s:%d:\n",      \
+                       shmem_internal_my_pe, __FILE__, __LINE__);       \
+        off+= snprintf(str+off, sizeof(str)-off, "[%03d]        ",      \
+                       shmem_internal_my_pe);                           \
+        off+= snprintf(str+off, sizeof(str)-off, __VA_ARGS__);          \
+        fprintf(stderr, "%s", str);                                     \
         shmem_runtime_abort(1, PACKAGE_NAME " exited in error");        \
     } while (0)
 
 
 #define RAISE_WARN_MSG(...)                                             \
     do {                                                                \
-        fprintf(stderr, "[%03d] WARN: %s:%d:\n",                        \
-                shmem_internal_my_pe, __FILE__, __LINE__);              \
-        fprintf(stderr, __VA_ARGS__);                                   \
+        char str[256];                                                  \
+        size_t off;                                                     \
+        off = snprintf(str, sizeof(str), "[%03d] WARN: %s:%d:\n",       \
+                       shmem_internal_my_pe, __FILE__, __LINE__);       \
+        off+= snprintf(str+off, sizeof(str)-off, "[%03d]       ",       \
+                       shmem_internal_my_pe);                           \
+        off+= snprintf(str+off, sizeof(str)-off, __VA_ARGS__);          \
+        fprintf(stderr, "%s", str);                                     \
     } while (0)
 
 
@@ -94,6 +104,20 @@ extern long shmem_internal_heap_huge_page_size;
         if(shmem_internal_debug) {                                      \
             fprintf(stderr, "[%03d] DEBUG: %s:%d: %s\n",                \
                     shmem_internal_my_pe, __FILE__, __LINE__, str);     \
+        }                                                               \
+    } while(0)
+
+#define DEBUG_MSG(...)                                                  \
+    do {                                                                \
+        if(shmem_internal_debug) {                                      \
+            char str[256];                                              \
+            size_t off;                                                 \
+            off = snprintf(str, sizeof(str), "[%03d] DEBUG: %s:%d:\n",  \
+                           shmem_internal_my_pe, __FILE__, __LINE__);   \
+            off+= snprintf(str+off, sizeof(str)-off, "[%03d]        ",  \
+                           shmem_internal_my_pe);                       \
+            off+= snprintf(str+off, sizeof(str)-off, __VA_ARGS__);      \
+            fprintf(stderr, "%s", str);                                 \
         }                                                               \
     } while(0)
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1053,8 +1053,11 @@ static inline int query_for_fabric(struct fabric_info *info)
     shmem_internal_assertp(info->p_info->tx_attr->inject_size >= shmem_transport_ofi_max_buffered_send);
     shmem_transport_ofi_max_buffered_send = info->p_info->tx_attr->inject_size;
 
-    return ret;
+    DEBUG_MSG("OFI provider: %s, fabric: %s, domain: %s\n",
+              info->p_info->fabric_attr->prov_name,
+              info->p_info->fabric_attr->name, info->p_info->domain_attr->name);
 
+    return ret;
 }
 
 int shmem_transport_init(long eager_size)


### PR DESCRIPTION
Example output:
```
$ SHMEM_DEBUG=1 mpiexec -np 4 test/unit/hello
[002] DEBUG: ../../src/transport_ofi.c:1058:
[002]        OFI provider: sockets, fabric: 127.0.0.0/8, domain: lo0
[000] DEBUG: ../../src/transport_ofi.c:1058:
[000]        OFI provider: sockets, fabric: 127.0.0.0/8, domain: lo0
[001] DEBUG: ../../src/transport_ofi.c:1058:
[001]        OFI provider: sockets, fabric: 127.0.0.0/8, domain: lo0
[003] DEBUG: ../../src/transport_ofi.c:1058:
[003]        OFI provider: sockets, fabric: 127.0.0.0/8, domain: lo0
Hello World from 0 of 4
Hello World from 1 of 4
Hello World from 2 of 4
Hello World from 3 of 4
```