### PR TITLE
Fix bugs in tree-based bcast and barrier

### DIFF
--- a/src/collectives.c
+++ b/src/collectives.c
@@ -501,6 +501,8 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         int i;
 
         if (parent != shmem_internal_my_pe) {
+            send_buf = target;
+
             /* wait for data arrival message if not the root */
             SHMEM_WAIT(pSync, 0);
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -645,6 +645,11 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
     /* need 2 slots, plus bcast */
     shmem_internal_assert(SHMEM_REDUCE_SYNC_SIZE >= 2 + SHMEM_BCAST_SYNC_SIZE);
 
+    if (PE_size == 1) {
+        memcpy(target, source, type_size*count);
+        return;
+    }
+
     if (PE_size == shmem_internal_num_pes) {
         /* we're the full tree, use the binomial tree */
         parent = full_tree_parent;

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -59,7 +59,7 @@ shmem_internal_build_kary_tree(int radix, int PE_start, int stride,
     for (i = 1 ; i <= radix ; ++i) {
         int tmp = radix * my_id + i;
         if (tmp < PE_size) {
-            children[(*num_children)++] = (PE_start + ((tmp + PE_root) * stride)) % (PE_size * stride);
+            children[(*num_children)++] = (PE_start + ((tmp + PE_root) * stride));
         }
     }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -709,149 +709,139 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
 }
 
 
-
 void
 shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, int type_size,
-                                int PE_start, int logPE_stride, int PE_size,
-                                void *pWrk, long *pSync,
-                                shm_internal_op_t op, shm_internal_datatype_t datatype)
+                                   int PE_start, int logPE_stride, int PE_size,
+                                   void *pWrk, long *pSync,
+                                   shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
-   int stride = 1 << logPE_stride;
-   int my_id = ((shmem_internal_my_pe - PE_start) / stride);
-   long one = 1, neg_one = -1, buff = 0;
-   int log2_proc = 1, pow2_proc = 2;
-   int i = PE_size >> 1;
-   int wrk_size = type_size*count;
-   void * const current_target = malloc(wrk_size);
-   int peer = 0;
-   long completion = 0;
-   long * pSync_extra_peer = pSync + SHMEM_REDUCE_SYNC_SIZE - 2;
+    int stride = 1 << logPE_stride;
+    int my_id = ((shmem_internal_my_pe - PE_start) / stride);
+    long one = 1, neg_one = -1, buff = 0;
+    int log2_proc = 1, pow2_proc = 2;
+    int i = PE_size >> 1;
+    int wrk_size = type_size*count;
+    void * const current_target = malloc(wrk_size);
+    int peer = 0;
+    long completion = 0;
+    long * pSync_extra_peer = pSync + SHMEM_REDUCE_SYNC_SIZE - 2;
 
- /***********************************
- *
- *       input checks and var init
- *
- * **************************************/
+    if (PE_size == 1) {
+        memcpy(target, source, type_size*count);
+        free(current_target);
+        return;
+    }
 
-   if (PE_size == 1) {
-      memcpy(target, source, type_size*count);
-      free(current_target);
-      return;
-   }
+    while (i != 1) {
+        i >>= 1;
+        pow2_proc <<= 1;
+        log2_proc++;
+    }
 
-   while (i != 1) {
-      i >>= 1;
-     pow2_proc <<= 1;
-     log2_proc++;
-   }
+    /* Currently SHMEM_REDUCE_SYNC_SIZE assumes space for 2^32 PEs; this
+       parameter may be changed if need-be */
+    shmem_internal_assert(log2_proc <= (SHMEM_REDUCE_SYNC_SIZE - 2));
 
-         /*Currently SHMEM_REDUCE_SYNC_SIZE assumes space for 2^32 PEs; this
-            parameter may be changed if need-be */
-   shmem_internal_assert(log2_proc <= (SHMEM_REDUCE_SYNC_SIZE - 2));
+    if (current_target)
+        memcpy(current_target, (void *) source, wrk_size);
+    else
+        RAISE_ERROR(1);
 
-   if (current_target)
-      memcpy(current_target, (void *) source, wrk_size);
-   else
-      RAISE_ERROR(1);
+    /* Algorithm: reduce N number of PE's into a power of two recursive
+     * doubling algorithm have extra_peers do the operation with one of the
+     * power of two PE's so the information is in the power of two algorithm,
+     * at the end, update extra_peers with answer found by power of two team
+     *
+     * -target is used as "temp" buffer -- current_target tracks latest result
+     * give partner current_result,
+     */
 
- /***********************************
- *
- *   alg: reduce N number of PE's into a power of two recursive doubling algorithm
- *   have extra_peers do the operation with one of the power of two PE's so the information
- *   is in the power of two algorithm, at the end, update extra_peers with answer found
- *   by power of two team
- *
- *   -target is used as "temp" buffer -- current_target tracks latest result
- *   give partner current_result,
- *
- * **************************************/
+    /* extra peer exchange: grab information from extra_peer so its part of
+     * pairwise exchange */
+    if (my_id >= pow2_proc) {
+        peer = (my_id - pow2_proc) * stride + PE_start;
+        shmem_internal_put_nb(target, current_target, wrk_size, peer,
+                              &completion);
+        shmem_internal_put_wait(&completion);
+        shmem_internal_fence();
 
-   /*extra peer exchange: grab information from extra_peer so its part of pairwise exchange*/
-   if (my_id >= pow2_proc) {
-      peer = (my_id - pow2_proc) * stride + PE_start;
-      shmem_internal_put_nb(target, current_target, wrk_size, peer,
-                            &completion);
-      shmem_internal_put_wait(&completion);
-      shmem_internal_fence();
+        buff = neg_one;
+        shmem_internal_put_small(pSync_extra_peer, &buff, sizeof(long),
+                                 peer);
+        shmem_internal_fence();
+        buff = neg_one;
+        SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, buff);
 
-      buff = neg_one;
-      shmem_internal_put_small(pSync_extra_peer, &buff, sizeof(long),
-                               peer);
-      shmem_internal_fence();
-      buff = neg_one;
-      SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, buff);
+    } else {
+        if ((PE_size - pow2_proc) > my_id) {
+            peer = (my_id + pow2_proc) * stride + PE_start;
+            buff = neg_one;
+            SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, buff);
 
-   } else {
-      if ((PE_size - pow2_proc) > my_id) {
-         peer = (my_id + pow2_proc) * stride + PE_start;
-         buff = neg_one;
-         SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, buff);
+            shmem_internal_reduce_local(op, datatype, count, target, current_target);
+        }
 
