### PR TITLE
Reduce default table size in GUPS

### DIFF
--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -177,8 +177,8 @@
 /* Define 64-bit constants */
 #define ZERO64B 0LL
 
-uint64_t TotalMemOpt;
-int NumUpdatesOpt;
+uint64_t TotalMemOpt = 8192;
+int NumUpdatesOpt = 0; /* FIXME: This option is ignored */
 double SHMEMGUPs;
 double SHMEMRandomAccess_ErrorsFraction;
 double SHMEMRandomAccess_time;
@@ -355,8 +355,8 @@ SHMEMRandomAccess(void)
    * TODO: replace this
    */
 
-  TotalMem = TotalMemOpt ? TotalMemOpt : 200000; /* max single node memory */
-  TotalMem *= NumProcs;             /* max memory in NumProcs nodes */
+  TotalMem = TotalMemOpt; /* max single node memory */
+  TotalMem *= NumProcs;   /* max memory in NumProcs nodes */
 
   TotalMem /= sizeof(uint64_t);
 

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -392,8 +392,11 @@ SHMEMRandomAccess(void)
   HPCC_Table = shmem_malloc(LocalTableSize * sizeof(uint64_t));
   if (! HPCC_Table) sAbort = 1;
 
-  HPCC_PELock = shmem_malloc(sizeof(uint64_t) * shmem_n_pes());
+  HPCC_PELock = shmem_malloc(sizeof(uint64_t) * NumProcs);
   if (! HPCC_PELock) sAbort = 1;
+
+  for (i = 0; i < NumProcs; i++)
+      HPCC_PELock[i] = 0;
 
   shmem_barrier_all();
   shmem_int_sum_to_all(&rAbort, &sAbort, 1, 0, 0, NumProcs, ipWrk, pSync_reduce);


### PR DESCRIPTION
The verification phase repeats the GUPS experiment with each update performed while holding a mutex.  This part is really slow...