### PR TITLE
Improvements to thread safety

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -140,6 +140,16 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     int cma_initialized       = 0;
 #endif
 
+    /* set up threading */
+    SHMEM_MUTEX_INIT(shmem_internal_mutex_alloc);
+#ifdef ENABLE_THREADS
+    shmem_internal_thread_level = tl_requested;
+    *tl_provided = tl_requested;
+#else
+    shmem_internal_thread_level = SHMEMX_THREAD_SINGLE;
+    *tl_provided = SHMEMX_THREAD_SINGLE;
+#endif
+
     ret = shmem_runtime_init();
     if (0 != ret) {
         fprintf(stderr, "ERROR: runtime init failed: %d\n", ret);
@@ -283,16 +293,6 @@ shmem_internal_init(int tl_requested, int *tl_provided)
 
     atexit(shmem_internal_shutdown_atexit);
     shmem_internal_initialized = 1;
-
-    /* set up threading */
-    SHMEM_MUTEX_INIT(shmem_internal_mutex_alloc);
-#ifdef ENABLE_THREADS
-    shmem_internal_thread_level = tl_requested;
-    *tl_provided = tl_requested;
-#else
-    shmem_internal_thread_level = SHMEMX_THREAD_SINGLE;
-    *tl_provided = SHMEMX_THREAD_SINGLE;
-#endif
 
     /* get hostname for shmem_getnodename */
     if (gethostname(shmem_internal_my_hostname,

--- a/src/init.c
+++ b/src/init.c
@@ -171,7 +171,9 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     radix = shmem_util_getenv_long("COLL_RADIX", 0, 4);
     crossover = shmem_util_getenv_long("COLL_CROSSOVER", 0, 4);
     heap_size = shmem_util_getenv_long("SYMMETRIC_SIZE", 1, 512 * 1024 * 1024);
-    eager_size = shmem_util_getenv_long("BOUNCE_SIZE", 1, 2048);
+    eager_size = shmem_util_getenv_long("BOUNCE_SIZE", 1,
+                            /* Disable by default in MULTIPLE because of threading overheads */
+                            shmem_internal_thread_level == SHMEMX_THREAD_MULTIPLE ? 0 : 2048);
     heap_use_malloc = shmem_util_getenv_long("SYMMETRIC_HEAP_USE_MALLOC", 0, 0);
     shmem_internal_debug = (NULL != shmem_util_getenv_str("DEBUG")) ? 1 : 0;
     shmem_internal_trap_on_abort = (NULL != shmem_util_getenv_str("TRAP_ON_ABORT")) ? 1 : 0;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -994,9 +994,14 @@ static inline int query_for_fabric(struct fabric_info *info)
     domain_attr.mr_key_size   = 1; /* Heap and data use different MR keys, need
                                       at least 1 byte */
 #endif
-    domain_attr.threading     = FI_THREAD_ENDPOINT; /* we promise to serialize access
-                                                       to endpoints. we have only one
-                                                       thread active at a time */
+#ifdef ENABLE_THREADS
+    if (shmem_internal_thread_level == SHMEMX_THREAD_MULTIPLE)
+        domain_attr.threading = FI_THREAD_SAFE;
+    else
+        domain_attr.threading = FI_THREAD_DOMAIN;
+#else
+    domain_attr.threading     = FI_THREAD_DOMAIN;
+#endif
 
     hints.domain_attr         = &domain_attr;
     ep_attr.type              = FI_EP_RDM; /* reliable connectionless */

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -85,9 +85,6 @@ fi_addr_t			*addr_table;
 #define EPHOSTNAMELEN  _POSIX_HOST_NAME_MAX + 1
 static char         myephostname[EPHOSTNAMELEN];
 #endif
-#ifdef ENABLE_THREADS
-shmem_internal_mutex_t           shmem_transport_ofi_lock;
-#endif
 
 size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
 
@@ -1095,8 +1092,6 @@ int shmem_transport_init(long eager_size)
     if(ret!=0)
         return ret;
 
-    SHMEM_MUTEX_INIT(shmem_transport_ofi_lock);
-
     /* The current bounce buffering implementation is only compatible with
      * providers that don't require FI_CONTEXT */
     if (info.p_info->mode & FI_CONTEXT) {
@@ -1272,8 +1267,6 @@ int shmem_transport_fini(void)
 #ifdef USE_AV_MAP
     free(addr_table);
 #endif
-
-    SHMEM_MUTEX_DESTROY(shmem_transport_ofi_lock);
 
     return 0;
 }


### PR DESCRIPTION
Improvements to performance of thread safety prototype.

Updated default to FI_THREAD_DOMAIN, which should also improve overall performance.