-         shmem_internal_reduce_local(op, datatype, count, target, current_target);
-      }
+        /* Pairwise exchange: (only for PE's that are within the power of 2
+         * set) with every iteration, the information from each previous
+         * exchange is passed forward in the new interation */
 
-   /* Pairwise exchange: (only for PE's that are within the power of 2 set) with every iteration,
-      the information from each previous exchange is passed forward in the new interation */
+        long *step_psync;
 
-      long *step_psync;
+        for (i = 0; i < log2_proc; i++) {
 
-      for (i = 0; i < log2_proc; i++) {
+            peer = (my_id ^ (1 << i)) * stride + PE_start;
+            step_psync = &pSync[i];
 
-         peer = (my_id ^ (1 << i)) * stride + PE_start;
-         step_psync = &pSync[i];
+            if (my_id < peer) {
+                shmem_internal_put_small(step_psync, &one,
+                                         sizeof(int), peer);
+                SHMEM_WAIT(step_psync, 0);
+                shmem_internal_put_nb(target, current_target,
+                                      wrk_size, peer, &completion);
+                shmem_internal_put_wait(&completion);
+                shmem_internal_fence();
+                shmem_internal_atomic_small(step_psync, &one,
+                                            sizeof(int), peer,
+                                            SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
+            } else {
+                SHMEM_WAIT(step_psync, 0);
+                shmem_internal_put_nb(target, current_target,
+                                      wrk_size, peer, &completion);
+                shmem_internal_put_wait(&completion);
+                shmem_internal_fence();
+                shmem_internal_put_small(step_psync,
+                                         &one, sizeof(int), peer);
+                SHMEM_WAIT(step_psync, 1);
+            }
 
-         if (my_id < peer) {
-            shmem_internal_put_small(step_psync, &one,
-                                     sizeof(int), peer);
-            SHMEM_WAIT(step_psync, 0);
-            shmem_internal_put_nb(target, current_target,
-                                  wrk_size, peer, &completion);
+            shmem_internal_reduce_local(op, datatype, count,
+                                        target, current_target);
+        }
+
+        shmem_internal_quiet();
+
+        /* update extra peer with the final result from the pairwise exchange */
+        if ((PE_size - pow2_proc) > my_id) {
+            peer = (my_id + pow2_proc) * stride + PE_start;
+
+            shmem_internal_put_nb(target, current_target, wrk_size,
+                                  peer, &completion);
             shmem_internal_put_wait(&completion);
             shmem_internal_fence();
-            shmem_internal_atomic_small(step_psync, &one,
-                                        sizeof(int), peer,
-            SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
-         } else {
-            SHMEM_WAIT(step_psync, 0);
-            shmem_internal_put_nb(target, current_target,
-                                  wrk_size, peer, &completion);
-            shmem_internal_put_wait(&completion);
+
+            buff = neg_one;
+            shmem_internal_put_small(pSync_extra_peer, &buff,
+                                     sizeof(long), peer);
             shmem_internal_fence();
-            shmem_internal_put_small(step_psync,
-                                     &one, sizeof(int), peer);
-            SHMEM_WAIT(step_psync, 1);
-         }
+        }
 
-         /* perform op */
-         shmem_internal_reduce_local(op, datatype, count,
-                                     target, current_target);
+        memcpy(target, current_target, wrk_size);
+    }
 
-      }
+    free(current_target);
 
-      shmem_internal_quiet();
-
-   /*update extra peer with the final result from the pairwise exchange */
-      if ((PE_size - pow2_proc) > my_id) {
-         peer = (my_id + pow2_proc) * stride + PE_start;
-
-         shmem_internal_put_nb(target, current_target, wrk_size,
-                               peer, &completion);
-         shmem_internal_put_wait(&completion);
-         shmem_internal_fence();
-
-         buff = neg_one;
-         shmem_internal_put_small(pSync_extra_peer, &buff,
-                                  sizeof(long), peer);
-         shmem_internal_fence();
-      }
-
-      memcpy(target, current_target, wrk_size);
-   }
-
-   free(current_target);
-
-   for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
-      pSync[i] = SHMEM_SYNC_VALUE;
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
+        pSync[i] = SHMEM_SYNC_VALUE;
 }
 
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -646,7 +646,9 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
     shmem_internal_assert(SHMEM_REDUCE_SYNC_SIZE >= 2 + SHMEM_BCAST_SYNC_SIZE);
 
     if (PE_size == 1) {
-        memcpy(target, source, type_size*count);
+        if (target != source)
+            memcpy(target, source, type_size*count);
+        }
         return;
     }
 
