### PR TITLE
Upstream OPAL update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ script:
     - mkdir ofi-build
     - cd ofi-build
     - export PATH=$TRAVIS_INSTALL/hydra/bin:$BASE_PATH
-    - ../configure --with-ofi=$TRAVIS_INSTALL/libfabric/ --prefix=$TRAVIS_INSTALL/sandia-shmem-ofi $SOS_GLOBAL_BUILD_OPTS $SOS_BUILD_OPTS
+    - ../configure --with-libfabric=$TRAVIS_INSTALL/libfabric/ --prefix=$TRAVIS_INSTALL/sandia-shmem-ofi $SOS_GLOBAL_BUILD_OPTS $SOS_BUILD_OPTS
     - make $TRAVIS_PAR_MAKE
     - make $TRAVIS_PAR_MAKE check TESTS=
     - make VERBOSE=1 TEST_RUNNER="mpiexec.hydra -np 2" check

--- a/config/ompi_check_ofi.m4
+++ b/config/ompi_check_ofi.m4
@@ -29,11 +29,11 @@
 AC_DEFUN([OMPI_CHECK_OFI],[
     AC_ARG_WITH([ofi],
         [AC_HELP_STRING([--with-ofi(=DIR)],
-             [Build OFI support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+             [(Deprecated: please use --with-libfabric) Build OFI support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
     OMPI_CHECK_WITHDIR([ofi], [$with_ofi], [include/rdma/fabric.h])
     AC_ARG_WITH([ofi-libdir],
         [AC_HELP_STRING([--with-ofi-libdir=DIR],
-             [Search for OFI libraries in DIR])])
+             [(Deprecated: please use --with-libfabric-libdir) Search for OFI libraries in DIR])])
     OMPI_CHECK_WITHDIR([ofi-libdir], [$with_ofi_libdir], [libfabric.*])
 
     ompi_check_ofi_$1_save_CPPFLAGS="$CPPFLAGS"

--- a/config/opal_check_libfabric.m4
+++ b/config/opal_check_libfabric.m4
@@ -1,0 +1,95 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+
+# OPAL_CHECK_LIBFABRIC(prefix, [action-if-found], [action-if-not-found]
+# --------------------------------------------------------
+# Check if libfabric support can be found.
+#
+# Sets prefix_{CPPFLAGS, LDFLAGs, LIBS} as needed and runs
+# action-if-found if there is support; otherwise executes
+# action-if-not-found.
+#
+AC_DEFUN([OPAL_CHECK_LIBFABRIC],[
+    if test -z "$opal_check_libfabric_happy" ; then
+	OPAL_VAR_SCOPE_PUSH([opal_check_libfabric_$1_save_CPPFLAGS opal_check_libfabric_$1_save_LDFLAGS opal_check_libfabric_$1_save_LIBS])
+
+	# Add --with options
+	AC_ARG_WITH([libfabric],
+		    [AC_HELP_STRING([--with-libfabric=DIR],
+				    [Specify location of libfabric installation, adding DIR/include to the default search location for libfabric headers, and DIR/lib or DIR/lib64 to the default search location for libfabric libraries.  Error if libfabric support cannot be found.])])
+	AC_ARG_WITH([libfabric-libdir],
+		    [AC_HELP_STRING([--with-libfabric-libdir=DIR],
+				    [Search for libfabric libraries in DIR])])
+
+		    # Sanity check the --with values
+	OPAL_CHECK_WITHDIR([libfabric], [$with_libfabric],
+			   [include/rdma/fabric.h])
+	OPAL_CHECK_WITHDIR([libfabric-libdir], [$with_libfabric_libdir],
+			   [libfabric.*])
+
+	opal_check_libfabric_$1_save_CPPFLAGS=$CPPFLAGS
+	opal_check_libfabric_$1_save_LDFLAGS=$LDFLAGS
+	opal_check_libfabric_$1_save_LIBS=$LIBS
+
+	opal_check_libfabric_happy=yes
+	AS_IF([test "$with_libfabric" = "no"],
+              [opal_check_libfabric_happy=no])
+
+	AS_IF([test $opal_check_libfabric_happy = yes],
+              [AC_MSG_CHECKING([looking for libfabric in])
+               AS_IF([test "$with_libfabric" != "yes"],
+                     [opal_libfabric_dir=$with_libfabric
+                      AC_MSG_RESULT([($opal_libfabric_dir)])],
+                     [AC_MSG_RESULT([(default search paths)])])
+               AS_IF([test ! -z "$with_libfabric_libdir" && \
+			     test "$with_libfabric_libdir" != "yes"],
+                     [opal_libfabric_libdir=$with_libfabric_libdir])
+              ])
+
+	AS_IF([test $opal_check_libfabric_happy = yes],
+              [OPAL_CHECK_PACKAGE([opal_check_libfabric],
+				  [rdma/fabric.h],
+				  [fabric],
+				  [fi_getinfo],
+				  [],
+				  [$opal_libfabric_dir],
+				  [$opal_libfabric_libdir],
+				  [],
+				  [opal_check_libfabric_happy=no])])
+
+	CPPFLAGS=$opal_check_libfabric_$1_save_CPPFLAGS
+	LDFLAGS=$opal_check_libfabric_$1_save_LDFLAGS
+	LIBS=$opal_check_libfabric_$1_save_LIBS
+
+	OPAL_SUMMARY_ADD([[Transports]],[[OpenFabrics Libfabric]],[$1],[$opal_check_libfabric_happy])
+
+	OPAL_VAR_SCOPE_POP
+    fi
+
+    if test $opal_check_libfabric_happy = yes ; then
+	$1_CPPFLAGS="[$]$1_CPPFLAGS $opal_check_libfabric_CPPFLAGS"
+	$1_LIBS="[$]$1_LIBS $opal_check_libfabric_LIBS"
+	$1_LDFLAGS="[$]$1_LDFLAGS $opal_check_libfabric_LDFLAGS"
+
+	AC_SUBST($1_CPPFLAGS)
+	AC_SUBST($1_LDFLAGS)
+	AC_SUBST($1_LIBS)
+    fi
+
+    AS_IF([test $opal_check_libfabric_happy = yes],
+          [$2],
+          [AS_IF([test -n "$with_libfabric" && test "$with_libfabric" != "no"],
+                 [AC_MSG_WARN([libfabric support requested (via --with-libfabric), but not found.])
+                  AC_MSG_ERROR([Cannot continue.])])
+           $3])
+])dnl

--- a/config/opal_check_libnl.m4
+++ b/config/opal_check_libnl.m4
@@ -1,0 +1,280 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl More libnl v1/v3 sadness: the two versions are not compatible
+dnl and will not work correctly if simultaneously linked into the
+dnl same applications.  Unfortunately, they *will* link into the
+dnl same image!  On platforms like CentOS 7, libibverbs depends on
+dnl libnl-3.so.200 and friends, so if libnl3-devel packages are not
+dnl installed, but libnl-devel are, Open MPI should not try to use libnl.
+dnl
+dnl GROSS: libnl wants us to either use pkg-config (which we
+dnl can't assume is always present) or we need to look in a
+dnl particular directory for the right libnl3 include files.  For
+dnl now, just hard code the special path into this logic.
+dnl
+dnl _OPAL_CHECK_PACKAGE_LIB() invokes OPAL_LIBNL_SANITY_CHECK() in order
+dnl to keep track of which libraries depend on libnl and which libraries
+dnl depend on libnl3.
+dnl Open MPI will not be able to build a component vs a given version of libnl
+dnl if the other libnl version is required by some third party components.
+dnl At the end of configure, display a summary of who is using what, and aborts
+dnl if both libnl versions are required.
+
+dnl OPAL_LIBNL_SANITY_INIT()
+dnl --------------------------------------------------------------------
+AC_DEFUN([OPAL_LIBNL_SANITY_INIT], [
+    opal_libnl_version=0
+    opal_libnlv1_libs=
+    opal_libnlv3_libs=
+    AC_ARG_WITH([libnl],
+                [AC_HELP_STRING([--with-libnl(=DIR)],
+                                [Directory prefix for libnl (typically only necessary if libnl is installed in a location that the compiler/linker will not search by default)])])
+
+    # The --with options carry two pieces of information: 1) do
+    # you want a specific version of libnl, and 2) where that
+    # version of libnl lives.  For simplicity, let's separate
+    # those two pieces of information.
+    case "$with_libnl" in
+        no)
+            # Nope, don't want it
+            opal_want_libnl=no
+            ;;
+        "")
+            # Just try to build with libnl
+            opal_want_libnl=try
+            opal_libnl_location=
+            ;;
+        yes)
+            # Yes, definitely want it
+            opal_want_libnl=yes
+            opal_libnl_location=
+            ;;
+        *)
+            # Yes, definitely want it -- at a specific location
+            opal_want_libnl=yes
+            opal_libnl_location=$with_libnl
+            ;;
+    esac
+])
+
+dnl OPAL_LIBNL_SANITY_CHECK(lib, function, LIBS)
+dnl --------------------------------------------------------------------
+AC_DEFUN([OPAL_LIBNL_SANITY_CHECK], [
+    case $host in
+        *linux*)
+            OPAL_VAR_SCOPE_PUSH([ldd_output libnl_version])
+            AC_LANG_PUSH(C)
+            cat > conftest_c.$ac_ext << EOF
+extern void $2 (void);
+int main(int argc, char *argv[[]]) {
+    $2 ();
+    return 0;
+}
+EOF
+            OPAL_LOG_COMMAND([$CC -o conftest $CFLAGS $CPPFLAGS conftest_c.$ac_ext $LDFLAGS -l$1 $LIBS $3],
+                             [ldd_output=`ldd conftest`
+                              libnl_version=0
+                              AS_IF([echo $ldd_output | grep -q libnl.so],
+                                    [AS_IF([test $opal_libnl_version -eq 3],
+                                           [AC_MSG_WARN([lib nl version conflict: $opal_libnlv3_libs requires libnl-3 whereas $1 requires libnl])],
+                                           [opal_libnlv1_libs="$opal_libnlv1_libs $1"
+                                            OPAL_UNIQ([opal_libnlv1_libs])
+                                            opal_libnl_version=1])
+                                     libnl_version=1])
+                              AS_IF([echo $ldd_output | grep -q libnl-3.so],
+                                    [AS_IF([test $libnl_version -eq 1],
+                                           [AC_MSG_WARN([lib $1 requires both libnl v1 and libnl v3 -- yoinks!])
+                                            AC_MSG_WARN([This is a configuration that is known to cause run-time crashes])
+                                            AC_MSG_ERROR([Cannot continue])])
+                                     AS_IF([test $opal_libnl_version -eq 1],
+                                           [AC_MSG_WARN([lib nl version conflict: $opal_libnlv1_libs requires libnl whereas $1 requires libnl-3])],
+                                           [opal_libnlv3_libs="$opal_libnlv3_libs $1"
+                                            OPAL_UNIQ([opal_libnlv3_libs])
+                                            opal_libnl_version=3])])
+                              rm -f conftest conftest_c.$ac_ext],
+                             [AC_MSG_WARN([Could not link a simple program with lib $1])])
+            AC_LANG_POP(C)
+            OPAL_VAR_SCOPE_POP([ldd_output libnl_version])
+            ;;
+        esac
+])
+
+dnl
+dnl Check for libnl-3.
+dnl
+dnl Inputs:
+dnl
+dnl $1: prefix where to look for libnl-3
+dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
+dnl
+dnl Outputs:
+dnl
+dnl - Set $2_CPPFLAGS necessary to compile with libnl-3
+dnl - Set $2_LDFLAGS necessary to link with libnl-3
+dnl - Set $2_LIBS necessary to link with libnl-3
+dnl - Set OPAL_HAVE_LIBNL3 1 if libnl-3 will be used
+dnl
+AC_DEFUN([OPAL_CHECK_LIBNL_V3],[
+    OPAL_VAR_SCOPE_PUSH([CPPFLAGS_save opal_tmp_CPPFLAGS LIBS_save LDFLAGS_save])
+    AC_MSG_NOTICE([checking for libnl v3])
+
+    AS_IF([test "$opal_want_libnl" != "no"],
+          [AS_IF([test -z "$opal_libnl_location"],
+                 [AC_MSG_CHECKING([for /usr/include/libnl3])
+                  AS_IF([test -d "/usr/include/libnl3"],
+                        [opal_tmp_CPPFLAGS=-I/usr/include/libnl3
+                         opal_libnlv3_happy=1
+                         AC_MSG_RESULT([found])],
+                        [AC_MSG_RESULT([not found])
+                         AC_MSG_CHECKING([for /usr/local/include/libnl3])
+                         AS_IF([test -d "/usr/local/include/libnl3"],
+                               [opal_tmp_CPPFLAGS=-I/usr/local/include/netlink3
+                                opal_libnlv3_happy=1
+                                AC_MSG_RESULT([found])],
+                               [opal_libnlv3_happy=0
+                                AC_MSG_RESULT([not found])])])],
+                 [AC_MSG_CHECKING([for $1/include/libnl3])
+                  AS_IF([test -d "$1/include/libnl3"],
+                        [opal_tmp_CPPFLAGS="-I$1/include/libnl3"
+                         opal_libnlv3_happy=1
+                         AC_MSG_RESULT([found])],
+                        [opal_libnlv3_happy=0
+                         AC_MSG_RESULT([not found])])])
+           CPPFLAGS_save=$CPPFLAGS
+           CPPFLAGS="$opal_tmp_CPPFLAGS $CPPFLAGS"
+
+           # Random note: netlink/version.h is only in libnl v3 - it is not in libnl v1.
+           # Also, nl_recvmsgs_report is only in libnl v3.
+           AS_IF([test $opal_libnlv3_happy -eq 1],
+                 [OPAL_CHECK_PACKAGE([$2],
+                                     [netlink/version.h],
+                                     [nl-3],
+                                     [nl_recvmsgs_report],
+                                     [],
+                                     [$1],
+                                     [],
+                                     [],
+                                     [opal_libnlv3_happy=0])
+
+                  # Note that OPAL_CHECK_PACKAGE is going to add
+                  # -I$dir/include into $2_CPPFLAGS.  But because libnl v3
+                  # puts the headers in $dir/include/libnl3, we need to
+                  # overwrite $2_CPPFLAGS with -I$dir/include/libnl3.  We can do
+                  # this unconditionally; we don't have to check for
+                  # success (checking for success occurs below).
+                  $2_CPPFLAGS=$opal_tmp_CPPFLAGS])
+
+           # If we found libnl-3, we *also* need libnl-route-3
+           LIBS_save=$LIBS
+           LDFLAGS_save=$LDFLAGS
+           AS_IF([test -n "$$2_LDFLAGS"],
+                 [LDFLAGS="$$2_LDFLAGS $LDFLAGS"])
+           AS_IF([test $opal_libnlv3_happy -eq 1],
+                 [AC_SEARCH_LIBS([nl_rtgen_request],
+                                 [nl-route-3],
+                                 [],
+                                 [opal_libnlv3_happy=0])])
+           LIBS=$LIBS_save
+           LDFLAGS=$LDFLAGS_save
+
+           # Just because libnl* is evil, double check that the
+           # netlink/version.h we found was for libnl v3.  As far as we
+           # know, netlink/version.h only first appeared in version
+           # 3... but let's really be sure.
+           AS_IF([test $opal_libnlv3_happy -eq 1],
+                 [AC_MSG_CHECKING([to ensure these really are libnl v3 headers])
+                  AS_IF([test -n "$$2_CPPFLAGS"],
+                        [CPPFLAGS="$$2_CPPFLAGS $CPPFLAGS"])
+                  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#include <netlink/netlink.h>
+#include <netlink/version.h>
+#ifndef LIBNL_VER_MAJ
+#error "LIBNL_VER_MAJ not defined!"
+#endif
+/* to the best of our knowledge, version.h only exists in libnl v3 */
+#if LIBNL_VER_MAJ != 3
+#error "LIBNL_VER_MAJ != 3, I am sad"
+#endif
+                                     ]])],
+                                    [AC_MSG_RESULT([yes])],
+                                    [AC_MSG_RESULT([no])
+                                     opal_libnlv3_happy=0])])
+
+           CPPFLAGS=$CPPFLAGS_save],
+
+          [opal_libnlv3_happy=0])
+
+    # If we found everything
+    AS_IF([test $opal_libnlv3_happy -eq 1],
+          [$2_LIBS="-lnl-3 -lnl-route-3"
+           OPAL_HAVE_LIBNL3=1])
+
+   OPAL_VAR_SCOPE_POP
+])
+
+dnl
+dnl Check for libnl.
+dnl
+dnl Inputs:
+dnl
+dnl $1: prefix where to look for libnl
+dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
+dnl
+dnl Outputs:
+dnl
+dnl - Set $2_CPPFLAGS necessary to compile with libnl
+dnl - Set $2_LDFLAGS necessary to link with libnl
+dnl - Set $2_LIBS necessary to link with libnl
+dnl - Set OPAL_HAVE_LIBNL3 0 if libnl will be used
+dnl
+AC_DEFUN([OPAL_CHECK_LIBNL_V1],[
+    AC_MSG_NOTICE([checking for libnl v1])
+
+    AS_IF([test "$opal_want_libnl" != "no"],
+          [OPAL_CHECK_PACKAGE([$2],
+                              [netlink/netlink.h],
+                              [nl],
+                              [nl_connect],
+                              [-lm],
+                              [$1],
+                              [],
+                              [opal_libnlv1_happy=1],
+                              [opal_libnlv1_happy=0])],
+          [opal_libnlv1_happy=0])
+
+    AS_IF([test $opal_libnlv1_happy -eq 1],
+          [$2_LIBS="-lnl -lm"
+           OPAL_HAVE_LIBNL3=0])
+])
+
+dnl
+dnl Summarize libnl and libnl3 usage,
+dnl and abort if conflict is found
+dnl
+dnl Print the list of libraries that use libnl, 
+dnl the list of libraries that use libnl3,
+dnl and aborts if both libnl and libnl3 are used.
+dnl
+AC_DEFUN([OPAL_CHECK_LIBNL_SUMMARY],[
+    AC_MSG_CHECKING([for libraries that use libnl v1])
+    AS_IF([test -n "$opal_libnlv1_libs"],
+          [AC_MSG_RESULT([$opal_libnlv1_libs])],
+          [AC_MSG_RESULT([(none)])])
+    AC_MSG_CHECKING([for libraries that use libnl v3])
+    AS_IF([test -n "$opal_libnlv3_libs"],
+          [AC_MSG_RESULT([$opal_libnlv3_libs])],
+          [AC_MSG_RESULT([(none)])])
+    AS_IF([test -n "$opal_libnlv1_libs" && test -n "$opal_libnlv3_libs"],
+          [AC_MSG_WARN([libnl v1 and libnl v3 have been found as dependent libraries])
+           AC_ERROR([This is a configuration that is known to cause run-time crashes])])
+])

