### PR TITLE
Fix gratuitous whitespace in git version output

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -155,8 +155,7 @@ am__v_SED_0 = @echo "  SED     " $@;
 build_info.h: $(top_builddir)/config.status
 	$(AM_V_GEN) echo "#ifndef BUILD_INFO_H" > $@
 	@if [ -f $(top_srcdir)/.git/HEAD ]; then \
-	     echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) \
-	                                    ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@; \
+	     echo "#define SOS_GIT_VERSION \"$(shell git describe --abbrev=8 --dirty --always --tags) ($(shell git rev-parse --abbrev-ref HEAD))\"" >> $@; \
 	fi;
 	@echo "#define SOS_CONFIGURE_ARGS \"$(shell $(top_builddir)/config.status --config)\"" >> $@;
 	@echo "#define SOS_BUILD_DATE \"$(shell date)\"" >> $@;


### PR DESCRIPTION
The line break I removed was causing a lot of whitespace to show up in the SHMEM_DEBUG output.