### PR TITLE
Add Cray test suite to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,6 +98,9 @@ before_install:
     ## Fetch UH Tests
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/openshmem-org/tests-uh.git tests-uh
+    # Fetch Cray Tests
+    - cd $TRAVIS_SRC
+    - git clone -b openshmem --depth 10 https://github.com/davidozog/tests-cray.git tests-cray
     ## Fetch ISx
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/ISx.git ISx
@@ -216,6 +219,14 @@ script:
           fi;
       fi
     - make clean
+    ###
+    ### Run the Cray test suite (OFI)
+    ###
+    - export CUSTOM_SHMEM_DIR=$TRAVIS_INSTALL/sandia-shmem-ofi
+    - export PATH=$CUSTOM_SHMEM_DIR/bin:$TRAVIS_INSTALL/hydra/bin:$BASE_PATH
+    - export CRAY_TESTS_DIR=$TRAVIS_SRC/tests-cray
+    - $SOS_SRC/scripts/cray_tests.sh
+
     ###
     ### Run ISx (Portals)
     ###

--- a/scripts/cray_tests.sh
+++ b/scripts/cray_tests.sh
@@ -6,14 +6,14 @@ export CC=oshcc
 export CXX=oshCC
 export FTN=oshfort
 export LAUNCHER=oshrun
-export CFLAGS="-DOPENSHMEM"
-export FFLAGS="-DOPENSHMEM -DOPENSHMEM_FORT_SHORT_HEADER -fcray-pointer"
+export CFLAGS="-DQUICK_TEST -DOPENSHMEM"
+export FFLAGS="-DQUICK_TEST -DOPENSHMEM -DOPENSHMEM_FORT_SHORT_HEADER -fcray-pointer"
 export NPES=4
 
 cd $CRAY_TESTS_DIR
 source configure.sh
-make sma1 MAKE_FLAGS=$TRAVIS_PAR_MAKE 
-make sma2 MAKE_FLAGS=$TRAVIS_PAR_MAKE 
+make sma1 MAKE_FLAGS="$TRAVIS_PAR_MAKE"
+make sma2 MAKE_FLAGS="$TRAVIS_PAR_MAKE"
 source $CRAY_TESTS_DIR/sma1/sma1_run 2>&1 | tee cray-tests-sma1.log
 source $CRAY_TESTS_DIR/sma2/sma2_run 2>&1 | tee cray-tests-sma2.log
 
@@ -24,7 +24,7 @@ tests_failed=0
 if grep "FAIL" cray-tests-sma1.log; then ((tests_failed+=1)); fi
 if grep "FAIL" cray-tests-sma2.log; then ((tests_failed+=1)); fi
 if [ ! $SOS_DISABLE_FORTRAN ]; then
-    make smaf MAKE_FLAGS=$TRAVIS_PAR_MAKE
+    make smaf MAKE_FLAGS="$TRAVIS_PAR_MAKE"
     if [ $? -eq 0 ]; then
         source $CRAY_TESTS_DIR/smaf/smaf_run 2>&1 | tee cray-tests-smaf.log;
         # Check for failures in the Fortran tests

--- a/scripts/cray_tests.sh
+++ b/scripts/cray_tests.sh
@@ -9,6 +9,7 @@ export LAUNCHER=oshrun
 export CFLAGS="-DQUICK_TEST -DOPENSHMEM"
 export FFLAGS="-DQUICK_TEST -DOPENSHMEM -DOPENSHMEM_FORT_SHORT_HEADER -fcray-pointer"
 export NPES=4
+export CRAY_PRINT_IF_FAIL=1
 
 cd $CRAY_TESTS_DIR
 source configure.sh

