### PR TITLE
Improve out of memory error message

### DIFF
--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #ifdef __linux__
 #include <mntent.h>
 #include <sys/vfs.h>
@@ -131,8 +132,10 @@ shmem_internal_get_next(intptr_t incr)
         shmem_internal_heap_curr = (char*) shmem_internal_heap_base;
     } else if (shmem_internal_heap_curr - (char*) shmem_internal_heap_base >
                shmem_internal_heap_length) {
-        fprintf(stderr, "[%03d] WARNING: top of symmetric heap found\n",
-                shmem_internal_my_pe);
+        fprintf(stderr, "[%03d] WARNING: Out of symmetric memory, heap size %ld, overrun %"PRIdPTR"\n"
+                        "[%03d]          Try increasing SHMEM_SYMMETRIC_SIZE\n",
+                        shmem_internal_my_pe, shmem_internal_heap_length, incr,
+                        shmem_internal_my_pe);
         shmem_internal_heap_curr = orig;
         orig = (void*) -1;
     }

--- a/test/unit/shmalloc.c
+++ b/test/unit/shmalloc.c
@@ -60,6 +60,7 @@ usage (void)
             "  [loops]  # of loops\n"
             "  [incWords] nWords += incWords per loop\n");
     }
+    shmem_finalize();
     exit (1);
 }
 
@@ -164,6 +165,7 @@ main(int argc, char **argv)
         if (! result)
         {
             perror ("Failed result memory allocation");
+            shmem_finalize();
             exit (1);
         }
         for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
@@ -174,6 +176,7 @@ main(int argc, char **argv)
         if (!(target = (DataType *)shmem_malloc(target_sz)))
         {
             perror ("Failed target memory allocation");
+            shmem_finalize();
             exit (1);
         }
         for(dp=target; dp < &target[(target_sz / sizeof(DataType))];)
@@ -183,6 +186,7 @@ main(int argc, char **argv)
         if (!(source = (DataType *)shmem_malloc(source_sz)))
         {
             perror ("Failed source memory allocation");
+            shmem_finalize();
             exit (1);
         }
         for(dp=source; dp < &source[(source_sz / sizeof(DataType))];)


### PR DESCRIPTION
Example output:
```
$ SHMEM_SYMMETRIC_SIZE=1 mpiexec -np 2 test/unit/shmalloc
[000] WARNING: Out of symmetric memory, heap size 1048577, overrun 32768
[000]          Try increasing SHMEM_SYMMETRIC_SIZE
[000] WARNING: Out of symmetric memory, heap size 1048577, overrun 528384
[000]          Try increasing SHMEM_SYMMETRIC_SIZE
[001] WARNING: Out of symmetric memory, heap size 1048577, overrun 32768
[001]          Try increasing SHMEM_SYMMETRIC_SIZE
[001] WARNING: Out of symmetric memory, heap size 1048577, overrun 528384
[001]          Try increasing SHMEM_SYMMETRIC_SIZE
Failed source memory allocation: Cannot allocate memory
Failed source memory allocation: Cannot allocate memory
```
Closes #104 