### PR TITLE
Fix hang in bcast tree algorithm

### DIFF
--- a/src/collectives.c
+++ b/src/collectives.c
@@ -463,6 +463,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
 
     /* need 1 slot */
     shmem_internal_assert(SHMEM_BCAST_SYNC_SIZE >= 1);
+    shmem_internal_assert(PE_size > 1 || PE_root == PE_start);
 
     if (PE_size == shmem_internal_num_pes && 0 == PE_root) {
         /* we're the full tree, use the binomial tree */
@@ -518,7 +519,8 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
-    } else {
+    }
+    else if (shmem_internal_my_pe != PE_root) {
         /* wait for data arrival message */
         SHMEM_WAIT(pSync, 0);
 


### PR DESCRIPTION
For single PE calls, the root PE was falling into the leaf PE code and
waiting for a broadcast message that would never arrive.

Possible fix for #325 

Signed-off-by: James Dinan <james.dinan@intel.com>