@@ -726,7 +728,9 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
     const long ps_target_ready = 1, ps_data_ready = 2;
 
     if (PE_size == 1) {
-        memcpy(target, source, type_size*count);
+        if (target != source) {
+            memcpy(target, source, type_size*count);
+        }
         free(current_target);
         return;
     }

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -63,8 +63,7 @@ shmem_internal_build_kary_tree(int radix, int PE_start, int stride,
     for (i = 1 ; i <= radix ; ++i) {
         int tmp = radix * my_id + i;
         if (tmp < PE_size) {
-            const int child_idx = (PE_root + tmp) % PE_size;
-            children[(*num_children)++] = PE_start + child_idx * stride;
+            children[(*num_children)++] = (PE_start + ((tmp + PE_root) * stride)) % (PE_size * stride);
         }
     }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -63,7 +63,8 @@ shmem_internal_build_kary_tree(int radix, int PE_start, int stride,
     for (i = 1 ; i <= radix ; ++i) {
         int tmp = radix * my_id + i;
         if (tmp < PE_size) {
-            children[(*num_children)++] = (PE_start + ((tmp + PE_root) * stride)) % (PE_size * stride);
+            const int child_idx = (PE_root + tmp) % PE_size;
+            children[(*num_children)++] = PE_start + child_idx * stride;
         }
     }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -54,9 +54,9 @@ shmem_internal_build_kary_tree(int radix, int PE_start, int stride,
        participating tasks. where the 0th entry is the root */
     int my_id = (((shmem_internal_my_pe - PE_start) / stride) + PE_size - PE_root) % PE_size;
 
-    /* PE active set layout is: 0 [ 1 2 3 4 ] [ 5 6 7 8 ] ...
-       where radix is 4 and the first group [ 1 2 3 4 ] are chilren of 0,
-       second group chilren of 1, and so on */
+    /* We shift PE_root to index 0, resulting in a PE active set layout of (for
+       example radix 2): 0 [ 1 2 ] [ 3 4 ] [ 5 6 ] ...  The first group [ 1 2 ]
+       are chilren of 0, second group [ 3 4 ] are chilren of 1, and so on */
     *parent = PE_start + (((my_id - 1) / radix + PE_root) % PE_size) * stride;
 
     *num_children = 0;

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -63,6 +63,26 @@ shmem_internal_build_kary_tree(int radix, int PE_start, int stride,
         }
     }
 
+    if (shmem_internal_debug) {
+        int len;
+        char debug_str[256];
+        len = snprintf(debug_str, sizeof(debug_str), "Building k-ary tree:"
+                       "\n\t\tradix=%d, PE_start=%d, stride=%d, PE_size=%d, PE_root=%d\n",
+                       radix, PE_start, stride, PE_size, PE_root);
+
+        len += snprintf(debug_str+len, sizeof(debug_str) - len, "\t\tid=%d, parent=%d, children[%d] = { ",
+                        my_id, *parent, *num_children);
+
+        for (i = 0; i < *num_children && len < sizeof(debug_str); i++)
+            len += snprintf(debug_str+len, sizeof(debug_str) - len, "%d ",
+                            children[i]);
+
+        if (len < sizeof(debug_str))
+            len += snprintf(debug_str+len, sizeof(debug_str) - len, "}");
+
+        DEBUG_STR(debug_str);
+    }
+
     return 0;
 }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -484,6 +484,8 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
     /* need 1 slot */
     shmem_internal_assert(SHMEM_BCAST_SYNC_SIZE >= 1);
 
+    if (PE_size == 1) return;
+
     if (PE_size == shmem_internal_num_pes && 0 == PE_root) {
         /* we're the full tree, use the binomial tree */
         parent = full_tree_parent;

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -79,7 +79,8 @@ TESTS = \
 	rma_coverage \
 	collect \
 	repeated_barriers \
-	broadcast_active_set
+	broadcast_active_set \
+	reduce_active_set
 
 if ENABLE_PROFILING
 TESTS += \
@@ -372,3 +373,6 @@ repeated_barriers_LDADD = $(top_builddir)/src/libsma.la
 
 broadcast_active_set_SOURCES = broadcast_active_set.c
 broadcast_active_set_LDADD = $(top_builddir)/src/libsma.la
+
+reduce_active_set_SOURCES = reduce_active_set.c
+reduce_active_set_LDADD = $(top_builddir)/src/libsma.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -77,7 +77,8 @@ TESTS = \
 	get_nbi \
 	put_nbi \
 	rma_coverage \
-	collect
+	collect \
+	repeated_barriers
 
 if ENABLE_PROFILING
 TESTS += \
@@ -364,3 +365,6 @@ put_nbi_LDADD = $(top_builddir)/src/libsma.la
 
 collect_SOURCES = collect.c
 collect_LDADD = $(top_builddir)/src/libsma.la
+
+repeated_barriers_SOURCES = repeated_barriers.c
+repeated_barriers_LDADD = $(top_builddir)/src/libsma.la

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -78,7 +78,8 @@ TESTS = \
 	put_nbi \
 	rma_coverage \
 	collect \
-	repeated_barriers
+	repeated_barriers \
+	broadcast_active_set
 
 if ENABLE_PROFILING
 TESTS += \
@@ -368,3 +369,6 @@ collect_LDADD = $(top_builddir)/src/libsma.la
 
 repeated_barriers_SOURCES = repeated_barriers.c
 repeated_barriers_LDADD = $(top_builddir)/src/libsma.la
+
+broadcast_active_set_SOURCES = broadcast_active_set.c
+broadcast_active_set_LDADD = $(top_builddir)/src/libsma.la

--- a/test/unit/broadcast_active_set.c
+++ b/test/unit/broadcast_active_set.c
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <inttypes.h>
+#include <shmem.h>
+
+#define NELEM 10
+
+long bcast_psync[SHMEM_BCAST_SYNC_SIZE];
+
+/* Note: Need to alternate psync arrays because the active set changes */
+long barrier_psync0[SHMEM_BARRIER_SYNC_SIZE];
+long barrier_psync1[SHMEM_BARRIER_SYNC_SIZE];
+
+int64_t src[NELEM];
+int64_t dst[NELEM];
+
+int main(void)
+{
+    int i, me, npes;
+    int errors = 0;
+
+    shmem_init();
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < NELEM; i++) {
+        src[i] = me;
+        dst[i] = -1;
+    }
+
+    for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
+        bcast_psync[i] = SHMEM_SYNC_VALUE;
+
+    for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++) {
+        barrier_psync0[i] = SHMEM_SYNC_VALUE;
+        barrier_psync1[i] = SHMEM_SYNC_VALUE;
+    }
+
+    shmem_barrier_all();
+
+    /* A total of npes tests are performed, where the active set in each test
+     * includes PEs i..npes-1 */
+    for (i = 0; i <= me; i++) {
+        int j;
+
+        if (me == i)
+            printf(" + iteration %d\n", i);
+
+        shmem_broadcast64(dst, src, NELEM, 0, i, 0, npes-i, bcast_psync);
+
+        /* Validate broadcasted data */
+        for (j = 0; j < NELEM; j++) {
+            int64_t expected = (me == i) ? i-1 : i;
+            if (dst[j] != expected) {
+                printf("%d: Expected dst[%d] = %"PRId64", got dst[%d] = %"PRId64", iteration %d\n",
+                       me, j, expected, j, dst[j], i);
+                errors++;
+            }
+        }
+
+        shmem_barrier(i, 0, npes-i, (i % 2) ? barrier_psync0 : barrier_psync1);
+    }
+
+    shmem_finalize();
+
+    return errors != 0;
+}

