### PR TITLE
Add build information to debug output

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -144,11 +144,10 @@ AM_V_SED = $(am__v_SED_@AM_V@)
 am__v_SED_ = $(am__v_SED_@AM_DEFAULT_V@)
 am__v_SED_0 = @echo "  SED     " $@;
 
-build_info.h:
+build_info.h: $(top_builddir)/config.status
 	$(AM_V_GEN) echo "#ifndef BUILD_INFO_H" > $@
 	if [ -f $(srcdir)/../.git/HEAD ] && \
-	   [ -f $(srcdir)/../.git/index ] && \
-	   [ -f $(top_builddir)/config.status ]; then \
+	   [ -f $(srcdir)/../.git/index ]; then \
 	     echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) \
 	                                    ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@; \
 	fi;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -144,9 +144,14 @@ AM_V_SED = $(am__v_SED_@AM_V@)
 am__v_SED_ = $(am__v_SED_@AM_DEFAULT_V@)
 am__v_SED_0 = @echo "  SED     " $@;
 
-build_info.h: $(srcdir)/../.git/HEAD $(srcdir)/../.git/index $(top_builddir)/config.status
+build_info.h:
 	$(AM_V_GEN) echo "#ifndef BUILD_INFO_H" > $@
-	@echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@
+	if [ -f $(srcdir)/../.git/HEAD ] && \
+	   [ -f $(srcdir)/../.git/index ] && \
+	   [ -f $(top_builddir)/config.status ]; then \
+	     echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) \
+	                                    ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@; \
+	fi;
 	@echo "#define SOS_CONFIGURE_ARGS \"$(shell $(top_builddir)/config.status --config)\"" >> $@;
 	@echo "#define SOS_BUILD_DATE \"$(shell date)\"" >> $@;
 	@echo "#define SOS_BUILD_CC \"$(CC)\"" >> $@;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -146,8 +146,7 @@ am__v_SED_0 = @echo "  SED     " $@;
 
 build_info.h: $(top_builddir)/config.status
 	$(AM_V_GEN) echo "#ifndef BUILD_INFO_H" > $@
-	if [ -f $(srcdir)/../.git/HEAD ] && \
-	   [ -f $(srcdir)/../.git/index ]; then \
+	if [ -f $(srcdir)/../.git/HEAD ]; then \
 	     echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) \
 	                                    ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@; \
 	fi;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,9 +53,11 @@ libsma_la_SOURCES = \
 	util.c \
 	$(GEN_BINDINGS)
 
-BUILT_SOURCES = $(GEN_BINDINGS)
+BUILT_SOURCES = $(GEN_BINDINGS) \
+		build_info.h
 
-CLEANFILES += $(GEN_BINDINGS)
+CLEANFILES += $(GEN_BINDINGS) \
+		build_info.h
 
 if HAVE_FORTRAN
 libsma_la_SOURCES += \
@@ -141,6 +143,15 @@ do_subst = sed -e 's|[@]PERL[@]|$(PERL)|g' \
 AM_V_SED = $(am__v_SED_@AM_V@)
 am__v_SED_ = $(am__v_SED_@AM_DEFAULT_V@)
 am__v_SED_0 = @echo "  SED     " $@;
+
+build_info.h: $(srcdir)/../.git/HEAD $(srcdir)/../.git/index $(top_builddir)/config.status
+	$(AM_V_GEN) echo "#ifndef BUILD_INFO_H" > $@
+	@echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@
+	@echo "#define SOS_CONFIGURE_ARGS \"$(shell $(top_builddir)/config.status --config)\"" >> $@;
+	@echo "#define SOS_BUILD_DATE \"$(shell date)\"" >> $@;
+	@echo "#define SOS_BUILD_CC \"$(CC)\"" >> $@;
+	@echo "#define SOS_BUILD_CFLAGS \"$(CFLAGS)\"" >> $@;
+	@echo "#endif" >> $@
 
 oshcc: shmem_compiler_script.in Makefile
 	$(AM_V_SED)$(do_subst) -e 's|[@]LANG[@]|C|g' < $(srcdir)/shmem_compiler_script.in > oshcc

--- a/src/init.c
+++ b/src/init.c
@@ -31,6 +31,7 @@
 #include "shmem_collectives.h"
 #include "shmem_comm.h"
 #include "runtime.h"
+#include "build_info.h"
 
 #ifdef __APPLE__
 #include <mach-o/getsect.h>