--- a/config/opal_check_package.m4
+++ b/config/opal_check_package.m4
@@ -1,0 +1,223 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl _OPAL_CHECK_PACKAGE_HEADER(prefix, header, dir-prefix,
+dnl                            [action-if-found], [action-if-not-found],
+dnl                            includes)
+dnl --------------------------------------------------------------------
+AC_DEFUN([_OPAL_CHECK_PACKAGE_HEADER], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.  one should not copy this
+    # code into other places unless you want much pain and suffering
+    AS_VAR_PUSHDEF([opal_Header], [ac_cv_header_$2])
+    OPAL_VAR_SCOPE_PUSH([dir_prefix])
+
+    # so this sucks, but there's no way to get through the progression
+    # of header includes without killing off the cache variable and trying
+    # again...
+    unset opal_Header
+
+    # get rid of the trailing slash(es)
+    dir_prefix=$(echo $3 | sed -e 'sX/*$XXg')
+    opal_check_package_header_happy="no"
+    AS_IF([test "$dir_prefix" = "/usr" || \
+           test "$dir_prefix" = "/usr/local"],
+           [ # try as is...
+            AC_VERBOSE([looking for header without includes])
+            AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [])
+            AS_IF([test "$opal_check_package_header_happy" = "no"],
+                  [# no go on the as is - reset the cache and try again
+                   unset opal_Header])])
+
+    AS_IF([test "$opal_check_package_header_happy" = "no"],
+          [AS_IF([test "$dir_prefix" != ""],
+                 [$1_CPPFLAGS="$$1_CPPFLAGS -I$dir_prefix/include"
+                  CPPFLAGS="$CPPFLAGS -I$dir_prefix/include"])
+          AC_CHECK_HEADERS([$2], [opal_check_package_header_happy="yes"], [], [$6])
+	  AS_IF([test "$opal_check_package_header_happy" = "yes"], [$4], [$5])],
+          [$4])
+    unset opal_check_package_header_happy
+
+    OPAL_VAR_SCOPE_POP([dir_prefix])
+    AS_VAR_POPDEF([opal_Header])dnl
+])
+
+
+dnl _OPAL_CHECK_PACKAGE_LIB(prefix, library, function, extra-libraries,
+dnl                         dir-prefix, libdir,
+dnl                         [action-if-found], [action-if-not-found]])
+dnl --------------------------------------------------------------------
+AC_DEFUN([_OPAL_CHECK_PACKAGE_LIB], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.  one should not copy this
+    # code into other places unless you want much pain and suffering
+    AS_VAR_PUSHDEF([opal_Lib], [ac_cv_search_$3])
+
+    # see comment above
+    unset opal_Lib
+    opal_check_package_lib_happy="no"
+    AS_IF([test "$6" != ""],
+          [ # libdir was specified - search only there
+           $1_LDFLAGS="$$1_LDFLAGS -L$6"
+           LDFLAGS="$LDFLAGS -L$6"
+           AC_SEARCH_LIBS([$3], [$2],
+                        [opal_check_package_lib_happy="yes"],
+                        [opal_check_package_lib_happy="no"], [$4])
+           AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                 [LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                  $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                  unset opal_Lib])],
+          [ # libdir was not specified - go through search path
+           opal_check_package_libdir="$5"
+           AS_IF([test "$opal_check_package_libdir" = "" || \
+                  test "$opal_check_package_libdir" = "/usr" || \
+                  test "$opal_check_package_libdir" = "/usr/local"],
+               [ # try as is...
+                AC_VERBOSE([looking for library without search path])
+                AC_SEARCH_LIBS([$3], [$2],
+                        [opal_check_package_lib_happy="yes"],
+                        [opal_check_package_lib_happy="no"], [$4])
+                AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                    [ # no go on the as is..  see what happens later...
+                     LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                     $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                     unset opal_Lib])])
+
+           AS_IF([test "$opal_check_package_lib_happy" = "no"],
+               [AS_IF([test "$opal_check_package_libdir" != ""],
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$opal_check_package_libdir/lib"
+                     LDFLAGS="$LDFLAGS -L$opal_check_package_libdir/lib"
+                     AC_VERBOSE([looking for library in lib])
+                     AC_SEARCH_LIBS([$3], [$2],
+                               [opal_check_package_lib_happy="yes"],
+                               [opal_check_package_lib_happy="no"], [$4])
+                     AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                         [ # no go on the as is..  see what happens later...
+                          LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                          $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                          unset opal_Lib])])])
+
+           AS_IF([test "$opal_check_package_lib_happy" = "no"],
+               [AS_IF([test "$opal_check_package_libdir" != ""],
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$opal_check_package_libdir/lib64"
+                     LDFLAGS="$LDFLAGS -L$opal_check_package_libdir/lib64"
+                     AC_VERBOSE([looking for library in lib64])
+                     AC_SEARCH_LIBS([$3], [$2],
+                               [opal_check_package_lib_happy="yes"],
+                               [opal_check_package_lib_happy="no"], [$4])
+                     AS_IF([test "$opal_check_package_lib_happy" = "no"],
+                         [ # no go on the as is..  see what happens later...
+                          LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+                          $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+                          unset opal_Lib])])])])
+
+    AS_IF([test "$opal_check_package_lib_happy" = "yes"],
+          [ # The result of AC SEARCH_LIBS is cached in $ac_cv_search_[function]
+           AS_IF([test "$ac_cv_search_$3" != "no" &&
+                  test "$ac_cv_search_$3" != "none required"],
+                 [$1_LIBS="$ac_cv_search_$3 $4"],
+                 [$1_LIBS="$4"])
+            # libnl v1 and libnl3 are known *not* to coexist
+            # for each library, figure out whether it depends on libnl or libnl3 or none
+            # so conflicts can be reported and/or prevented
+            OPAL_LIBNL_SANITY_CHECK([$2], [$3], [$$1_LIBS])
+           $7],
+          [$8])
+
+    AS_VAR_POPDEF([opal_Lib])dnl
+])
+
+
+dnl OPAL_CHECK_PACKAGE(prefix,
+dnl                    header,
+dnl                    library,
+dnl                    function,
+dnl                    extra-libraries,
+dnl                    dir-prefix,
+dnl                    libdir-prefix,
+dnl                    [action-if-found], [action-if-not-found],
+dnl                    includes)
+dnl -----------------------------------------------------------
+dnl Check for package defined by header and libs, and probably
+dnl located in dir-prefix, possibly with libs in libdir-prefix.
+dnl Both dir-prefix and libdir-prefix can be empty.  Will set
+dnl prefix_{CPPFLAGS, LDFLAGS, LIBS} as needed.
+dnl
+dnl The general intent of this macro is to provide finer-grained scoping
+dnl of C preprocessor flags, linker flags, and libraries (as opposed to
+dnl unconditionally adding to the top-level CPFLAGS, LDFLAGS, and LIBS,
+dnl which get used to compile/link *everything*).
+dnl
+dnl Here is a breakdown of the parameters:
+dnl
+dnl * prefix: the macro sets $prefix_CPPFLAGS, $prefix_LDFLAGS, and
+dnl   $prefix_LIBS (and AC_SUBSTs all of them).  For example, if a
+dnl   provider uses this macro to check for a header/library that it
+dnl   needs, it might well set prefix to be its provider name.
+dnl * header_filename: the foo.h file to check for
+dnl * library_name / function_name: check for function function_name in
+dnl   -llibrary_name.  Specifically, for library_name, use the "foo" form,
+dnl   as opposed to "libfoo".
+dnl * extra_libraries: if the library_name you are checking for requires
+dnl   additonal -l arguments to link successfully, list them here.
+dnl * dir_prefix: if the header/library is located in a non-standard
+dnl   location (e.g., /opt/foo as opposed to /usr), list it here
+dnl * libdir_prefix: if the library is not under $dir_prefix/lib or
+dnl   $dir_prefix/lib64, list it here.
+dnl * action_if_found: if both the header and library are found and
+dnl   usable, execute action_if_found
+dnl * action_if_not_found: otherwise, execute action_if_not_found
+dnl * extra_includes: if including header_filename requires additional
+dnl   headers to be included first, list them here
+dnl
+dnl The output _CPPFLAGS, _LDFLAGS, and _LIBS can be used to limit the
+dnl scope various flags in Makefiles.
+dnl
+AC_DEFUN([OPAL_CHECK_PACKAGE],[
+    opal_check_package_$1_save_CPPFLAGS="$CPPFLAGS"
+    opal_check_package_$1_save_LDFLAGS="$LDFLAGS"
+    opal_check_package_$1_save_LIBS="$LIBS"
+
+    opal_check_package_$1_orig_CPPFLAGS="$$1_CPPFLAGS"
+    opal_check_package_$1_orig_LDFLAGS="$$1_LDFLAGS"
+    opal_check_package_$1_orig_LIBS="$$1_LIBS"
+
+    _OPAL_CHECK_PACKAGE_HEADER([$1], [$2], [$6],
+          [_OPAL_CHECK_PACKAGE_LIB([$1], [$3], [$4], [$5], [$6], [$7],
+                [opal_check_package_happy="yes"],
+                [opal_check_package_happy="no"])],
+          [opal_check_package_happy="no"],
+          [$10])
+
+    AS_IF([test "$opal_check_package_happy" = "yes"],
+          [$8],
+          [$1_CPPFLAGS="$opal_check_package_$1_orig_CPPFLAGS"
+           $1_LDFLAGS="$opal_check_package_$1_orig_LDFLAGS"
+           $1_LIBS="$opal_check_package_$1_orig_LIBS"
+           $9])
+
+    CPPFLAGS="$opal_check_package_$1_save_CPPFLAGS"
+    LDFLAGS="$opal_check_package_$1_save_LDFLAGS"
+    LIBS="$opal_check_package_$1_save_LIBS"
+])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -11,17 +11,21 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
-# Copyright (c) 2014-2016 Research Organization for Information Science
+# Copyright (c) 2014      Intel, Inc. All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
+#
+
+#
+# NOTE: this is a modified version of the opal_check_pmi.m4 file from
+# the Open MPI project.
 #
 
 # define an internal function for checking the existence
@@ -72,8 +76,9 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
            LDFLAGS="$LDFLAGS -L$2"
            AC_CHECK_LIB([$3], [$4],
                         [opal_check_$3_lib_happy=yes
-                         $3_LDFLAGS=-L$2
-                         $3_rpath=$2],
+                         pmi_LDFLAGS=-L$2
+                         pmi_LIBS=-l$3
+                         pmi_rpath=$2],
                         [opal_check_$3_lib_happy=no])],
           [opal_check_$3_lib_happy=no
            AC_MSG_RESULT([not found])])
@@ -88,8 +93,9 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
                   LDFLAGS="$LDFLAGS -L$2/lib64"
                   AC_CHECK_LIB([$3], [$4],
                                [opal_check_$3_lib_happy=yes
-                                $3_LDFLAGS=-L$2/lib64
-                                $3_rpath=$2/lib64],
+                                pmi_LDFLAGS=-L$2/lib64
+                                pmi_LIBS=-l$3
+                                pmi_rpath=$2/lib64],
                                [opal_check_$3_lib_happy=no])],
                  [opal_check_$3_lib_happy=no
                   AC_MSG_RESULT([not found])])])
@@ -105,8 +111,9 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
                   LDFLAGS="$LDFLAGS -L$2/lib"
                   AC_CHECK_LIB([$3], [$4],
                                [opal_check_$3_lib_happy=yes
-                                $3_LDFLAGS=-L$2/lib
-                                $3_rpath=$2/lib],
+                                pmi_LDFLAGS=-L$2/lib
+                                pmi_LIBS=-l$3
+                                pmirpath=$2/lib],
                                [opal_check_$3_lib_happy=no])],
                  [opal_check_$3_lib_happy=no
                   AC_MSG_RESULT([not found])])])
