### PR TITLE
perf tests: enable 1 PE on bw tests

### DIFF
--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -104,6 +104,9 @@ void static uni_dir_data_init(perf_metrics_t * data) {
 
 int static inline partner_node(perf_metrics_t my_info)
 {
+    if(my_info.num_pes == 1)
+        return 0;
+
     if(my_info.cstyle == COMM_PAIRWISE) {
         int pairs = my_info.num_pes / 2;
 
@@ -473,8 +476,6 @@ void static inline bw_init_data_stream(perf_metrics_t *metric_info,
 
     data_init(metric_info);
 
-    only_even_PEs_check(metric_info->my_node, metric_info->num_pes);
-
     for(i = 0; i < _SHMEM_REDUCE_MIN_WRKDATA_SIZE; i++)
         red_psync[i] = _SHMEM_SYNC_VALUE;
 
@@ -492,6 +493,8 @@ void static inline bi_dir_init(perf_metrics_t *metric_info, int argc,
                                 char *argv[]) {
     bw_init_data_stream(metric_info, argc, argv);
 
+    only_even_PEs_check(metric_info->my_node, metric_info->num_pes);
+
     bi_dir_data_init(metric_info);
 
 }
@@ -499,6 +502,9 @@ void static inline bi_dir_init(perf_metrics_t *metric_info, int argc,
 void static inline uni_dir_init(perf_metrics_t *metric_info, int argc,
                                 char *argv[]) {
     bw_init_data_stream(metric_info, argc, argv);
+
+    if(metric_info->num_pes != 1)
+        only_even_PEs_check(metric_info->my_node, metric_info->num_pes);
 
     uni_dir_data_init(metric_info);
 }

--- a/test/performance/shmem_perf_suite/uni_dir.h
+++ b/test/performance/shmem_perf_suite/uni_dir.h
@@ -4,10 +4,11 @@ void static inline uni_bw(int len, perf_metrics_t *metric_info, int streaming_no
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
     int dest = partner_node(*metric_info);
+    int snode = (metric_info->num_pes != 1)? streaming_node : true;
 
     shmem_barrier_all();
 
-    if (streaming_node) {
+    if (snode) {
         for (i = 0; i < metric_info->trials + metric_info->warmup; i++) {
             if(i == metric_info->warmup)
                 start = perf_shmemx_wtime();


### PR DESCRIPTION
-only bw tests (bibw will still abort if not even PE set)
-verified change on atomic/get/put bw tests

Signed-off-by: kseager <kayla.seager@intel.com>