--- a/scripts/cray_tests.sh
+++ b/scripts/cray_tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#export CUSTOM_SHMEM_DIR="<SOS_INSTALL_DIRECTORY>"
+#export CRAY_TESTS_DIR="<CRAY_TESTS_SRC_DIRECTORY"
+export CC=oshcc
+export CXX=oshCC
+export FTN=oshfort
+export LAUNCHER=oshrun
+export CFLAGS="-DOPENSHMEM"
+export FFLAGS="-DOPENSHMEM -DOPENSHMEM_FORT_SHORT_HEADER -fcray-pointer"
+export NPES=4
+
+cd $CRAY_TESTS_DIR
+source configure.sh
+make $TRAVIS_PAR_MAKE sma1
+make $TRAVIS_PAR_MAKE sma2
+source $CRAY_TESTS_DIR/sma1/sma1_run 2>&1 | tee cray-tests-sma1.log
+source $CRAY_TESTS_DIR/sma2/sma2_run 2>&1 | tee cray-tests-sma2.log
+
+# Increment by 1 when a set of test fails (max is 3 for C/C++/Fortran)
+tests_failed=0
+
+#Check for failures in the C/C++ tests
+if grep "FAIL" cray-tests-sma1.log; then ((tests_failed+=1)); fi
+if grep "FAIL" cray-tests-sma2.log; then ((tests_failed+=1)); fi
+if [ ! $SOS_DISABLE_FORTRAN ]; then
+    make $TRAVIS_PAR_MAKE smaf
+    if [ $? -eq 0 ]; then
+        source $CRAY_TESTS_DIR/smaf/smaf_run 2>&1 | tee cray-tests-smaf.log;
+        # Check for failures in the Fortran tests
+        if grep "FAIL" cray-tests-smaf.log; then ((tests_failed+=1)); fi
+    fi;
+fi
+
+make clean
+
+if [ $tests_failed -eq 0 ]; then
+  echo $'\n********************************\n'
+  echo    "  All Cray SHMEM tests passed!  "
+  echo $'\n********************************\n'
+else
+  echo $'\n\nCray SHMEM tests failed... exiting with code: ' $tests_failed $'\n\n'
+fi
+exit $tests_failed

--- a/scripts/cray_tests.sh
+++ b/scripts/cray_tests.sh
@@ -24,7 +24,7 @@ tests_failed=0
 #Check for failures in the C/C++ tests
 if grep "FAIL" cray-tests-sma1.log; then ((tests_failed+=1)); fi
 if grep "FAIL" cray-tests-sma2.log; then ((tests_failed+=1)); fi
-if [ ! $SOS_DISABLE_FORTRAN ]; then
+if [ -z $SOS_DISABLE_FORTRAN ]; then
     make smaf MAKE_FLAGS="$TRAVIS_PAR_MAKE"
     if [ $? -eq 0 ]; then
         source $CRAY_TESTS_DIR/smaf/smaf_run 2>&1 | tee cray-tests-smaf.log;

--- a/scripts/cray_tests.sh
+++ b/scripts/cray_tests.sh
@@ -12,8 +12,8 @@ export NPES=4
 
 cd $CRAY_TESTS_DIR
 source configure.sh
-make $TRAVIS_PAR_MAKE sma1
-make $TRAVIS_PAR_MAKE sma2
+make sma1 MAKE_FLAGS=$TRAVIS_PAR_MAKE 
+make sma2 MAKE_FLAGS=$TRAVIS_PAR_MAKE 
 source $CRAY_TESTS_DIR/sma1/sma1_run 2>&1 | tee cray-tests-sma1.log
 source $CRAY_TESTS_DIR/sma2/sma2_run 2>&1 | tee cray-tests-sma2.log
 
@@ -24,7 +24,7 @@ tests_failed=0
 if grep "FAIL" cray-tests-sma1.log; then ((tests_failed+=1)); fi
 if grep "FAIL" cray-tests-sma2.log; then ((tests_failed+=1)); fi
 if [ ! $SOS_DISABLE_FORTRAN ]; then
-    make $TRAVIS_PAR_MAKE smaf
+    make smaf MAKE_FLAGS=$TRAVIS_PAR_MAKE
     if [ $? -eq 0 ]; then
         source $CRAY_TESTS_DIR/smaf/smaf_run 2>&1 | tee cray-tests-smaf.log;
         # Check for failures in the Fortran tests

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -291,7 +291,9 @@ void
 shmem_free(void *ptr)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
-    SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
+    if (ptr != NULL) {
+      SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
+    }
 
     shmem_internal_barrier_all();
 
@@ -307,6 +309,9 @@ shmem_realloc(void *ptr, size_t size)
     void *ret;
 
     SHMEM_ERR_CHECK_INITIALIZED();
+    if (ptr != NULL) {
+      SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
+    }
 
     shmem_internal_barrier_all();
 


### PR DESCRIPTION
- The script in `scripts/cray-tests.sh` can be run independently or as a part of Travis CI.  
- Most tests currently pass, but a couple don't, presumably because of bugs in the "tree" and "recursive doubling" reduction algorithms.  It seems like they might be with weird edge cases, for example, `shmem_int_and_to_all` when `PE_Size` is 1.
- Note the NULL pointer check when `--enable-error-checking` is set, which is required for a few Cray tests to pass, because they call `shmem_free(NULL)`.
- In Travis, this commit currently clones my [openshmem branch](https://github.com/davidozog/tests-cray/tree/openshmem) of [tests-cray](https://github.com/openshmem-org/tests-cray), but I'll submit a pull request there as well.