@@ -135,16 +142,43 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                 [AC_HELP_STRING([--with-pmi-libdir(=DIR)],
                                 [Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
 
+    AC_ARG_ENABLE([pmi1],
+                [AS_HELP_STRING([--enable-pmi1],
+                                [If slurm has both PMI1 and PMI2, PMI2 will be used by default, override this for PMI1 if need-be (default: disabled)])],
+                                [], enable_pmi1=no)
+
     check_pmi_install_dir=
     check_pmi_lib_dir=
     default_pmi_loc=
     default_pmi_libloc=
     slurm_pmi_found=
 
+    # enable Portals4 PMI if using Portals4 provider else slurm PMI check
+    AS_IF([ test ! -z "$with_portals4"],[
+        AS_IF([test ! -z "$with_pmi" -a "$with_pmi" != "yes"],
+                [ompi_check_pmi_dir="$with_pmi"])
+        AS_IF([test ! -z "$with_pmi_libdir" -a "$with_pmi_libdir" != "yes"],
+                [ompi_check_pmi_libdir="$with_pmi_libdir"])
+
+        AS_IF([test -z "$with_pmi" -o "$with_pmi" = "yes"],
+                [ompi_check_pmi_dir="$with_portals4"])
+        OMPI_CHECK_PACKAGE([],
+                [portals4/pmi.h],
+                [portals_runtime],
+                [PMI_Init],
+                [],
+                [$ompi_check_pmi_dir],
+                [$ompi_check_pmi_libdir],
+                [AC_DEFINE([PMI_PORTALS4], [1],
+                        [Defined to 1 if PMI implementation is Portals4.])
+                 ompi_check_pmi_happy="yes"],
+                [ompi_check_pmi_happy="no"])], [
+
+      #else slurm PMI check
+
     AC_MSG_CHECKING([if user requested PMI support])
     AS_IF([test "$with_pmi" = "no"],
-          [AC_MSG_RESULT([no])
-           $3],
+          [AC_MSG_RESULT([no])],
           [AC_MSG_RESULT([yes])
            # cannot use OPAL_CHECK_PACKAGE as its backend header
            # support appends "include" to the path, which won't
@@ -156,65 +190,55 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                   default_pmi_loc=yes])
            AS_IF([test ! -z "$with_pmi_libdir"],
                  [check_pmi_lib_dir=$with_pmi_libdir
-                  default_pmi_libloc=no],
+		  default_pmi_libloc=no],
                  [check_pmi_lib_dir=$check_pmi_install_dir
-          AS_IF([test "$default_pmi_loc" = "no"],
-                [default_pmi_libloc=no],
-                [default_pmi_libloc=yes])])
+		  AS_IF([test "$default_pmi_loc" = "no"],
+		        [default_pmi_libloc=no],
+			[default_pmi_libloc=yes])])
 
            # check for pmi-1 lib */
            slurm_pmi_found=no
            OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
-                              [$check_pmi_lib_dir],
+	                      [$check_pmi_lib_dir],
                               [pmi], [PMI_Init],
                               [slurm_pmi_found=yes],
                               [opal_enable_pmi1=yes
-                               opal_pmi1_LIBS="-lpmi"
-                               AC_SUBST(opal_pmi1_LIBS)],
+                               opal_pmi1_LIBS="-lpmi"],
                               [opal_enable_pmi1=no])
 
-           AS_IF([test "$opal_enable_pmi1" = "yes"],
-                 [AS_IF([test "$default_pmi_loc" = "no" || test "$slurm_pmi_found" = "yes"],
-                        [opal_pmi1_CPPFLAGS="$pmi_CPPFLAGS"
-                         AC_SUBST(opal_pmi1_CPPFLAGS)])
-                  AS_IF([test "$default_pmi_libloc" = "no" || test "$slurm_pmi_found" = "yes"],
-                        [opal_pmi1_LDFLAGS="$pmi_LDFLAGS"
-                         AC_SUBST(opal_pmi1_LDFLAGS)
-                         opal_pmi1_rpath="$pmi_rpath"
-                         AC_SUBST(opal_pmi1_rpath)])])
-
            # check for pmi2 lib */
+           AS_IF([test "$enable_pmi1" = "no"],
            slurm_pmi_found=no
-           OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+                [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
                               [$check_pmi_lib_dir],
                               [pmi2], [PMI2_Init],
                               [slurm_pmi_found=yes],
                               [opal_enable_pmi2=yes
-                               opal_pmi2_LIBS="-lpmi2"
-                               AC_SUBST(opal_pmi2_LIBS)],
+                               opal_pmi2_LIBS="-lpmi2"],
                               [opal_enable_pmi2=no])
 
-           AS_IF([test "$opal_enable_pmi2" = "yes"],
-                 [AS_IF([test "$default_pmi_loc" = "no" || test "$slurm_pmi_found" = "yes"],
-                        [opal_pmi2_CPPFLAGS="$pmi2_CPPFLAGS"
-                         AC_SUBST(opal_pmi2_CPPFLAGS)])
-                  AS_IF([test "$default_pmi_libloc" = "no" || test "$slurm_pmi_found" = "yes"],
-                        [opal_pmi2_LDFLAGS="$pmi2_LDFLAGS"
-                         AC_SUBST(opal_pmi2_LDFLAGS)
-                         opal_pmi2_rpath="$pmi2_rpath"
-                         AC_SUBST(opal_pmi2_rpath)])])
+dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
+
+           AS_IF([test "$opal_enable_pmi2" = "no"],
+                 [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+                                     [$check_pmi_lib_dir],
+                                     [pmi], [PMI2_Init],
+                                     [slurm_pmi_found=yes],
+                                     [opal_enable_pmi2=yes
+                                      opal_pmi2_LIBS="-lpmi"],
+                                     [opal_enable_pmi2=no])],[])])
 
            # since support was explicitly requested, then we should error out
            # if we didn't find the required support
-           AC_MSG_CHECKING([can PMI support be built])
+	   AC_MSG_CHECKING([can PMI support be built])
            AS_IF([test "$opal_enable_pmi1" != "yes" && test "$opal_enable_pmi2" != "yes"],
                  [AC_MSG_RESULT([no])
                   AC_MSG_WARN([PMI support requested (via --with-pmi) but neither pmi.h])
-                  AC_MSG_WARN([nor pmi2.h were found under locations:])
+		  AC_MSG_WARN([nor pmi2.h were found under locations:])
                   AC_MSG_WARN([    $check_pmi_install_dir])
                   AC_MSG_WARN([    $check_pmi_install_dir/slurm])
                   AC_MSG_WARN([Specified path: $with_pmi])
-                  AC_MSG_WARN([OR neither libpmi nor libpmi2 were found under:])
+		  AC_MSG_WARN([OR neither libpmi nor libpmi2 were found under:])
                   AC_MSG_WARN([    $check_pmi_lib_dir/lib])
                   AC_MSG_WARN([    $check_pmi_lib_dir/lib64])
                   AC_MSG_WARN([Specified path: $with_pmi_libdir])
@@ -222,109 +246,13 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                  [AC_MSG_RESULT([yes])])
            ])
 
-    OPAL_VAR_SCOPE_POP
-])
+           AS_IF([test "$opal_enable_pmi1" = "yes" && test "$opal_enable_pmi2" != "yes"],
+                 [$1="pmi1"],[])
 
-AC_DEFUN([OPAL_CHECK_PMIX],[
-
-    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
-
-    AC_ARG_WITH([pmix],
-                [AC_HELP_STRING([--with-pmix(=DIR)],
-                                [Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
-
-    AS_IF([test "$with_pmix" = "no"],
-          [AC_MSG_WARN([Open MPI requires PMIx support. It can be built])
-           AC_MSG_WARN([with either its own internal copy of PMIx, or with])
-           AC_MSG_WARN([an external copy that you supply.])
-           AC_MSG_ERROR([Cannot continue])])
-
-    AC_MSG_CHECKING([if user requested external PMIx support($with_pmix)])
-    AS_IF([test -z "$with_pmix" || test "$with_pmix" = "yes" || test "$with_pmix" = "internal"],
-          [AC_MSG_RESULT([no])
-           opal_external_pmix_happy=no],
-
-          [AC_MSG_RESULT([yes])
-           # check for external pmix lib */
-           AS_IF([test "$with_pmix" = "external"],
-                 [pmix_ext_install_dir=/usr],
-                 [pmix_ext_install_dir=$with_pmix])
-
-           # Make sure we have the headers and libs in the correct location
-           OPAL_CHECK_WITHDIR([external-pmix], [$pmix_ext_install_dir/include], [pmix.h])
-           OPAL_CHECK_WITHDIR([external-libpmix], [$pmix_ext_install_dir/lib], [libpmix.*])
-
-           # check the version
-           opal_external_pmix_save_CPPFLAGS=$CPPFLAGS
-           opal_external_pmix_save_LDFLAGS=$LDFLAGS
-           opal_external_pmix_save_LIBS=$LIBS
-
-           # if the pmix_version.h file does not exist, then
-           # this must be from a pre-1.1.5 version
-           AC_MSG_CHECKING([PMIx version])
-           CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
-           AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
-                 [AC_MSG_RESULT([version file not found - assuming v1.1.4])
-                  opal_external_pmix_version_found=1
-                  opal_external_pmix_version=114],
-                 [AC_MSG_RESULT([version file found])
-                  opal_external_pmix_version_found=0])
-
-           # if it does exist, then we need to parse it to find
-           # the actual release series
-           AS_IF([test "$opal_external_pmix_version_found" = "0"],
-                 [AC_MSG_CHECKING([version 3x])
-                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                      #include <pmix_version.h>
-                                                      #if (PMIX_VERSION_MAJOR != 3L)
-                                                      #error "not version 3"
-                                                      #endif
-                                                      ], [])],
-                                    [AC_MSG_RESULT([found])
-                                     opal_external_pmix_version=3x
-                                     opal_external_pmix_version_found=1],
-                                    [AC_MSG_RESULT([not found])])])
-
-           AS_IF([test "$opal_external_pmix_version_found" = "0"],
-                 [AC_MSG_CHECKING([version 2x])
-                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                      #include <pmix_version.h>
-                                                      #if (PMIX_VERSION_MAJOR != 2L)
-                                                      #error "not version 2"
-                                                      #endif
-                                                      ], [])],
-                                    [AC_MSG_RESULT([found])
-                                     opal_external_pmix_version=2x
-                                     opal_external_pmix_version_found=1],
-                                    [AC_MSG_RESULT([not found])])])
-
-           AS_IF([test "$opal_external_pmix_version_found" = "0"],
-                 [AC_MSG_CHECKING([version 1x])
-                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
-                                                      #include <pmix_version.h>
-                                                      #if (PMIX_VERSION_MAJOR != 1L)
-                                                      #error "not version 1"
-                                                      #endif
-                                                      ], [])],
-                                    [AC_MSG_RESULT([found])
-                                     opal_external_pmix_version=1x
-                                     opal_external_pmix_version_found=1],
-                                    [AC_MSG_RESULT([not found])])])
-
-           AS_IF([test "x$opal_external_pmix_version" = "x"],
-                 [AC_MSG_WARN([External PMIx support requested, but version])
-                  AC_MSG_WARN([information of the external lib could not])
-                  AC_MSG_WARN([be detected])
-                  AC_MSG_ERROR([cannot continue])])
-
-           CPPFLAGS=$opal_external_pmix_save_CPPFLAGS
-           LDFLAGS=$opal_external_pmix_save_LDFLAGS
-           LIBS=$opal_external_pmix_save_LIBS
-
-           opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
-           opal_external_pmix_LDFLAGS=-L$pmix_ext_install_dir/lib
-           opal_external_pmix_LIBS=-lpmix
-           opal_external_pmix_happy=yes])
-
+           AS_IF([test "$opal_enable_pmi2" = "yes"],
+                 [$1="pmi2"],[])
+    ])
+    TEST_RUNNER='$(abs_top_builddir)/src/oshrun -np $(NPROCS)'
+    AC_SUBST(TEST_RUNNER)
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -11,21 +11,17 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2011-2016 Los Alamos National Security, LLC. All rights
+# Copyright (c) 2011-2014 Los Alamos National Security, LLC. All rights
 #                         reserved.
-# Copyright (c) 2014      Intel, Inc. All rights reserved.
-# Copyright (c) 2014      Research Organization for Information Science
+# Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2016 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
 #
 # $HEADER$
-#
-
-#
-# NOTE: this is a modified version of the opal_check_pmi.m4 file from
-# the Open MPI project.
 #
 
 # define an internal function for checking the existence
@@ -76,9 +72,8 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
            LDFLAGS="$LDFLAGS -L$2"
            AC_CHECK_LIB([$3], [$4],
                         [opal_check_$3_lib_happy=yes
-                         pmi_LDFLAGS=-L$2
-                         pmi_LIBS=-l$3
-                         pmi_rpath=$2],
+                         $3_LDFLAGS=-L$2
+                         $3_rpath=$2],
                         [opal_check_$3_lib_happy=no])],
           [opal_check_$3_lib_happy=no
            AC_MSG_RESULT([not found])])
@@ -93,9 +88,8 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
                   LDFLAGS="$LDFLAGS -L$2/lib64"
                   AC_CHECK_LIB([$3], [$4],
                                [opal_check_$3_lib_happy=yes
-                                pmi_LDFLAGS=-L$2/lib64
-                                pmi_LIBS=-l$3
-                                pmi_rpath=$2/lib64],
+                                $3_LDFLAGS=-L$2/lib64
+                                $3_rpath=$2/lib64],
                                [opal_check_$3_lib_happy=no])],
                  [opal_check_$3_lib_happy=no
                   AC_MSG_RESULT([not found])])])
@@ -111,9 +105,8 @@ AC_DEFUN([OPAL_CHECK_PMI_LIB],
                   LDFLAGS="$LDFLAGS -L$2/lib"
                   AC_CHECK_LIB([$3], [$4],
                                [opal_check_$3_lib_happy=yes
-                                pmi_LDFLAGS=-L$2/lib
-                                pmi_LIBS=-l$3
-                                pmirpath=$2/lib],
+                                $3_LDFLAGS=-L$2/lib
+                                $3_rpath=$2/lib],
                                [opal_check_$3_lib_happy=no])],
                  [opal_check_$3_lib_happy=no
                   AC_MSG_RESULT([not found])])])