--- a/test/unit/reduce_active_set.c
+++ b/test/unit/reduce_active_set.c
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <shmem.h>
+
+#define NELEM 10
+
+long max_psync[SHMEM_REDUCE_SYNC_SIZE];
+long min_psync[SHMEM_REDUCE_SYNC_SIZE];
+
+long min_pwrk[NELEM/2 + SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+long max_pwrk[NELEM/2 + SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+
+long src[NELEM];
+long dst_max[NELEM];
+long dst_min[NELEM];
+
+int main(void)
+{
+    int i, me, npes;
+    int errors = 0;
+
+    shmem_init();
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < NELEM; i++) {
+        src[i] = me;
+        dst_max[i] = -1;
+        dst_min[i] = -1;
+    }
+
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
+        max_psync[i] = SHMEM_SYNC_VALUE;
+        max_psync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    if (me == 0)
+        printf("Shrinking active set test\n");
+
+    shmem_barrier_all();
+
+    /* A total of npes tests are performed, where the active set in each test
+     * includes PEs i..npes-1 */
+    for (i = 0; i <= me; i++) {
+    //for (i = 1; i <= me && i <= 1; i++) {
+        int j;
+
+        if (me == i)
+            printf(" + PE_start=%d, logPE_stride=0, PE_size=%d\n", i, npes-i);
+
+        shmem_long_max_to_all(dst_max, src, NELEM, i, 0, npes-i, max_pwrk, max_psync);
+
+        /* Validate reduced data */
+        for (j = 0; j < NELEM; j++) {
+            long expected = npes-1;
+            if (dst_max[j] != expected) {
+                printf("%d: Max expected dst_max[%d] = %ld, got dst_max[%d] = %ld, iteration %d\n",
+                       me, j, expected, j, dst_max[j], i);
+                errors++;
+            }
+        }
+
+        shmem_long_min_to_all(dst_min, src, NELEM, i, 0, npes-i, min_pwrk, min_psync);
+
+        /* Validate reduced data */
+        for (j = 0; j < NELEM; j++) {
+            long expected = i;
+            if (dst_min[j] != expected) {
+                printf("%d: Min expected dst_min[%d] = %ld, got dst_min[%d] = %ld, iteration %d\n",
+                       me, j, expected, j, dst_min[j], i);
+                errors++;
+            }
+        }
+
+    }
+
+    shmem_finalize();
+
+    return errors != 0;
+}

--- a/test/unit/reduce_active_set.c
+++ b/test/unit/reduce_active_set.c
@@ -69,7 +69,6 @@ int main(void)
     /* A total of npes tests are performed, where the active set in each test
      * includes PEs i..npes-1 */
     for (i = 0; i <= me; i++) {
-    //for (i = 1; i <= me && i <= 1; i++) {
         int j;
 
         if (me == i)

--- a/test/unit/repeated_barriers.c
+++ b/test/unit/repeated_barriers.c
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <shmem.h>
+
+#define NREPS 50
+
+long barrier_psync0[SHMEM_BARRIER_SYNC_SIZE];
+long barrier_psync1[SHMEM_BARRIER_SYNC_SIZE];
+
+int main(void)
+{
+    int i, me, npes;
+
+    shmem_init();
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++) {
+        barrier_psync0[i] = SHMEM_SYNC_VALUE;
+        barrier_psync1[i] = SHMEM_SYNC_VALUE;
+    }
+
+    shmem_barrier_all();
+
+    /* A total of npes tests are performed, where the active set in each test
+     * includes PEs i..npes-1 */
+    for (i = 0; i <= me; i++) {
+        int j;
+
+        if (me == i)
+            printf(" + iteration %d\n", i);
+
+        /* Test that barrier can be called repeatedly with the *same* pSync */
+        for (j = 0; j < NREPS; j++)
+            shmem_barrier(i, 0, npes-i, (i % 2) ? barrier_psync0 : barrier_psync1);
+    }
+
+    shmem_finalize();
+
+    return 0;
+}


### PR DESCRIPTION
This fixes several bugs, but seems to have also caused a bug in the Cray ```shmem_broadcast_all.c``` test to fail nearly every time.