@@ -168,12 +169,16 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     /* huge page support only on Linux for now, default is to use 2MB large pages */
 #ifdef __linux__
     if (heap_use_malloc == 0) {
-        shmem_internal_heap_use_huge_pages=
-             (shmem_util_getenv_str("SYMMETRIC_HEAP_USE_HUGE_PAGES") != NULL) ? 1 : 0;
-        shmem_internal_heap_huge_page_size = shmem_util_getenv_long("SYMMETRIC_HEAP_PAGE_SIZE",
-                                                                    1,
-                                                                    2 * 1024 * 1024);
+        shmem_internal_heap_use_huge_pages =
+            (shmem_util_getenv_str("SYMMETRIC_HEAP_USE_HUGE_PAGES") != NULL) ? 1 : 0;
+        shmem_internal_heap_huge_page_size =
+            shmem_util_getenv_long("SYMMETRIC_HEAP_PAGE_SIZE", 1, 2 * 1024 * 1024);
     }
+#endif
+
+#ifdef USE_CMA
+    shmem_transport_cma_put_max = shmem_util_getenv_long("CMA_PUT_MAX", 1, 8*1024);
+    shmem_transport_cma_get_max = shmem_util_getenv_long("CMA_GET_MAX", 1, 16*1024);
 #endif
 
     /* Find symmetric data */
@@ -220,10 +225,8 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     }
     xpmem_initialized = 1;
 #endif
-#ifdef USE_CMA
-    shmem_transport_cma_put_max = shmem_util_getenv_long("CMA_PUT_MAX", 1, 8*1024);
-    shmem_transport_cma_get_max = shmem_util_getenv_long("CMA_GET_MAX", 1, 16*1024);
 