@@ -142,43 +135,16 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                 [AC_HELP_STRING([--with-pmi-libdir(=DIR)],
                                 [Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
 
-    AC_ARG_ENABLE([pmi1],
-                [AS_HELP_STRING([--enable-pmi1],
-                                [If slurm has both PMI1 and PMI2, PMI2 will be used by default, override this for PMI1 if need-be (default: disabled)])],
-                                [], enable_pmi1=no)
-
     check_pmi_install_dir=
     check_pmi_lib_dir=
     default_pmi_loc=
     default_pmi_libloc=
     slurm_pmi_found=
 
-    # enable Portals4 PMI if using Portals4 provider else slurm PMI check
-    AS_IF([ test ! -z "$with_portals4"],[
-        AS_IF([test ! -z "$with_pmi" -a "$with_pmi" != "yes"],
-                [ompi_check_pmi_dir="$with_pmi"])
-        AS_IF([test ! -z "$with_pmi_libdir" -a "$with_pmi_libdir" != "yes"],
-                [ompi_check_pmi_libdir="$with_pmi_libdir"])
-
-        AS_IF([test -z "$with_pmi" -o "$with_pmi" = "yes"],
-                [ompi_check_pmi_dir="$with_portals4"])
-        OMPI_CHECK_PACKAGE([],
-                [portals4/pmi.h],
-                [portals_runtime],
-                [PMI_Init],
-                [],
-                [$ompi_check_pmi_dir],
-                [$ompi_check_pmi_libdir],
-                [AC_DEFINE([PMI_PORTALS4], [1],
-                        [Defined to 1 if PMI implementation is Portals4.])
-                 ompi_check_pmi_happy="yes"],
-                [ompi_check_pmi_happy="no"])], [
-
-      #else slurm PMI check
-
     AC_MSG_CHECKING([if user requested PMI support])
     AS_IF([test "$with_pmi" = "no"],
-          [AC_MSG_RESULT([no])],
+          [AC_MSG_RESULT([no])
+           $3],
           [AC_MSG_RESULT([yes])
            # cannot use OPAL_CHECK_PACKAGE as its backend header
            # support appends "include" to the path, which won't
@@ -190,55 +156,65 @@ AC_DEFUN([OPAL_CHECK_PMI],[
                   default_pmi_loc=yes])
            AS_IF([test ! -z "$with_pmi_libdir"],
                  [check_pmi_lib_dir=$with_pmi_libdir
-		  default_pmi_libloc=no],
+                  default_pmi_libloc=no],
                  [check_pmi_lib_dir=$check_pmi_install_dir
-		  AS_IF([test "$default_pmi_loc" = "no"],
-		        [default_pmi_libloc=no],
-			[default_pmi_libloc=yes])])
+          AS_IF([test "$default_pmi_loc" = "no"],
+                [default_pmi_libloc=no],
+                [default_pmi_libloc=yes])])
 
            # check for pmi-1 lib */
            slurm_pmi_found=no
            OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
-	                      [$check_pmi_lib_dir],
+                              [$check_pmi_lib_dir],
                               [pmi], [PMI_Init],
                               [slurm_pmi_found=yes],
                               [opal_enable_pmi1=yes
-                               opal_pmi1_LIBS="-lpmi"],
+                               opal_pmi1_LIBS="-lpmi"
+                               AC_SUBST(opal_pmi1_LIBS)],
                               [opal_enable_pmi1=no])
 
+           AS_IF([test "$opal_enable_pmi1" = "yes"],
+                 [AS_IF([test "$default_pmi_loc" = "no" || test "$slurm_pmi_found" = "yes"],
+                        [opal_pmi1_CPPFLAGS="$pmi_CPPFLAGS"
+                         AC_SUBST(opal_pmi1_CPPFLAGS)])
+                  AS_IF([test "$default_pmi_libloc" = "no" || test "$slurm_pmi_found" = "yes"],
+                        [opal_pmi1_LDFLAGS="$pmi_LDFLAGS"
+                         AC_SUBST(opal_pmi1_LDFLAGS)
+                         opal_pmi1_rpath="$pmi_rpath"
+                         AC_SUBST(opal_pmi1_rpath)])])
+
            # check for pmi2 lib */
-           AS_IF([test "$enable_pmi1" = "no"],
            slurm_pmi_found=no
-                [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
+           OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
                               [$check_pmi_lib_dir],
                               [pmi2], [PMI2_Init],
                               [slurm_pmi_found=yes],
                               [opal_enable_pmi2=yes
-                               opal_pmi2_LIBS="-lpmi2"],
+                               opal_pmi2_LIBS="-lpmi2"
+                               AC_SUBST(opal_pmi2_LIBS)],
                               [opal_enable_pmi2=no])
 
-dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
-
-           AS_IF([test "$opal_enable_pmi2" = "no"],
-                 [OPAL_CHECK_PMI_LIB([$check_pmi_install_dir],
-                                     [$check_pmi_lib_dir],
-                                     [pmi], [PMI2_Init],
-                                     [slurm_pmi_found=yes],
-                                     [opal_enable_pmi2=yes
-                                      opal_pmi2_LIBS="-lpmi"],
-                                     [opal_enable_pmi2=no])],[])])
+           AS_IF([test "$opal_enable_pmi2" = "yes"],
+                 [AS_IF([test "$default_pmi_loc" = "no" || test "$slurm_pmi_found" = "yes"],
+                        [opal_pmi2_CPPFLAGS="$pmi2_CPPFLAGS"
+                         AC_SUBST(opal_pmi2_CPPFLAGS)])
+                  AS_IF([test "$default_pmi_libloc" = "no" || test "$slurm_pmi_found" = "yes"],
+                        [opal_pmi2_LDFLAGS="$pmi2_LDFLAGS"
+                         AC_SUBST(opal_pmi2_LDFLAGS)
+                         opal_pmi2_rpath="$pmi2_rpath"
+                         AC_SUBST(opal_pmi2_rpath)])])
 
            # since support was explicitly requested, then we should error out
            # if we didn't find the required support
-	   AC_MSG_CHECKING([can PMI support be built])
+           AC_MSG_CHECKING([can PMI support be built])
            AS_IF([test "$opal_enable_pmi1" != "yes" && test "$opal_enable_pmi2" != "yes"],
                  [AC_MSG_RESULT([no])
                   AC_MSG_WARN([PMI support requested (via --with-pmi) but neither pmi.h])
-		  AC_MSG_WARN([nor pmi2.h were found under locations:])
+                  AC_MSG_WARN([nor pmi2.h were found under locations:])
                   AC_MSG_WARN([    $check_pmi_install_dir])
                   AC_MSG_WARN([    $check_pmi_install_dir/slurm])
                   AC_MSG_WARN([Specified path: $with_pmi])
-		  AC_MSG_WARN([OR neither libpmi nor libpmi2 were found under:])
+                  AC_MSG_WARN([OR neither libpmi nor libpmi2 were found under:])
                   AC_MSG_WARN([    $check_pmi_lib_dir/lib])
                   AC_MSG_WARN([    $check_pmi_lib_dir/lib64])
                   AC_MSG_WARN([Specified path: $with_pmi_libdir])
@@ -246,13 +222,109 @@ dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
                  [AC_MSG_RESULT([yes])])
            ])
 
-           AS_IF([test "$opal_enable_pmi1" = "yes" && test "$opal_enable_pmi2" != "yes"],
-                 [$1="pmi1"],[])
+    OPAL_VAR_SCOPE_POP
+])
 
-           AS_IF([test "$opal_enable_pmi2" = "yes"],
-                 [$1="pmi2"],[])
-    ])
-    TEST_RUNNER='$(abs_top_builddir)/src/oshrun -np $(NPROCS)'
-    AC_SUBST(TEST_RUNNER)
+AC_DEFUN([OPAL_CHECK_PMIX],[
+
+    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
+
+    AC_ARG_WITH([pmix],
+                [AC_HELP_STRING([--with-pmix(=DIR)],
+                                [Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
+
+    AS_IF([test "$with_pmix" = "no"],
+          [AC_MSG_WARN([Open MPI requires PMIx support. It can be built])
+           AC_MSG_WARN([with either its own internal copy of PMIx, or with])
+           AC_MSG_WARN([an external copy that you supply.])
+           AC_MSG_ERROR([Cannot continue])])
+
+    AC_MSG_CHECKING([if user requested external PMIx support($with_pmix)])
+    AS_IF([test -z "$with_pmix" || test "$with_pmix" = "yes" || test "$with_pmix" = "internal"],
+          [AC_MSG_RESULT([no])
+           opal_external_pmix_happy=no],
+
+          [AC_MSG_RESULT([yes])
+           # check for external pmix lib */
+           AS_IF([test "$with_pmix" = "external"],
+                 [pmix_ext_install_dir=/usr],
+                 [pmix_ext_install_dir=$with_pmix])
+
+           # Make sure we have the headers and libs in the correct location
+           OPAL_CHECK_WITHDIR([external-pmix], [$pmix_ext_install_dir/include], [pmix.h])
+           OPAL_CHECK_WITHDIR([external-libpmix], [$pmix_ext_install_dir/lib], [libpmix.*])
+
+           # check the version
+           opal_external_pmix_save_CPPFLAGS=$CPPFLAGS
+           opal_external_pmix_save_LDFLAGS=$LDFLAGS
+           opal_external_pmix_save_LIBS=$LIBS
+
+           # if the pmix_version.h file does not exist, then
+           # this must be from a pre-1.1.5 version
+           AC_MSG_CHECKING([PMIx version])
+           CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
+           AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
+                 [AC_MSG_RESULT([version file not found - assuming v1.1.4])
+                  opal_external_pmix_version_found=1
+                  opal_external_pmix_version=114],
+                 [AC_MSG_RESULT([version file found])
+                  opal_external_pmix_version_found=0])
+
+           # if it does exist, then we need to parse it to find
+           # the actual release series
+           AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 3x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 3L)
+                                                      #error "not version 3"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=3x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+
+           AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 2x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 2L)
+                                                      #error "not version 2"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=2x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+
+           AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 1x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 1L)
+                                                      #error "not version 1"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=1x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+
+           AS_IF([test "x$opal_external_pmix_version" = "x"],
+                 [AC_MSG_WARN([External PMIx support requested, but version])
+                  AC_MSG_WARN([information of the external lib could not])
+                  AC_MSG_WARN([be detected])
+                  AC_MSG_ERROR([cannot continue])])
+
+           CPPFLAGS=$opal_external_pmix_save_CPPFLAGS
+           LDFLAGS=$opal_external_pmix_save_LDFLAGS
+           LIBS=$opal_external_pmix_save_LIBS
+
+           opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
+           opal_external_pmix_LDFLAGS=-L$pmix_ext_install_dir/lib
+           opal_external_pmix_LIBS=-lpmix
+           opal_external_pmix_happy=yes])
+
     OPAL_VAR_SCOPE_POP
 ])

--- a/config/opal_check_withdir.m4
+++ b/config/opal_check_withdir.m4
@@ -1,0 +1,38 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2006      Los Alamos National Security, LLC.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2008-2009 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# OPAL_CHECK_WITHDIR(with_option_name, dir_value, file_in_dir)
+# ----------------------------------------------------
+AC_DEFUN([OPAL_CHECK_WITHDIR],[
+    AC_MSG_CHECKING([--with-$1 value])
+    AS_IF([test "$2" = "yes" || test "$2" = "no" || test "x$2" = "x"],
+          [AC_MSG_RESULT([simple ok (unspecified)])],
+          [AS_IF([test ! -d "$2"],
+                 [AC_MSG_RESULT([not found])
+                  AC_MSG_WARN([Directory $2 not found])
+                  AC_MSG_ERROR([Cannot continue])],
+                 [AS_IF([test "x`ls $2/$3 2> /dev/null`" = "x"],
+                        [AC_MSG_RESULT([not found])
+                         AC_MSG_WARN([Expected file $2/$3 not found])
+                         AC_MSG_ERROR([Cannot continue])],
+                        [AC_MSG_RESULT([sanity check ok ($2)])]
+                       )
+                 ]
+                )
+          ]
+         )
+])dnl

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -6,18 +6,21 @@ dnl                         Corporation.  All rights reserved.
 dnl Copyright (c) 2004-2005 The University of Tennessee and The University
 dnl                         of Tennessee Research Foundation.  All rights
 dnl                         reserved.
-dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart, 
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2009      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
 dnl
 dnl $COPYRIGHT$
-dnl 
+dnl
 dnl Additional copyrights may follow
-dnl 
+dnl
 dnl $HEADER$
 dnl
 dnl Portions of this file derived from GASNet v1.12 (see "GASNet"
@@ -28,7 +31,7 @@ dnl IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
 dnl DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
 dnl OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
 dnl CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-dnl 
+dnl
 dnl THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
 dnl INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
 dnl AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
@@ -42,36 +45,49 @@ AC_DEFUN([OPAL_CONFIGURE_SETUP],[
 # of arugments here because of the m4 substitution.  So we have to set
 # special variable names before invoking the function.  :-\
 
-ompi_show_title() {
+opal_show_title() {
   cat <<EOF
 
 ============================================================================
 == ${1}
 ============================================================================
 EOF
+  OPAL_LOG_MSG([=== ${1}], 1)
 }
 
 
-ompi_show_subtitle() {
+opal_show_subtitle() {
   cat <<EOF
 
 *** ${1}
 EOF
+  OPAL_LOG_MSG([*** ${1}], 1)
 }
 
 
-ompi_show_subsubtitle() {
+opal_show_subsubtitle() {
   cat <<EOF
 
 +++ ${1}
 EOF
+  OPAL_LOG_MSG([+++ ${1}], 1)
 }
 
-ompi_show_subsubsubtitle() {
+opal_show_subsubsubtitle() {
   cat <<EOF
 
 --- ${1}
 EOF
+  OPAL_LOG_MSG([--- ${1}], 1)
+}
+
+opal_show_verbose() {
+  if test "$V" = "1"; then
+      cat <<EOF
++++ VERBOSE: ${1}
+EOF
+      OPAL_LOG_MSG([--- ${1}], 1)
+  fi
 }
 
 #
@@ -82,8 +98,10 @@ OPAL_CONFIGURE_USER="`whoami`"
 OPAL_CONFIGURE_HOST="`hostname | head -n 1`"
 OPAL_CONFIGURE_DATE="`date`"
 
+OPAL_LIBNL_SANITY_INIT
+
 #
-# Save these details so that they can be used in ompi_info later
+# Save these details so that they can be used in opal_info later
 #
 AC_SUBST(OPAL_CONFIGURE_USER)
 AC_SUBST(OPAL_CONFIGURE_HOST)
@@ -110,19 +128,19 @@ CLEANFILES="*~ .\#*"
 AC_SUBST(CLEANFILES)
 
 #
-# See if we can find an old installation of OMPI to overwrite
+# See if we can find an old installation of OPAL to overwrite
 #
 
-# Stupid autoconf 2.54 has a bug in AC_PREFIX_PROGRAM -- if ompi_clean
+# Stupid autoconf 2.54 has a bug in AC_PREFIX_PROGRAM -- if opal_clean
 # is not found in the path and the user did not specify --prefix,
 # we'll get a $prefix of "."
 
-ompi_prefix_save="$prefix"
-AC_PREFIX_PROGRAM(ompi_clean)
+opal_prefix_save="$prefix"
+AC_PREFIX_PROGRAM(opal_clean)
 if test "$prefix" = "."; then
-    prefix="$ompi_prefix_save"
+    prefix="$opal_prefix_save"
 fi
-unset ompi_prefix_save
+unset opal_prefix_save
 
 #
 # Basic sanity checking; we can't install to a relative path
@@ -131,33 +149,21 @@ unset ompi_prefix_save
 case "$prefix" in
   /*/bin)
     prefix="`dirname $prefix`"
-    echo installing to directory \"$prefix\" 
+    echo installing to directory \"$prefix\"
     ;;
-  /*) 
-    echo installing to directory \"$prefix\" 
+  /*)
+    echo installing to directory \"$prefix\"
     ;;
   NONE)
-    echo installing to directory \"$ac_default_prefix\" 
+    echo installing to directory \"$ac_default_prefix\"
     ;;
   @<:@a-zA-Z@:>@:*)
-    echo installing to directory \"$prefix\" 
+    echo installing to directory \"$prefix\"
     ;;
-  *) 
-    AC_MSG_ERROR(prefix "$prefix" must be an absolute directory path) 
+  *)
+    AC_MSG_ERROR(prefix "$prefix" must be an absolute directory path)
     ;;
 esac
-
-# Allow the --enable-dist flag to be passed in
-
-AC_ARG_ENABLE(dist, 
-    AC_HELP_STRING([--enable-dist],
-		   [guarantee that that the "dist" make target will be functional, although may not guarantee that any other make target will be functional.]),
-    OPAL_WANT_DIST=yes, OPAL_WANT_DIST=no)
-
-if test "$OPAL_WANT_DIST" = "yes"; then
-    AC_MSG_WARN([Configuring in 'make dist' mode])
-    AC_MSG_WARN([Most make targets may be non-functional!])
-fi
 
 # BEGIN: Derived from GASNet
 
@@ -211,7 +217,7 @@ dnl #######################################################################
 
 AC_DEFUN([OPAL_LOG_FILE],[
 # 1 is the filename
-if test -n "$1" -a -f "$1"; then
+if test -n "$1" && test -f "$1"; then
     cat $1 >&5
 fi])dnl
 
@@ -225,13 +231,13 @@ AC_DEFUN([OPAL_LOG_COMMAND],[
 # 3 is actions to do if fail
 echo "configure:__oline__: $1" >&5
 $1 1>&5 2>&1
-ompi_status=$?
-OPAL_LOG_MSG([\$? = $ompi_status], 1)
-if test "$ompi_status" = "0"; then
-    unset ompi_status
+opal_status=$?
+OPAL_LOG_MSG([\$? = $opal_status], 1)
+if test "$opal_status" = "0"; then
+    unset opal_status
     $2
 else
-    unset ompi_status
+    unset opal_status
     $3
 fi])dnl
 
@@ -241,84 +247,229 @@ dnl #######################################################################
 
 AC_DEFUN([OPAL_UNIQ],[
 # 1 is the variable name to be uniq-ized
-ompi_name=$1
+opal_name=$1
 
 # Go through each item in the variable and only keep the unique ones
 
-ompi_count=0
+opal_count=0
 for val in ${$1}; do
-    ompi_done=0
-    ompi_i=1
-    ompi_found=0
+    opal_done=0
+    opal_i=1
+    opal_found=0
 
     # Loop over every token we've seen so far
 
-    ompi_done="`expr $ompi_i \> $ompi_count`"
-    while test "$ompi_found" = "0" -a "$ompi_done" = "0"; do
+    opal_done="`expr $opal_i \> $opal_count`"
+    while test "$opal_found" = "0" && test "$opal_done" = "0"; do
 
 	# Have we seen this token already?  Prefix the comparison with
 	# "x" so that "-Lfoo" values won't be cause an error.
 
-	ompi_eval="expr x$val = x\$ompi_array_$ompi_i"
-	ompi_found=`eval $ompi_eval`
+	opal_eval="expr x$val = x\$opal_array_$opal_i"
+	opal_found=`eval $opal_eval`
 
 	# Check the ending condition
 
-	ompi_done="`expr $ompi_i \>= $ompi_count`"
+	opal_done="`expr $opal_i \>= $opal_count`"
 
 	# Increment the counter
 
-	ompi_i="`expr $ompi_i + 1`"
+	opal_i="`expr $opal_i + 1`"
     done
-
-    # Check for special cases where we do want to allow repeated
-    # arguments (per
-    # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php).
-
-    case $val in
-    -Xclang)  
-            ompi_found=0 
-            ompi_i=`expr $ompi_count + 1`
-            ;;
-    esac
 
     # If we didn't find the token, add it to the "array"
 
-    if test "$ompi_found" = "0"; then
-	ompi_eval="ompi_array_$ompi_i=$val"
-	eval $ompi_eval
-	ompi_count="`expr $ompi_count + 1`"
+    if test "$opal_found" = "0"; then
+	opal_eval="opal_array_$opal_i=$val"
+	eval $opal_eval
+	opal_count="`expr $opal_count + 1`"
     else
-	ompi_i="`expr $ompi_i - 1`"
+	opal_i="`expr $opal_i - 1`"
     fi
 done
 
 # Take all the items in the "array" and assemble them back into a
 # single variable
 
-ompi_i=1
-ompi_done="`expr $ompi_i \> $ompi_count`"
-ompi_newval=
-while test "$ompi_done" = "0"; do
-    ompi_eval="ompi_newval=\"$ompi_newval \$ompi_array_$ompi_i\""
-    eval $ompi_eval
+opal_i=1
+opal_done="`expr $opal_i \> $opal_count`"
+opal_newval=
+while test "$opal_done" = "0"; do
+    opal_eval="opal_newval=\"$opal_newval \$opal_array_$opal_i\""
+    eval $opal_eval
 
-    ompi_eval="unset ompi_array_$ompi_i"
-    eval $ompi_eval
+    opal_eval="unset opal_array_$opal_i"
+    eval $opal_eval
 
-    ompi_done="`expr $ompi_i \>= $ompi_count`"
-    ompi_i="`expr $ompi_i + 1`"
+    opal_done="`expr $opal_i \>= $opal_count`"
+    opal_i="`expr $opal_i + 1`"
 done
 
 # Done; do the assignment
 
-ompi_newval="`echo $ompi_newval`"
-ompi_eval="$ompi_name=\"$ompi_newval\""
-eval $ompi_eval
+opal_newval="`echo $opal_newval`"
+opal_eval="$opal_name=\"$opal_newval\""
+eval $opal_eval
 
 # Clean up
 
-unset ompi_name ompi_i ompi_done ompi_newval ompi_eval ompi_count])dnl
+unset opal_name opal_i opal_done opal_newval opal_eval opal_count])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# OPAL_APPEND_UNIQ(variable, new_argument)
+# ----------------------------------------
+# Append new_argument to variable if not already in variable.  This assumes a
+# space seperated list.
+#
+# This could probably be made more efficient :(.
+AC_DEFUN([OPAL_APPEND_UNIQ], [
+for arg in $2; do
+    opal_found=0;
+    for val in ${$1}; do
+        if test "x$val" = "x$arg" ; then
+            opal_found=1
+            break
+        fi
+    done
+    if test "$opal_found" = "0" ; then
+        if test -z "$$1"; then
+            $1="$arg"
+        else
+            $1="$$1 $arg"
+        fi
+    fi
+done
+unset opal_found
+])
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Remove all duplicate -I, -L, and -l flags from the variable named $1
+AC_DEFUN([OPAL_FLAGS_UNIQ],[
+    # 1 is the variable name to be uniq-ized
+    opal_name=$1
+
+    # Go through each item in the variable and only keep the unique ones
+
+    opal_count=0
+    for val in ${$1}; do
+        opal_done=0
+        opal_i=1
+        opal_found=0
+
+        # Loop over every token we've seen so far
+
+        opal_done="`expr $opal_i \> $opal_count`"
+        while test "$opal_found" = "0" && test "$opal_done" = "0"; do
+
+            # Have we seen this token already?  Prefix the comparison
+            # with "x" so that "-Lfoo" values won't be cause an error.
+
+	    opal_eval="expr x$val = x\$opal_array_$opal_i"
+	    opal_found=`eval $opal_eval`
+
+            # Check the ending condition
+
+	    opal_done="`expr $opal_i \>= $opal_count`"
+
+            # Increment the counter
+
+	    opal_i="`expr $opal_i + 1`"
+        done
+
+        # Check for special cases where we do want to allow repeated
+        # arguments (per
+        # http://www.open-mpi.org/community/lists/devel/2012/08/11362.php
+        # and
+        # https://github.com/open-mpi/ompi/issues/324).
+
+        case $val in
+        -Xclang)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        -framework)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        --param)
+                opal_found=0
+                opal_i=`expr $opal_count + 1`
+                ;;
+        esac
+
+        # If we didn't find the token, add it to the "array"
+
+        if test "$opal_found" = "0"; then
+	    opal_eval="opal_array_$opal_i=$val"
+	    eval $opal_eval
+	    opal_count="`expr $opal_count + 1`"
+        else
+	    opal_i="`expr $opal_i - 1`"
+        fi
+    done
+
+    # Take all the items in the "array" and assemble them back into a
+    # single variable
+
+    opal_i=1
+    opal_done="`expr $opal_i \> $opal_count`"
+    opal_newval=
+    while test "$opal_done" = "0"; do
+        opal_eval="opal_newval=\"$opal_newval \$opal_array_$opal_i\""
+        eval $opal_eval
+
+        opal_eval="unset opal_array_$opal_i"
+        eval $opal_eval
+
+        opal_done="`expr $opal_i \>= $opal_count`"
+        opal_i="`expr $opal_i + 1`"
+    done
+
+    # Done; do the assignment
+
+    opal_newval="`echo $opal_newval`"
+    opal_eval="$opal_name=\"$opal_newval\""
+    eval $opal_eval
+
+    # Clean up
+
+    unset opal_name opal_i opal_done opal_newval opal_eval opal_count
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# OPAL_FLAGS_APPEND_UNIQ(variable, new_argument)
+# ----------------------------------------------
+# Append new_argument to variable if:
+#
+# - the argument does not begin with -I, -L, or -l, or
+# - the argument begins with -I, -L, or -l, and it's not already in variable
+#
+# This macro assumes a space seperated list.
+AC_DEFUN([OPAL_FLAGS_APPEND_UNIQ], [
+    OPAL_VAR_SCOPE_PUSH([opal_tmp opal_append])
+
+    for arg in $2; do
+        opal_tmp=`echo $arg | cut -c1-2`
+        opal_append=1
+        AS_IF([test "$opal_tmp" = "-I" || test "$opal_tmp" = "-L" || test "$opal_tmp" = "-l"],
+              [for val in ${$1}; do
+                   AS_IF([test "x$val" = "x$arg"], [opal_append=0])
+               done])
+        AS_IF([test "$opal_append" = "1"],
+              [AS_IF([test -z "$$1"], [$1=$arg], [$1="$$1 $arg"])])
+    done
+
+    OPAL_VAR_SCOPE_POP
+])
 
 dnl #######################################################################
 dnl #######################################################################
@@ -334,15 +485,15 @@ AC_DEFUN([OPAL_WHICH],[
 # 1 is the variable name to do "which" on
 # 2 is the variable name to assign the return value to
 
-OPAL_VAR_SCOPE_PUSH([ompi_prog ompi_file ompi_dir ompi_sentinel])
+OPAL_VAR_SCOPE_PUSH([opal_prog opal_file opal_dir opal_sentinel])
 
-ompi_prog=$1
+opal_prog=$1
 
 IFS_SAVE=$IFS
 IFS="$PATH_SEPARATOR"
-for ompi_dir in $PATH; do
-    if test -x "$ompi_dir/$ompi_prog"; then
-        $2="$ompi_dir/$ompi_prog"
+for opal_dir in $PATH; do
+    if test -x "$opal_dir/$opal_prog"; then
+        $2="$opal_dir/$opal_prog"
         break
     fi
 done
@@ -355,27 +506,27 @@ dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
-# Declare some variables; use OMPI_VAR_SCOPE_END to ensure that they
+# Declare some variables; use OPAL_VAR_SCOPE_END to ensure that they
 # are cleaned up / undefined.
 AC_DEFUN([OPAL_VAR_SCOPE_PUSH],[
 
     # Is the private index set?  If not, set it.
-    if test "x$ompi_scope_index" = "x"; then
-        ompi_scope_index=1
+    if test "x$opal_scope_index" = "x"; then
+        opal_scope_index=1
     fi
 
     # First, check to see if any of these variables are already set.
     # This is a simple sanity check to ensure we're not already
     # overwriting pre-existing variables (that have a non-empty
     # value).  It's not a perfect check, but at least it's something.
-    for ompi_var in $1; do
-        ompi_str="ompi_str=\"\$$ompi_var\""
-        eval $ompi_str
+    for opal_var in $1; do
+        opal_str="opal_str=\"\$$opal_var\""
+        eval $opal_str
 
-        if test "x$ompi_str" != "x"; then
+        if test "x$opal_str" != "x"; then
             AC_MSG_WARN([Found configure shell variable clash!])
-            AC_MSG_WARN([[OPAL_VAR_SCOPE_PUSH] called on "$ompi_var",])
-            AC_MSG_WARN([but it is already defined with value "$ompi_str"])
+            AC_MSG_WARN([[OPAL_VAR_SCOPE_PUSH] called on "$opal_var",])
+            AC_MSG_WARN([but it is already defined with value "$opal_str"])
             AC_MSG_WARN([This usually indicates an error in configure.])
             AC_MSG_ERROR([Cannot continue])
         fi
@@ -383,32 +534,32 @@ AC_DEFUN([OPAL_VAR_SCOPE_PUSH],[
 
     # Ok, we passed the simple sanity check.  Save all these names so
     # that we can unset them at the end of the scope.
-    ompi_str="ompi_scope_$ompi_scope_index=\"$1\""
-    eval $ompi_str
-    unset ompi_str
+    opal_str="opal_scope_$opal_scope_index=\"$1\""
+    eval $opal_str
+    unset opal_str
 
-    env | grep ompi_scope
-    ompi_scope_index=`expr $ompi_scope_index + 1`
+    env | grep opal_scope
+    opal_scope_index=`expr $opal_scope_index + 1`
 ])dnl
 
 # Unset a bunch of variables that were previously set
 AC_DEFUN([OPAL_VAR_SCOPE_POP],[
     # Unwind the index
-    ompi_scope_index=`expr $ompi_scope_index - 1`
-    ompi_scope_test=`expr $ompi_scope_index \> 0`
-    if test "$ompi_scope_test" = "0"; then
-        AC_MSG_WARN([[OPAL_VAR_SCOPE_POP] popped too many OMPI configure scopes.])
+    opal_scope_index=`expr $opal_scope_index - 1`
+    opal_scope_test=`expr $opal_scope_index \> 0`
+    if test "$opal_scope_test" = "0"; then
+        AC_MSG_WARN([[OPAL_VAR_SCOPE_POP] popped too many OPAL configure scopes.])
         AC_MSG_WARN([This usually indicates an error in configure.])
         AC_MSG_ERROR([Cannot continue])
     fi
 
     # Get the variable names from that index
-    ompi_str="ompi_str=\"\$ompi_scope_$ompi_scope_index\""
-    eval $ompi_str
+    opal_str="opal_str=\"\$opal_scope_$opal_scope_index\""
+    eval $opal_str
 
     # Iterate over all the variables and unset them all
-    for ompi_var in $ompi_str; do
-        unset $ompi_var
+    for opal_var in $opal_str; do
+        unset $opal_var
     done
 ])dnl
 
@@ -429,11 +580,11 @@ AC_DEFUN([OPAL_WITH_OPTION_MIN_MAX_VALUE], [
     AC_ARG_WITH([max-]m4_translit($1, [_], [-]),
         AC_HELP_STRING([--with-max-]m4_translit($1, [_], [-])[=VALUE],
                        [maximum length of ]m4_translit($1, [_], [ ])[s.  VALUE argument has to be specified (default: [$2]).]))
-    if test ! -z "$with_max_[$1]" -a "$with_max_[$1]" != "no" ; then
+    if test ! -z "$with_max_[$1]" && test "$with_max_[$1]" != "no" ; then
         # Ensure it's a number (hopefully an integer!), and >0
         expr $with_max_[$1] + 1 > /dev/null 2> /dev/null
         AS_IF([test "$?" != "0"], [happy=0],
-              [AS_IF([test $with_max_[$1] -ge $3 -a $with_max_[$1] -le $4],
+              [AS_IF([test $with_max_[$1] -ge $3 && test $with_max_[$1] -le $4],
                      [happy=1], [happy=0])])
 
         # If badness in the above tests, bail
@@ -448,4 +599,63 @@ AC_DEFUN([OPAL_WITH_OPTION_MIN_MAX_VALUE], [
                        [Maximum length of ]m4_translit($1, [_], [ ])[s (default is $2)])
     [OPAL_MAX_]m4_toupper($1)=$max_value
     AC_SUBST([OPAL_MAX_]m4_toupper($1))
+])dnl
+
+dnl #######################################################################
+dnl #######################################################################
+dnl #######################################################################
+
+# Usage: OPAL_COMPUTE_MAX_VALUE(number_bytes, variable_to_set, action if overflow)
+# Compute maximum value of datatype of
+# number_bytes, setting the result in the second argument.  Assumes a
+# signed datatype.
+AC_DEFUN([OPAL_COMPUTE_MAX_VALUE], [
+    # This is more complicated than it really should be.  But some
+    # expr implementations (OpenBSD) have an expr with a max value of
+    # 2^31 - 1, and we sometimes want to compute the max value of a
+    # type as big or bigger than that...
+    opal_num_bits=`expr $1 \* 8 - 1`
+    newval=1
+    value=1
+    overflow=0
+
+    while test $opal_num_bits -ne 0 ; do
+        newval=`expr $value \* 2`
+        if test 0 -eq `expr $newval \< 0` ; then
+            # if the new value is not negative, next iteration...
+            value=$newval
+            opal_num_bits=`expr $opal_num_bits - 1`
+            # if this was the last iteration, subtract 1 (as signed
+            # max positive is 2^num_bits - 1).  Do this here instead
+            # of outside of the while loop because we might have
+            # already subtracted 1 by then if we're trying to find the
+            # max value of the same datatype expr uses as it's
+            # internal representation (ie, if we hit the else
+            # below...)
+            if test 0 -eq $opal_num_bits ; then
+                value=`expr $value - 1`
+            fi
+        else
+            # if the new value is negative, we've over flowed.  First,
+            # try adding value - 1 instead of value (see if we can get
+            # to positive max of expr)
+            newval=`expr $value - 1 + $value`
+            if test 0 -eq `expr $newval \< 0` ; then
+                value=$newval
+                # Still positive, this is as high as we can go.  If
+                # opal_num_bits is 1, we didn't actually overflow.
+                # Otherwise, we overflowed.
+                if test 1 -ne $opal_num_bits ; then
+                    overflow=1
+                fi
+            else
+                # stil negative.  Time to give up.
+                overflow=1
+            fi
+            opal_num_bits=0
+        fi
+    done
+
+    AS_VAR_SET([$2], [$value])
+    AS_IF([test $overflow -ne 0], [$3])
 ])dnl

--- a/config/opal_setup_wrappers.m4
+++ b/config/opal_setup_wrappers.m4
@@ -1,0 +1,560 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2006-2010 Oracle and/or its affiliates.  All rights reserved.
+dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2015-2016 Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2016      IBM Corporation.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# OPAL_WRAPPER_FLAGS_ADD(variable, new_argument)
+# ----------------------------------------------
+# Add new_argument to the list of arguments for variable in the
+# wrapper compilers, if it's not already there.  For example:
+#   OPAL_WRAPPER_FLAGS_ADD(CFLAGS, "-pthread")
+# will add -pthread to the list of CFLAGS the wrappers use when invoked.
+#
+# This macro MAY NOT be invoked from configure macros for MCA components.
+# See the comment in SETUP_WRAPPER_INIT (below) for more information.
+AC_DEFUN([OPAL_WRAPPER_FLAGS_ADD], [
+    m4_ifdef([mca_component_configure_active],
+        [m4_fatal([OPAL_WRAPPER_FLAGS_ADD can not be called from a component configure])])
+    m4_if([$1], [CPPFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_cppflags], [$2])],
+          [$1], [CFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_cflags], [$2])],
+          [$1], [CXXFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_cxxflags], [$2])],
+          [$1], [FCFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_fcflags], [$2])],
+          [$1], [LDFLAGS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_ldflags], [$2])],
+          [$1], [LIBS], [OPAL_FLAGS_APPEND_UNIQ([wrapper_extra_libs], [$2])],
+          [m4_fatal([Unknown wrapper flag type $1])])
+])
+
+
+# OPAL_SETUP_WRAPPER_INIT()
+# -------------------------
+# Setup wrapper compiler configuration information.  Should be called early to
+# prevent lots of calculations and then an abort for a silly user typo.  This
+# macro works in pair with OPAL_SETUP_WRAPPER_FINAL, which should be called
+# almost at the end of configure (after the last call to OPAL_WRAPPER_FLAGS_ADD
+# and after the MCA system has been setup).
+#
+# The wrapper compiler arguments are a little fragile and should NOT
+# be edited by configure directly.  Instead, main configure should use
+# OPAL_WRAPPER_FLAGS_ADD.
+#
+# When building statically, the MCA system will add
+# <framework>_<component>_WRAPPER_EXTRA_{LDFLAGS, LIBS} if set and try
+# to add <framework>_<component>_{LDFLAGS, LIBS} (if not an external
+# configure) to the wrapper LDFLAGS and LIBS.  Any arguments in
+# <framework>_<component>_WRAPPER_EXTRA_CPPFLAGS are passed to the
+# wrapper compilers IF AND ONLY IF the framework was a STOP_AT_FIRST
+# framework, the component is a static component, and devel headers
+# are installed.  Note that MCA components are ONLY allowed to
+# (indirectly) influence the wrapper CPPFLAGS, LDFLAGS, and LIBS.
+# That is, a component may not influence CFLAGS, CXXFLAGS, or FCFLAGS.
+#
+# Notes:
+#   * Keep user flags seperate as 1) they should have no influence
+#     over build and 2) they don't go through the uniqification we do
+#     with the other wrapper compiler options
+#   * While the user (the person who runs configure) is allowed to set
+#     <flag>_prefix, configure is not.  There's no known use case for
+#     doing so, and we'd like to force the issue.
+AC_DEFUN([OPAL_SETUP_WRAPPER_INIT],[
+    AC_ARG_WITH([wrapper-cflags],
+                [AC_HELP_STRING([--with-wrapper-cflags],
+                                [Extra flags to add to CFLAGS when using mpicc])])
+    AS_IF([test "$with_wrapper_cflags" = "yes" || test "$with_wrapper_cflags" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-cflags must have an argument.])])
+
+    AC_ARG_WITH([wrapper-cflags-prefix],
+                [AC_HELP_STRING([--with-wrapper-cflags-prefix],
+                                [Extra flags (before user flags) to add to CFLAGS when using mpicc])])
+    AS_IF([test "$with_wrapper_cflags_prefix" = "yes" || test "$with_wrapper_cflags_prefix" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-cflags-prefix must have an argument.])])
+
+    AC_ARG_WITH([wrapper-cxxflags],
+        [AC_HELP_STRING([--with-wrapper-cxxflags],
+                        [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
+    AS_IF([test "$with_wrapper_cxxflags" = "yes" || test "$with_wrapper_cxxflags" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-cxxflags must have an argument.])])
+
+    AC_ARG_WITH([wrapper-cxxflags-prefix],
+        [AC_HELP_STRING([--with-wrapper-cxxflags-prefix],
+                        [Extra flags to add to CXXFLAGS when using mpiCC/mpic++])])
+    AS_IF([test "$with_wrapper_cxxflags_prefix" = "yes" || test "$with_wrapper_cxxflags_prefix" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-cxxflags-prefix must have an argument.])])
+
+    m4_ifdef([project_ompi], [
+            AC_ARG_WITH([wrapper-fcflags],
+                [AC_HELP_STRING([--with-wrapper-fcflags],
+                        [Extra flags to add to FCFLAGS when using mpifort])])
+            AS_IF([test "$with_wrapper_fcflags" = "yes" || test "$with_wrapper_fcflags" = "no"],
+                [AC_MSG_ERROR([--with-wrapper-fcflags must have an argument.])])
+
+            AC_ARG_WITH([wrapper-fcflags-prefix],
+                [AC_HELP_STRING([--with-wrapper-fcflags-prefix],
+                        [Extra flags (before user flags) to add to FCFLAGS when using mpifort])])
+            AS_IF([test "$with_wrapper_fcflags_prefix" = "yes" || test "$with_wrapper_fcflags_prefix" = "no"],
+                [AC_MSG_ERROR([--with-wrapper-fcflags-prefix must have an argument.])])])
+
+    AC_ARG_WITH([wrapper-ldflags],
+                [AC_HELP_STRING([--with-wrapper-ldflags],
+                                [Extra flags to add to LDFLAGS when using wrapper compilers])])
+    AS_IF([test "$with_wrapper_ldflags" = "yes" || test "$with_wrapper_ldflags" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-ldflags must have an argument.])])
+
+    AC_ARG_WITH([wrapper-libs],
+                [AC_HELP_STRING([--with-wrapper-libs],
+                                [Extra flags to add to LIBS when using wrapper compilers])])
+    AS_IF([test "$with_wrapper_libs" = "yes" || test "$with_wrapper_libs" = "no"],
+          [AC_MSG_ERROR([--with-wrapper-libs must have an argument.])])
+
+    AC_MSG_CHECKING([if want wrapper compiler rpath support])
+    AC_ARG_ENABLE([wrapper-rpath],
+                  [AS_HELP_STRING([--enable-wrapper-rpath],
+                  [enable rpath/runpath support in the wrapper compilers (default=yes)])])
+    AS_IF([test "$enable_wrapper_rpath" != "no"], [enable_wrapper_rpath=yes])
+    AC_MSG_RESULT([$enable_wrapper_rpath])
+])
+
+# Check to see whether the linker supports DT_RPATH.  We'll need to
+# use config.rpath to find the flags that it needs, if it does (see
+# comments in config.rpath for an explanation of where it came from).
+AC_DEFUN([OPAL_SETUP_RPATH],[
+    OPAL_VAR_SCOPE_PUSH([rpath_libdir_save rpath_script rpath_outfile])
+    AC_MSG_CHECKING([if linker supports RPATH])
+    # Output goes into globally-visible $rpath_args.  Run this in a
+    # sub-process so that we don't pollute the current process
+    # environment.
+    rpath_script=conftest.$$.sh
+    rpath_outfile=conftest.$$.out
+    rm -f $rpath_script $rpath_outfile
+    cat > $rpath_script <<EOF
+#!/bin/sh
+
+# Slurp in the libtool config into my environment
+
+# Apparently, "libtoool --config" calls "exit", so we can't source it
+# (because if script A sources script B, and B calls "exit", then both
+# B and A will exit).  Instead, we have to send the output to a file
+# and then source that.
+$OPAL_TOP_BUILDDIR/libtool --config > $rpath_outfile
+
+chmod +x $rpath_outfile
+. ./$rpath_outfile
+rm -f $rpath_outfile
+
+# Evaluate \$hardcode_libdir_flag_spec, and substitute in LIBDIR for \$libdir
+libdir=LIBDIR
+flags="\`eval echo \$hardcode_libdir_flag_spec\`"
+echo \$flags
+
+# Done
+exit 0
+EOF
+    chmod +x $rpath_script
+    rpath_args=`./$rpath_script`
+    rm -f $rpath_script
+
+    AS_IF([test -n "$rpath_args"],
+          [WRAPPER_RPATH_SUPPORT=rpath
+           cat > $rpath_script <<EOF
+#!/bin/sh
+
+# Slurp in the libtool config into my environment
+
+# Apparently, "libtoool --config" calls "exit", so we can't source it
+# (because if script A sources script B, and B calls "exit", then both
+# B and A will exit).  Instead, we have to send the output to a file
+# and then source that.
+$OPAL_TOP_BUILDDIR/libtool --tag=FC --config > $rpath_outfile
+
+chmod +x $rpath_outfile
+. ./$rpath_outfile
+rm -f $rpath_outfile
+
+# Evaluate \$hardcode_libdir_flag_spec, and substitute in LIBDIR for \$libdir
+libdir=LIBDIR
+flags="\`eval echo \$hardcode_libdir_flag_spec\`"
+echo \$flags
+
+# Done
+exit 0
+EOF
+           chmod +x $rpath_script
+           rpath_fc_args=`./$rpath_script`
+           rm -f $rpath_script
+           AC_MSG_RESULT([yes ($rpath_args + $rpath_fc_args)])],
+          [WRAPPER_RPATH_SUPPORT=unnecessary
+           AC_MSG_RESULT([yes (no extra flags needed)])])
+
+    OPAL_VAR_SCOPE_POP
+
+    # If we found RPATH support, check for RUNPATH support, too
+    AS_IF([test "$WRAPPER_RPATH_SUPPORT" = "rpath"],
+          [OPAL_SETUP_RUNPATH])
+])
+
+# Check to see if the linker supports the DT_RUNPATH flags via
+# --enable-new-dtags (a GNU ld-specific option).  These flags are more
+# social than DT_RPATH -- they can be overridden by LD_LIBRARY_PATH
+# (where a regular DT_RPATH cannot).
+#
+# If DT_RUNPATH is supported, then we'll use *both* the RPATH and
+# RUNPATH flags in the LDFLAGS.
+AC_DEFUN([OPAL_SETUP_RUNPATH],[
+    OPAL_VAR_SCOPE_PUSH([LDFLAGS_save rpath_script rpath_outfile wl_fc])
+
+    AC_MSG_CHECKING([if linker supports RUNPATH])
+    # Set the output in $runpath_args
+    runpath_args=
+    LDFLAGS_save=$LDFLAGS
+    LDFLAGS="$LDFLAGS -Wl,--enable-new-dtags"
+    AC_LANG_PUSH([C])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([], [return 7;])],
+                   [WRAPPER_RPATH_SUPPORT=runpath
+                    runpath_args="-Wl,--enable-new-dtags"
+                    AC_MSG_RESULT([yes (-Wl,--enable-new-dtags)])],
+                   [AC_MSG_RESULT([no])])
+    AC_LANG_POP([C])
+m4_ifdef([project_ompi],[
+    # Output goes into globally-visible $rpath_args.  Run this in a
+    # sub-process so that we don't pollute the current process
+    # environment.
+    rpath_script=conftest.$$.sh
+    rpath_outfile=conftest.$$.out
+    rm -f $rpath_script $rpath_outfile
+    cat > $rpath_script <<EOF
+#!/bin/sh
+
+# Slurp in the libtool config into my environment
+
+# Apparently, "libtoool --config" calls "exit", so we can't source it
+# (because if script A sources script B, and B calls "exit", then both
+# B and A will exit).  Instead, we have to send the output to a file
+# and then source that.
+$OPAL_TOP_BUILDDIR/libtool --tag=FC --config > $rpath_outfile
+
+chmod +x $rpath_outfile
+. ./$rpath_outfile
+rm -f $rpath_outfile
+
+wl="\`eval echo \$wl\`"
+echo \$wl
+
+# Done
+exit 0
+EOF
+    chmod +x $rpath_script
+    wl_fc=`./$rpath_script`
+    rm -f $rpath_script
+
+    LDFLAGS="$LDFLAGS_save ${wl_fc}--enable-new-dtags"
+    AC_LANG_PUSH([Fortran])
+    AC_LINK_IFELSE([AC_LANG_SOURCE([[program test
+end program]])],
+                   [runpath_fc_args="${wl_fc}--enable-new-dtags"],
+                   [runpath_fc_args=""])
+    AC_LANG_POP([Fortran])])
+    LDFLAGS=$LDFLAGS_save
+
+    OPAL_VAR_SCOPE_POP
+])
+
+# Called to find all -L arguments in the LDFLAGS and add in RPATH args
+# for each of them.  Then also add in an RPATH for @{libdir} (which
+# will be replaced by the wrapper compile to the installdir libdir at
+# runtime), and the RUNPATH args, if we have them.
+AC_DEFUN([RPATHIFY_LDFLAGS_INTERNAL],[
+    OPAL_VAR_SCOPE_PUSH([rpath_out rpath_dir rpath_tmp])
+
+    AS_IF([test "$enable_wrapper_rpath" = "yes" && test "$WRAPPER_RPATH_SUPPORT" != "disabled" && test "$WRAPPER_RPATH_SUPPORT" != "unnecessary"], [
+           rpath_out=""
+           for val in ${$1}; do
+               case $val in
+               -L*)
+                   rpath_dir=`echo $val | cut -c3-`
+                   rpath_tmp=`echo ${$2} | sed -e s@LIBDIR@$rpath_dir@`
+                   rpath_out="$rpath_out $rpath_tmp"
+                   ;;
+               esac
+           done
+
+           # Now add in the RPATH args for @{libdir}, and the RUNPATH args
+           rpath_tmp=`echo ${$2} | sed -e s/LIBDIR/@{libdir}/`
+           $1="${$1} $rpath_out $rpath_tmp ${$3}"
+          ])
+    OPAL_VAR_SCOPE_POP
+])
+
+AC_DEFUN([RPATHIFY_LDFLAGS],[RPATHIFY_LDFLAGS_INTERNAL([$1], [rpath_args], [runpath_args])])
+
+AC_DEFUN([RPATHIFY_FC_LDFLAGS],[RPATHIFY_LDFLAGS_INTERNAL([$1], [rpath_fc_args], [runpath_fc_args])])
+
+dnl
+dnl Avoid some repetitive code below
+dnl
+AC_DEFUN([_OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG],[
+    AC_MSG_CHECKING([for $1 pkg-config LDFLAGS])
+    $1_PKG_CONFIG_LDFLAGS=`echo "$$1_WRAPPER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
+    AC_SUBST([$1_PKG_CONFIG_LDFLAGS])
+    AC_MSG_RESULT([$$1_PKG_CONFIG_LDFLAGS])
+])
+
+
+# OPAL_SETUP_WRAPPER_FINAL()
+# ---------------------------
+AC_DEFUN([OPAL_SETUP_WRAPPER_FINAL],[
+
+    # Setup RPATH support, if desired
+    WRAPPER_RPATH_SUPPORT=disabled
+    AS_IF([test "$enable_wrapper_rpath" = "yes"],
+          [OPAL_SETUP_RPATH])
+    AS_IF([test "$enable_wrapper_rpath" = "yes" && test "$WRAPPER_RPATH_SUPPORT" = "disabled"],
+          [AC_MSG_WARN([RPATH support requested but not available])
+           AC_MSG_ERROR([Cannot continue])])
+
+    # Note that we have to setup <package>_PKG_CONFIG_LDFLAGS for the
+    # pkg-config files to parallel the
+    # <package>_WRAPPER_EXTRA_LDFLAGS.  This is because pkg-config
+    # will not understand the @{libdir} notation in
+    # *_WRAPPER_EXTRA_LDFLAGS; we have to translate it to ${libdir}.
+
+    # We now have all relevant flags.  Substitute them in everywhere.
+    m4_ifdef([project_opal], [
+       AC_MSG_CHECKING([for OPAL CPPFLAGS])
+       if test "$WANT_INSTALL_HEADERS" = "1" ; then
+           OPAL_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi'
+       fi
+       OPAL_WRAPPER_EXTRA_CPPFLAGS="$OPAL_WRAPPER_EXTRA_CPPFLAGS $opal_mca_wrapper_extra_cppflags $wrapper_extra_cppflags $with_wrapper_cppflags"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_CPPFLAGS])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_CPPFLAGS])
+
+       AC_MSG_CHECKING([for OPAL CFLAGS])
+       OPAL_WRAPPER_EXTRA_CFLAGS="$wrapper_extra_cflags $with_wrapper_cflags"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_CFLAGS])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_CFLAGS])
+
+       AC_MSG_CHECKING([for OPAL CFLAGS_PREFIX])
+       OPAL_WRAPPER_EXTRA_CFLAGS_PREFIX="$with_wrapper_cflags_prefix"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_CFLAGS_PREFIX])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_CFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for OPAL CXXFLAGS])
+       OPAL_WRAPPER_EXTRA_CXXFLAGS="$wrapper_extra_cxxflags $with_wrapper_cxxflags"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_CXXFLAGS])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_CXXFLAGS])
+
+       AC_MSG_CHECKING([for OPAL CXXFLAGS_PREFIX])
+       OPAL_WRAPPER_EXTRA_CXXFLAGS_PREFIX="$with_wrapper_cxxflags_prefix"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_CXXFLAGS_PREFIX])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_CXXFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for OPAL LDFLAGS])
+       OPAL_WRAPPER_EXTRA_LDFLAGS="$opal_mca_wrapper_extra_ldflags $wrapper_extra_ldflags $with_wrapper_ldflags"
+       RPATHIFY_LDFLAGS([OPAL_WRAPPER_EXTRA_LDFLAGS])
+       AC_SUBST([OPAL_WRAPPER_EXTRA_LDFLAGS])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([OPAL])
+
+       # wrapper_extra_libs doesn't really get populated until after the mca system runs
+       # since most of the libs come from libtool.  So this is the first time we can
+       # uniq them.  ROMIO in particular adds lots of things already in wrapper_extra_libs,
+       # and this cleans the duplication up a bunch.  Always add everything the user
+       # asked for, as they know better than us.
+       AC_MSG_CHECKING([for OPAL LIBS])
+       OPAL_WRAPPER_EXTRA_LIBS="$opal_mca_wrapper_extra_libs"
+       OPAL_FLAGS_APPEND_UNIQ([OPAL_WRAPPER_EXTRA_LIBS], [$wrapper_extra_libs])
+       OPAL_WRAPPER_EXTRA_LIBS="$OPAL_WRAPPER_EXTRA_LIBS $with_wrapper_libs"
+       AC_SUBST([OPAL_WRAPPER_EXTRA_LIBS])
+       AC_MSG_RESULT([$OPAL_WRAPPER_EXTRA_LIBS])
+    ])
+
+    m4_ifdef([project_orte], [
+       AC_MSG_CHECKING([for ORTE CPPFLAGS])
+       if test "$WANT_INSTALL_HEADERS" = "1" ; then
+           ORTE_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi'
+       fi
+       ORTE_WRAPPER_EXTRA_CPPFLAGS="$ORTE_WRAPPER_EXTRA_CPPFLAGS $orte_mca_wrapper_extra_cppflags $wrapper_extra_cppflags $with_wrapper_cppflags"
+       AC_SUBST([ORTE_WRAPPER_EXTRA_CPPFLAGS])
+       AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_CPPFLAGS])
+
+       AC_MSG_CHECKING([for ORTE CFLAGS])
+       ORTE_WRAPPER_EXTRA_CFLAGS="$wrapper_extra_cflags $with_wrapper_cflags"
+       AC_SUBST([ORTE_WRAPPER_EXTRA_CFLAGS])
+       AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_CFLAGS])
+
+       AC_MSG_CHECKING([for ORTE CFLAGS_PREFIX])
+       ORTE_WRAPPER_EXTRA_CFLAGS_PREFIX="$with_wrapper_cflags_prefix"
+       AC_SUBST([ORTE_WRAPPER_EXTRA_CFLAGS_PREFIX])
+       AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_CFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for ORTE LDFLAGS])
+       ORTE_WRAPPER_EXTRA_LDFLAGS="$orte_mca_wrapper_extra_ldflags $wrapper_extra_ldflags $with_wrapper_ldflags"
+       RPATHIFY_LDFLAGS([ORTE_WRAPPER_EXTRA_LDFLAGS])
+       AC_SUBST([ORTE_WRAPPER_EXTRA_LDFLAGS])
+       AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([ORTE])
+
+       AC_MSG_CHECKING([for ORTE LIBS])
+       ORTE_WRAPPER_EXTRA_LIBS="$orte_mca_wrapper_extra_libs"
+       OPAL_FLAGS_APPEND_UNIQ([ORTE_WRAPPER_EXTRA_LIBS], [$wrapper_extra_libs])
+       ORTE_WRAPPER_EXTRA_LIBS="$ORTE_WRAPPER_EXTRA_LIBS $with_wrapper_libs"
+       AC_SUBST([ORTE_WRAPPER_EXTRA_LIBS])
+       AC_MSG_RESULT([$ORTE_WRAPPER_EXTRA_LIBS])
+
+       m4_ifdef([project_ompi], [], [
+          # these are used by orte_info/ompi_info (yes, they are named poorly)
+          AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CFLAGS, "$ORTE_WRAPPER_EXTRA_CFLAGS",
+              [Additional CFLAGS to pass through the wrapper compilers])
+          AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CFLAGS_PREFIX, "$ORTE_WRAPPER_EXTRA_CFLAGS_PREFIX",
+              [Additional CFLAGS_PREFIX to pass through the wrapper compilers])
+          AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_LDFLAGS, "$ORTE_WRAPPER_EXTRA_LDFLAGS",
+              [Additional LDFLAGS to pass through the wrapper compilers])
+          AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_LIBS, "$ORTE_WRAPPER_EXTRA_LIBS",
+              [Additional LIBS to pass through the wrapper compilers])
+       ])
+    ])
+
+    m4_ifdef([project_ompi], [
+       AC_MSG_CHECKING([for OMPI CPPFLAGS])
+       if test "$WANT_INSTALL_HEADERS" = "1" ; then
+           OMPI_WRAPPER_EXTRA_CPPFLAGS='-I${includedir}/openmpi'
+       fi
+       OMPI_WRAPPER_EXTRA_CPPFLAGS="$OMPI_WRAPPER_EXTRA_CPPFLAGS $ompi_mca_wrapper_extra_cppflags $wrapper_extra_cppflags $with_wrapper_cppflags"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_CPPFLAGS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_CPPFLAGS])
+
+       AC_MSG_CHECKING([for OMPI CFLAGS])
+       OMPI_WRAPPER_EXTRA_CFLAGS="$wrapper_extra_cflags $with_wrapper_cflags"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_CFLAGS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_CFLAGS])
+
+       AC_MSG_CHECKING([for OMPI CFLAGS_PREFIX])
+       OMPI_WRAPPER_EXTRA_CFLAGS_PREFIX="$with_wrapper_cflags_prefix"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_CFLAGS_PREFIX])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_CFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for OMPI CXXFLAGS])
+       OMPI_WRAPPER_EXTRA_CXXFLAGS="$wrapper_extra_cxxflags $with_wrapper_cxxflags"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_CXXFLAGS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_CXXFLAGS])
+
+       AC_MSG_CHECKING([for OMPI CXXFLAGS_PREFIX])
+       OMPI_WRAPPER_EXTRA_CXXFLAGS_PREFIX="$with_wrapper_cxxflags_prefix"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_CXXFLAGS_PREFIX])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_CXXFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for OMPI FCFLAGS])
+       OMPI_WRAPPER_EXTRA_FCFLAGS="$wrapper_extra_fcflags $with_wrapper_fcflags"
+       if test "$OMPI_FC_MODULE_FLAG" != "" ; then
+           OMPI_WRAPPER_EXTRA_FCFLAGS="$OMPI_WRAPPER_EXTRA_FCFLAGS $OMPI_FC_MODULE_FLAG"'${libdir}'
+       fi
+       AC_SUBST([OMPI_WRAPPER_EXTRA_FCFLAGS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_FCFLAGS])
+
+       AC_MSG_CHECKING([for OMPI FCFLAGS_PREFIX])
+       OMPI_WRAPPER_EXTRA_FCFLAGS_PREFIX="$with_wrapper_fcflags_prefix"
+       AC_SUBST([OMPI_WRAPPER_EXTRA_FCFLAGS_PREFIX])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_FCFLAGS_PREFIX])
+
+       AC_MSG_CHECKING([for OMPI LDFLAGS])
+       OMPI_WRAPPER_EXTRA_LDFLAGS="$ompi_mca_wrapper_extra_ldflags $wrapper_extra_ldflags $with_wrapper_ldflags"
+       OMPI_WRAPPER_EXTRA_FC_LDFLAGS=$OMPI_WRAPPER_EXTRA_LDFLAGS
+       RPATHIFY_LDFLAGS([OMPI_WRAPPER_EXTRA_LDFLAGS])
+       AC_SUBST([OMPI_WRAPPER_EXTRA_LDFLAGS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_LDFLAGS])
+       RPATHIFY_FC_LDFLAGS([OMPI_WRAPPER_EXTRA_FC_LDFLAGS])
+       AC_SUBST([OMPI_WRAPPER_EXTRA_FC_LDFLAGS])
+
+       # Convert @{libdir} to ${libdir} for pkg-config
+       _OPAL_SETUP_WRAPPER_FINAL_PKGCONFIG([OMPI])
+
+       AC_MSG_CHECKING([for OMPI LIBS])
+       OMPI_WRAPPER_EXTRA_LIBS="$ompi_mca_wrapper_extra_libs"
+       OPAL_FLAGS_APPEND_UNIQ([OMPI_WRAPPER_EXTRA_LIBS], [$wrapper_extra_libs])
+       OMPI_WRAPPER_EXTRA_LIBS="$OMPI_WRAPPER_EXTRA_LIBS $with_wrapper_libs"
+       OPAL_FLAGS_APPEND_UNIQ([OMPI_WRAPPER_EXTRA_LIBS], [$LIBS])
+       AC_SUBST([OMPI_WRAPPER_EXTRA_LIBS])
+       AC_MSG_RESULT([$OMPI_WRAPPER_EXTRA_LIBS])
+
+      # language binding support.  C++ is a bit different, as the
+      # compiler should work even if there is no MPI C++ bindings
+      # support.  However, we do want it to fail if there is no C++
+      # compiler.
+       if test "$WANT_MPI_CXX_SUPPORT" = "1" ; then
+          OMPI_WRAPPER_CXX_LIB="-l${with_libmpi_name}_cxx"
+          OMPI_WRAPPER_CXX_REQUIRED_FILE=""
+       elif test "$CXX" = "none"; then
+          OMPI_WRAPPER_CXX_LIB=""
+          OMPI_WRAPPER_CXX_REQUIRED_FILE="not supported"
+       else
+          OMPI_WRAPPER_CXX_LIB=""
+          OMPI_WRAPPER_CXX_REQUIRED_FILE=""
+       fi
+       AC_SUBST([OMPI_WRAPPER_CXX_LIB])
+       AC_SUBST([OMPI_WRAPPER_CXX_REQUIRED_FILE])
+
+       if test "$OMPI_TRY_FORTRAN_BINDINGS" -gt "$OMPI_FORTRAN_NO_BINDINGS" ; then
+          OMPI_WRAPPER_FORTRAN_REQUIRED_FILE=""
+       else
+          OMPI_WRAPPER_FORTRAN_REQUIRED_FILE="not supported"
+       fi
+       AC_SUBST([OMPI_WRAPPER_FORTRAN_REQUIRED_FILE])
+
+       # For script-based wrappers that don't do relocatable binaries.
+       # Don't use if you don't have to.
+       exec_prefix_save="${exec_prefix}"
+       test "x$exec_prefix" = xNONE && exec_prefix="${prefix}"
+       eval "OMPI_WRAPPER_INCLUDEDIR=\"${includedir}\""
+       eval "OMPI_WRAPPER_LIBDIR=\"${libdir}\""
+       exec_prefix="${exec_prefix_save}"
+       AC_SUBST([OMPI_WRAPPER_INCLUDEDIR])
+       AC_SUBST([OMPI_WRAPPER_LIBDIR])
+
+       # if wrapper compilers were requested, set the ompi one up
+       if test "$WANT_SCRIPT_WRAPPER_COMPILERS" = "1" ; then
+         AC_CONFIG_FILES([ompi/tools/wrappers/ompi_wrapper_script],
+                         [chmod +x ompi/tools/wrappers/ompi_wrapper_script])
+       fi
+
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CFLAGS, "$OMPI_WRAPPER_EXTRA_CFLAGS",
+           [Additional CFLAGS to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CFLAGS_PREFIX, "$OMPI_WRAPPER_EXTRA_CFLAGS_PREFIX",
+           [Additional CFLAGS_PREFIX to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CXXFLAGS, "$OMPI_WRAPPER_EXTRA_CXXFLAGS",
+           [Additional CXXFLAGS to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_CXXFLAGS_PREFIX, "$OMPI_WRAPPER_EXTRA_CXXFLAGS_PREFIX",
+           [Additional CXXFLAGS_PREFIX to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_FCFLAGS, "$OMPI_WRAPPER_EXTRA_FCFLAGS",
+           [Additional FCFLAGS to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_FCFLAGS_PREFIX, "$OMPI_WRAPPER_EXTRA_FCFLAGS_PREFIX",
+           [Additional FCFLAGS to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_LDFLAGS, "$OMPI_WRAPPER_EXTRA_LDFLAGS",
+           [Additional LDFLAGS to pass through the wrapper compilers])
+       AC_DEFINE_UNQUOTED(WRAPPER_EXTRA_LIBS, "$OMPI_WRAPPER_EXTRA_LIBS",
+           [Additional LIBS to pass through the wrapper compilers])
+    ])
+
+    AC_DEFINE_UNQUOTED(WRAPPER_RPATH_SUPPORT, "$WRAPPER_RPATH_SUPPORT",
+        [Whether the wrapper compilers add rpath flags by default])
+])

--- a/config/opal_summary.m4
+++ b/config/opal_summary.m4
@@ -1,0 +1,115 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+AC_DEFUN([OPAL_SUMMARY_ADD],[
+    OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_line ompi_summary_section_current])
+
+    dnl need to replace spaces in the section name with somethis else. _ seems like a reasonable
+    dnl choice. if this changes remember to change OMPI_PRINT_SUMMARY as well.
+    ompi_summary_section=$(echo $1 | tr ' ' '_')
+    ompi_summary_line="$2: $4"
+    ompi_summary_section_current=$(eval echo \$ompi_summary_values_$ompi_summary_section)
+
+    if test -z "$ompi_summary_section_current" ; then
+        if test -z "$ompi_summary_sections" ; then
+            ompi_summary_sections=$ompi_summary_section
+        else
+            ompi_summary_sections="$ompi_summary_sections $ompi_summary_section"
+        fi
+        eval ompi_summary_values_$ompi_summary_section=\"$ompi_summary_line\"
+    else
+        eval ompi_summary_values_$ompi_summary_section=\"$ompi_summary_section_current,$ompi_summary_line\"
+    fi
+
+    OPAL_VAR_SCOPE_POP
+])
+
+AC_DEFUN([OPAL_SUMMARY_PRINT],[
+    OPAL_VAR_SCOPE_PUSH([ompi_summary_section ompi_summary_section_name])
+    cat <<EOF
+
+Open MPI configuration:
+-----------------------
+Version: $OMPI_MAJOR_VERSION.$OMPI_MINOR_VERSION.$OMPI_RELEASE_VERSION$OMPI_GREEK_VERSION
+EOF
+
+    if test "$project_ompi_amc" = "true" ; then
+        echo "Build MPI C bindings: yes"
+    else
+        echo "Build MPI C bindings: no"
+    fi
+
+    dnl Print out the bindings if we are building OMPI
+    if test "$project_ompi_amc" = "true" ; then
+	if test x$enable_mpi_cxx = xyes ; then
+            echo "Build MPI C++ bindings (deprecated): yes"
+	else
+            echo "Build MPI C++ bindings (deprecated): no"
+	fi
+
+	if test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_MPIFH_BINDINGS ; then
+            echo "Build MPI Fortran bindings: mpif.h"
+	elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPI_BINDINGS ; then
+            echo "Build MPI Fortran bindings: mpif.h, use mpi"
+	elif test $OMPI_BUILD_FORTRAN_BINDINGS = $OMPI_FORTRAN_USEMPIF08_BINDINGS ; then
+	    echo "Build MPI Fortran bindings: mpif.h, use mpi, use mpi_f08"
+	else
+	    echo "Build MPI Fortran bindings: no"
+	fi
+
+        if test x$WANT_MPI_JAVA_SUPPORT = x1 ; then
+            echo "Build MPI Java bindings (experimental): yes"
+        else
+            echo "MPI Build Java bindings (experimental): no"
+        fi
+    fi
+
+    if test "$project_oshmem_amc" = "true" ; then
+        echo "Build Open SHMEM support: yes"
+    else
+        echo "Build Open SHMEM support: no"
+    fi
+
+    if test $WANT_DEBUG = 0 ; then
+        echo "Debug build: no"
+    else
+        echo "Debug build: yes"
+    fi
+
+    if test ! -z $with_platform ; then
+        echo "Platform file: $with_platform"
+    else
+        echo "Platform file: (none)"
+    fi
+
+    echo
+
+    for ompi_summary_section in $(echo $ompi_summary_sections) ; do
+        ompi_summary_section_name=$(echo $ompi_summary_section | tr '_' ' ')
+        echo "$ompi_summary_section_name"
+        echo "-----------------------"
+        echo "$(eval echo \$ompi_summary_values_$ompi_summary_section)" | tr ',' $'\n' | sort -f
+        echo " "
+    done
+
+    if test $WANT_DEBUG = 1 ; then
+        cat <<EOF
+*****************************************************************************
+ THIS IS A DEBUG BUILD!  DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!
+*****************************************************************************
+
+EOF
+    fi
+
+    OPAL_VAR_SCOPE_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,6 @@ m4_ifndef([AS_VAR_COPY],
     [m4_define([AS_VAR_COPY],
        [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
 
-OPAL_TOP_BUILDDIR="`pwd`"
-
 dnl Work around change in how the rules were implemented between
 dnl 1.11.2 and 1.11.3.
 AM_SILENT_RULES([yes])
@@ -455,6 +453,7 @@ LIBS="$LIBS $portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 # Need the libtool binary before setting up rpath
 LT_OUTPUT
 
+OPAL_TOP_BUILDDIR="`pwd`"
 OPAL_SETUP_RPATH
 
 # wrapper compiler gorp

--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ m4_ifndef([AS_VAR_COPY],
     [m4_define([AS_VAR_COPY],
        [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])
 
+OPAL_TOP_BUILDDIR="`pwd`"
+
 dnl Work around change in how the rules were implemented between
 dnl 1.11.2 and 1.11.3.
 AM_SILENT_RULES([yes])
@@ -129,7 +131,7 @@ AC_SUBST([LIBTOOL_WRAPPER_LDFLAGS])
 AC_ARG_ENABLE([rpath],
   [AS_HELP_STRING([--disable-rpath],
     [Disable use of rpath in compiler wrappers and building tests (default: enabled)])])
-AS_IF([test "$enable_rpath" = "no"], [RPATH_LDFLAGS=], [RPATH_LDFLAGS="-Wl,-rpath -Wl,$libdir"])
+AS_IF([test "$enable_rpath" = "no"], [RPATH_LDFLAGS=], [RPATH_LDFLAGS="-Wl,-rpath -Wl,$libdir"; enable_wrapper_rpath="yes"])
 
 
 AC_ARG_ENABLE([profiling],
@@ -450,9 +452,18 @@ CPPFLAGS="$CPPFLAGS $portals4_CPPFLAGS $libfabric_CPPFLAGS $ofi_CPPFLAGS $XPMEM_
 LDFLAGS="$LDFLAGS $portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
 LIBS="$LIBS $portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 
+# Need the libtool binary before setting up rpath
+LT_OUTPUT
+
+OPAL_SETUP_RPATH
+
 # wrapper compiler gorp
 WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
 WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
+
+AC_MSG_CHECKING([for OPAL LDFLAGS])
+RPATHIFY_LDFLAGS([WRAPPER_COMPILER_EXTRA_LDFLAGS])
+AC_MSG_RESULT([$WRAPPER_COMPILER_EXTRA_LDFLAGS])
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LDFLAGS)
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -234,12 +234,21 @@ OMPI_CHECK_PORTALS4([portals4],
     [transport_portals4="no"])
 AM_CONDITIONAL([USE_PORTALS4], [test "$transport_portals4" = "yes"])
 
-OMPI_CHECK_OFI([ofi],
+OPAL_CHECK_LIBFABRIC([libfabric],
     [AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
      transport="ofi"
      transport_ofi="yes"],
     [transport_ofi="no"])
 AM_CONDITIONAL([USE_OFI], [test "$transport_ofi" = "yes"])
+
+if test "$transport_ofi" = "no" ; then
+  OMPI_CHECK_OFI([ofi],
+      [AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
+       transport="ofi"
+       transport_ofi="yes"],
+      [transport_ofi="no"])
+  AM_CONDITIONAL([USE_OFI], [test "$transport_ofi" = "yes"])
+fi
 
 SANDIA_CHECK_XPMEM(
     [AC_DEFINE([USE_XPMEM], [1], [Define if XPMEM transport is active])
@@ -437,13 +446,13 @@ AC_SUBST(CLEANFILES)
 
 # last minute updates of the flags so that tests don't fail oddly if
 # portals libdir isn't in LD_LIBRARY_PATH...
-CPPFLAGS="$CPPFLAGS $portals4_CPPFLAGS $ofi_CPPFLAGS $XPMEM_CPPFLAGS $pmi_CPPFLAGS"
-LDFLAGS="$LDFLAGS $portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
-LIBS="$LIBS $portals4_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
+CPPFLAGS="$CPPFLAGS $portals4_CPPFLAGS $libfabric_CPPFLAGS $ofi_CPPFLAGS $XPMEM_CPPFLAGS $pmi_CPPFLAGS"
+LDFLAGS="$LDFLAGS $portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
+LIBS="$LIBS $portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 
 # wrapper compiler gorp
-WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
-WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
+WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
+WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LDFLAGS)
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ AC_SUBST([LIBTOOL_WRAPPER_LDFLAGS])
 AC_ARG_ENABLE([rpath],
   [AS_HELP_STRING([--disable-rpath],
     [Disable use of rpath in compiler wrappers and building tests (default: enabled)])])
-AS_IF([test "$enable_rpath" = "no"], [RPATH_LDFLAGS=], [RPATH_LDFLAGS="-Wl,-rpath -Wl,$libdir"; enable_wrapper_rpath="yes"])
+AS_IF([test "$enable_rpath" = "no"], [RPATH_LDFLAGS=], [enable_wrapper_rpath="yes"])
 
 
 AC_ARG_ENABLE([profiling],
@@ -463,6 +463,7 @@ WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIB
 
 AC_MSG_CHECKING([for OPAL LDFLAGS])
 RPATHIFY_LDFLAGS([WRAPPER_COMPILER_EXTRA_LDFLAGS])
+WRAPPER_COMPILER_EXTRA_LDFLAGS=`echo "$WRAPPER_COMPILER_EXTRA_LDFLAGS" | sed -e 's/@{libdir}/\${libdir}/g'`
 AC_MSG_RESULT([$WRAPPER_COMPILER_EXTRA_LDFLAGS])
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LDFLAGS)
 AC_SUBST(WRAPPER_COMPILER_EXTRA_LIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ AC_SUBST([LIBTOOL_WRAPPER_LDFLAGS])
 AC_ARG_ENABLE([rpath],
   [AS_HELP_STRING([--disable-rpath],
     [Disable use of rpath in compiler wrappers and building tests (default: enabled)])])
-AS_IF([test "$enable_rpath" = "no"], [RPATH_LDFLAGS=], [enable_wrapper_rpath="yes"])
+AS_IF([test "$enable_rpath" = "no"], [], [enable_wrapper_rpath="yes"])
 
 
 AC_ARG_ENABLE([profiling],
@@ -449,7 +449,7 @@ AC_SUBST(CLEANFILES)
 # last minute updates of the flags so that tests don't fail oddly if
 # portals libdir isn't in LD_LIBRARY_PATH...
 CPPFLAGS="$CPPFLAGS $portals4_CPPFLAGS $libfabric_CPPFLAGS $ofi_CPPFLAGS $XPMEM_CPPFLAGS $pmi_CPPFLAGS"
-LDFLAGS="$LDFLAGS $portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
+LDFLAGS="$LDFLAGS $portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
 LIBS="$LIBS $portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 
 # Need the libtool binary before setting up rpath
@@ -458,7 +458,7 @@ LT_OUTPUT
 OPAL_SETUP_RPATH
 
 # wrapper compiler gorp
-WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS $RPATH_LDFLAGS"
+WRAPPER_COMPILER_EXTRA_LDFLAGS="$portals4_LDFLAGS $libfabric_LDFLAGS $ofi_LDFLAGS $XPMEM_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
 WRAPPER_COMPILER_EXTRA_LIBS="$portals4_LIBS $libfabric_LIBS $ofi_LIBS $XPMEM_LIBS $pmi_LIBS"
 
 AC_MSG_CHECKING([for OPAL LDFLAGS])


### PR DESCRIPTION
This PR would update the SOS build setup to use the upstream (OMPI) check for libfabric, while still supporting the `--with-ofi` flag.  It also updates to some other upstream OPAL m4 scripts, such as check_package, check_withdir, and a setup wrapper.  This wrapper does a good job of addressing Issue #138, by explicitly setting rpath to include all external library directories.  The SOS configure then passes that rpath string to oshcc and friends via LDFLAGS.