+#ifdef USE_CMA
     ret = shmem_transport_cma_init(eager_size);
     if (0 != ret) {
         fprintf(stderr,
@@ -301,13 +304,15 @@ shmem_internal_init(int tl_requested, int *tl_provided)
 
     /* last minute printing of information */
     if (0 == shmem_internal_my_pe) {
-        if (NULL != shmem_util_getenv_str("VERSION")) {
+        if (NULL != shmem_util_getenv_str("VERSION") ||
+            NULL != shmem_util_getenv_str("INFO")    ||
+            shmem_internal_debug)
+        {
             printf(PACKAGE_STRING "\n");
             fflush(NULL);
         }
 
         if (NULL != shmem_util_getenv_str("INFO")) {
-            printf(PACKAGE_STRING "\n\n");
             printf("SMA_VERSION             %s\n",
                    (NULL != shmem_util_getenv_str("VERSION")) ? "Set" : "Not set");
             printf("\tIf set, print library version at startup\n");
@@ -348,15 +353,36 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             printf("\tEnable debugging messages\n");
             printf("SMA_TRAP_ON_ABORT       %s\n", shmem_internal_trap_on_abort ? "On" : "Off");
             printf("\tGenerate trap if the program aborts or calls shmem_global_exit\n");
+
+            printf("\n");
+#ifdef USE_XPMEM
+            printf("On-node transport:      XPMEM\n");
+#endif
 #ifdef USE_CMA
+            printf("On-node transport:      CMA\n");
             printf("SMA_CMA_PUT_MAX         %zu\n", shmem_transport_cma_put_max);
             printf("SMA_CMA_GET_MAX         %zu\n", shmem_transport_cma_get_max);
 #endif /* USE_CMA */
+#if !defined(USE_XPMEM) && !defined(USE_CMA)
+            printf("On-node transport:      NONE\n");
+#endif
 
+            printf("\n");
             shmem_transport_print_info();
             printf("\n");
-            fflush(NULL);
         }
+
+        if (shmem_internal_debug) {
+            printf("Build information:\n");
+            printf("%-23s %s\n", "Git Version", SOS_GIT_VERSION);
+            printf("%-23s %s\n", "Configure Args", SOS_CONFIGURE_ARGS);
+            printf("%-23s %s\n", "Build Date", SOS_BUILD_DATE);
+            printf("%-23s %s\n", "Build CC", SOS_BUILD_CC);
+            printf("%-23s %s\n", "Build CFLAGS", SOS_BUILD_CFLAGS);
+            printf("\n");
+        }
+
+        fflush(NULL);
     }
 
     /* finish up */

--- a/src/init.c
+++ b/src/init.c
@@ -374,7 +374,9 @@ shmem_internal_init(int tl_requested, int *tl_provided)
 
         if (shmem_internal_debug) {
             printf("Build information:\n");
+#ifdef SOS_GIT_VERSION
             printf("%-23s %s\n", "Git Version", SOS_GIT_VERSION);
+#endif
             printf("%-23s %s\n", "Configure Args", SOS_CONFIGURE_ARGS);
             printf("%-23s %s\n", "Build Date", SOS_BUILD_DATE);
             printf("%-23s %s\n", "Build CC", SOS_BUILD_CC);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1157,7 +1157,6 @@ void shmem_transport_print_info(void)
         if (NULL == (ofi_provider = shmem_util_getenv_str("OFI_USE_PROVIDER")))
             ofi_provider = "AUTO";
 
-    printf("\n");
     printf("Network transport:      OFI\n");
     printf("SMA_OFI_PROVIDER        %s\n", ofi_provider);
     printf("\tProvider that should be used by the OFI transport\n");

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -654,7 +654,6 @@ shmem_transport_startup(void)
 
 void shmem_transport_print_info(void)
 {
-    printf("\n");
     printf("Network transport:      Portals\n");
 }
 


### PR DESCRIPTION
Add the following to the SHMEM_DEBUG output:
```
Sandia OpenSHMEM 1.3.1
Build information:
Git Version             v1.3.1-177-gd2f74b6d (pr/debug-msg)
Configure Args          '--prefix=/Users/dinanjam/opt/sandia-openshmem' '--with-ofi=/Users/dinanjam/opt/libfabric' '--enable-pmi-simple' '--enable-picky' '--enable-debug' '--enable-error-checking'
Build Date              Fri Feb 24 10:38:24 EST 2017
Build CC                gcc
Build CFLAGS            -std=gnu11 -g -O2 -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -g
```

Also cleans up the SHMEM_INFO output to better include on-node comms info.  Here's the full output from the hello test when both SHMEM_INFO and SHMEM_DEBUG are enabled:
```
$ SMA_INFO=1 SMA_DEBUG=1 test/unit/hello
[000] DEBUG: ../../src/transport_ofi.c:1058:
[000]        OFI provider: sockets, fabric: 127.0.0.0/8, domain: lo0
Sandia OpenSHMEM 1.3.1
SMA_VERSION             Not set
	If set, print library version at startup
SMA_INFO                Set
	If set, print this help message at startup
SMA_SYMMETRIC_SIZE      536870912
	Symmetric heap size
SMA_SYMMETRIC_HEAP_USE_MALLOC Not set
	If set, allocate the symmetric heap using malloc
SMA_SYMMETRIC_HEAP_USE_HUGE_PAGES No
	Symmetric heap use large pages
SMA_COLL_CROSSOVER      4
	Cross-over between linear and tree collectives
SMA_COLL_RADIX          4
	Radix for tree-based collectives
SMA_BOUNCE_SIZE         2048
	Maximum message size to bounce buffer
SMA_BARRIER_ALGORITHM   AUTO
	Algorithm for barrier.  Options are auto, linear, tree, dissem
SMA_BCAST_ALGORITHM     AUTO
	Algorithm for broadcast.  Options are auto, linear, tree
SMA_REDUCE_ALGORITHM    AUTO
	Algorithm for reductions.  Options are auto, linear, tree, recdbl
SMA_COLLECT_ALGORITHM   AUTO
	Algorithm for collect.  Options are auto, linear
SMA_FCOLLECT_ALGORITHM  AUTO
	Algorithm for fcollect.  Options are auto, linear, ring, recdbl
SMA_DEBUG               On
	Enable debugging messages
SMA_TRAP_ON_ABORT       Off
	Generate trap if the program aborts or calls shmem_global_exit

On-node transport:      NONE

Network transport:      OFI
SMA_OFI_PROVIDER        AUTO
	Provider that should be used by the OFI transport
SMA_OFI_FABRIC          AUTO
	Fabric that should be used by the OFI transport
SMA_OFI_DOMAIN          AUTO
	Fabric domain that should be used by the OFI transport
SMA_OFI_ATOMIC_CHECKS_WARN Not set
	Display warnings about unsupported atomic operations

Build information:
Git Version             v1.3.1-174-g8721494b (pr/debug-msg)
Configure Args          '--prefix=/Users/dinanjam/opt/sandia-openshmem' '--with-ofi=/Users/dinanjam/opt/libfabric' '--enable-pmi-simple' '--enable-picky' '--enable-debug' '--enable-error-checking'
Build Date              Fri Feb 24 10:43:40 EST 2017
Build CC                gcc
Build CFLAGS            -std=gnu11 -g -O2 -Wall -Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic -g

Hello World from 0 of 1
```

I would have liked to print this output before the debug messages from transport initialization, but this requires a full rewrite of how we parse the environment variables.