### PR TITLE
Perf put target

### DIFF
--- a/test/performance/shmem_perf_suite/Makefile.am
+++ b/test/performance/shmem_perf_suite/Makefile.am
@@ -30,7 +30,8 @@ noinst_HEADERS = \
 	int_element_latency.h \
 	bw_common.h \
 	uni_dir.h \
-	bi_dir.h
+	bi_dir.h \
+	target_put.h
 
 if ENABLE_LENGTHY_TESTS
 TESTS = $(check_PROGRAMS)

--- a/test/performance/shmem_perf_suite/bi_dir.h
+++ b/test/performance/shmem_perf_suite/bi_dir.h
@@ -28,7 +28,7 @@
 void static inline bi_bw(int len, perf_metrics_t *metric_info)
 {
     double start = 0.0, end = 0.0;
-    int dest = partner_node(*metric_info);
+    uint32_t dest = partner_node(*metric_info);
     int i = 0, j = 0;
 
     shmem_barrier_all();

--- a/test/performance/shmem_perf_suite/common.h
+++ b/test/performance/shmem_perf_suite/common.h
@@ -131,11 +131,11 @@ int static inline is_pow_of_2(unsigned int num)
     return ((num == 1 || num == 0)? true : false);
 }
 
-void static init_array(char * const buf, int len, int my_pe_num)
+void static init_array(char * const buf, int len, uint32_t my_pe_num)
 {
     int i = 0;
     int array_size = len / sizeof(int);
-    int * ibuf = (int *)buf;
+    uint32_t * ibuf = (uint32_t *)buf;
 
     assert(is_divisible_by_4(len));
 
@@ -144,11 +144,11 @@ void static init_array(char * const buf, int len, int my_pe_num)
 
 }
 
-void static inline validate_recv(char * buf, int len, int partner_pe)
+void static inline validate_recv(char * buf, int len, uint32_t partner_pe)
 {
     int i = 0;
     int array_size = len / sizeof(int);
-    int * ibuf = (int *)buf;
+    uint32_t * ibuf = (uint32_t *)buf;
 
     assert(is_divisible_by_4(len));
 

--- a/test/performance/shmem_perf_suite/shmem_bibw_atomics_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bibw_atomics_perf.c
@@ -42,7 +42,7 @@
     do {                                                                       \
         double start = 0.0, end = 0.0;                                         \
         int i = 0, j = 0, num_itr = metric_info->trials + metric_info->warmup; \
-        int dest = partner_node(*metric_info);                                 \
+        uint32_t dest = partner_node(*metric_info);                                 \
         shmem_barrier_all();                                                   \
                                                                                \
         switch(op) {                                                       \

--- a/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
@@ -150,7 +150,6 @@ static inline void bw_set_metric_info_len(perf_metrics_t *metric_info)
                                         sizeof(long long)};
     metric_info->cstyle = ATOMIC_COMM_STYLE;
     metric_info->type = UNI_DIR;
-    metric_info->bwstyle = STYLE_ATOMIC;
     int snode = streaming_node(*metric_info);
     atomic_op_type op_type = OP_ADD;
 
@@ -189,7 +188,7 @@ void uni_dir_bw(int len, perf_metrics_t *metric_info)
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_ATOMIC);
 
     return 0;
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
@@ -43,7 +43,7 @@
     do {                                                                       \
         double start = 0.0, end = 0.0;                                         \
         int i = 0, j = 0, num_itr = metric_info->trials + metric_info->warmup; \
-        int dest = partner_node(*metric_info);                                 \
+        uint32_t dest = partner_node(*metric_info);                                 \
         shmem_barrier_all();                                                   \
                                                                                \
         if(snode) {                                                   \

--- a/test/performance/shmem_perf_suite/shmem_bw_get_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_get_perf.c
@@ -48,13 +48,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc,argv);
+    uni_dir_bw_main(argc,argv, STYLE_GET);
 
     return 0;
 }  /* end of main() */
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, streaming_node(*metric_info));
-}

--- a/test/performance/shmem_perf_suite/shmem_bw_nb_get_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_nb_get_perf.c
@@ -45,13 +45,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc,argv);
+    uni_dir_bw_main(argc,argv, STYLE_GET);
 
     return 0;
 }  /* end of main() */
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, streaming_node(*metric_info));
-}

--- a/test/performance/shmem_perf_suite/shmem_bw_nb_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_nb_put_perf.c
@@ -45,13 +45,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_PUT);
 
     return 0;
-}
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -37,21 +37,10 @@
 */
 #include <bw_common.h>
 #include <uni_dir.h>
-#include <target_put.h>
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_PUT);
 
     return 0;
-}
-
-void uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    if(metric_info->target_data) {
-        target_bw_itr(len, metric_info, !streaming_node(*metric_info));
-        return;
-    }
-
-    uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -46,31 +46,29 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, int start_pe)
+void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, uint32_t start_pe)
 {
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
-    int dest = partner_node(metric_info);
+    uint32_t dest = partner_node(metric_info);
     int snode = (metric_info.num_pes != 1)? streaming_node : true;
     size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
-    int result[2] = {dest, dest};
-    int init[2] = {metric_info.my_node, metric_info.my_node};
-    long *end_dst_ptr = (long *)(metric_info.dest + (final_len));
-
-    assert(sizeof(int)*2 == sizeof(long));
+    uint32_t result[2] = {dest, dest};
+    uint32_t init[2] = {metric_info.my_node, metric_info.my_node};
+    uint64_t *end_dst_ptr = (uint64_t *)(metric_info.dest + (final_len));
 
     shmem_barrier_all();
 
     /* reset pointer we will be waiting on */
     if(!snode)
-        *(end_dst_ptr) = *((long *)init);
+        *(end_dst_ptr) = *((uint64_t *)init);
 
     shmem_barrier_all();
     start = perf_shmemx_wtime();
 
     /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
     if(!snode) {
-        shmem_long_wait_until(end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        shmem_long_wait_until((long *)end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
         end = perf_shmemx_wtime();
 
         if(start_pe == metric_info.my_node)
@@ -97,7 +95,8 @@ void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int s
 
 void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
 {
-    int nPEs = 0, stride = 0, start_pe = 0;
+    int stride = 0;
+    uint32_t start_pe = 0, nPEs = 0;
     PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
 
     target_data_uni_bw(len, *metric_info, snode, start_pe);

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -35,9 +35,9 @@
 **
 **NOTE: this test assumes correctness of reduction algorithm
 */
-
 #include <bw_common.h>
 #include <uni_dir.h>
+#include <target_put.h>
 
 int main(int argc, char *argv[])
 {
@@ -46,73 +46,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, uint32_t start_pe)
-{
-    double start = 0.0, end = 0.0;
-    int i = 0, j = 0;
-    uint32_t dest = partner_node(metric_info);
-    int snode = (metric_info.num_pes != 1)? streaming_node : true;
-    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
-    uint32_t result[2] = {dest, dest};
-    uint32_t init[2] = {metric_info.my_node, metric_info.my_node};
-    uint64_t *end_dst_ptr = (uint64_t *)(metric_info.dest + (final_len));
-
-    shmem_barrier_all();
-
-    /* reset pointer we will be waiting on */
-    if(!snode)
-        *(end_dst_ptr) = *((uint64_t *)init);
-
-    shmem_barrier_all();
-    start = perf_shmemx_wtime();
-
-    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
-    if(!snode) {
-        shmem_long_wait_until((long *)end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
-        end = perf_shmemx_wtime();
-
-        if(start_pe == metric_info.my_node)
-            printf("target: \n");
-
-        calc_and_print_results((end - start), len, metric_info);
-    } else if(snode) {
-        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
-            for(j = 0; j < metric_info.window_size; j++)
-                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
-
-            shmem_quiet();
-        }
-        end = perf_shmemx_wtime();
-    }
-
-    shmem_barrier_all();
-
-    if(start_pe == metric_info.my_node && snode)
-        printf("initator: \n");
-    if(snode)
-        calc_and_print_results((end - start), len, metric_info);
-}
-
-void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
-{
-    int stride = 0;
-    uint32_t start_pe = 0, nPEs = 0;
-    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
-
-    target_data_uni_bw(len, *metric_info, snode, start_pe);
-
-    metric_info->start_len = TARGET_SZ_MAX;
-    len = TARGET_SZ_MAX;
-
-    target_data_uni_bw(len, *metric_info, snode, start_pe);
-
-    /* stopping upper layer from iterating, we are done */
-    metric_info->max_len = TARGET_SZ_MIN;
-}
-
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
+void uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
     if(metric_info->target_data) {
         target_bw_itr(len, metric_info, !streaming_node(*metric_info));

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -46,8 +46,79 @@ int main(int argc, char *argv[])
     return 0;
 }
 
+void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, int start_pe)
+{
+    double start = 0.0, end = 0.0;
+    int i = 0, j = 0;
+    int dest = partner_node(metric_info);
+    int snode = (metric_info.num_pes != 1)? streaming_node : true;
+    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
+    int result[2] = {dest, dest};
+    int init[2] = {metric_info.my_node, metric_info.my_node};
+    long *end_dst_ptr = (long *)(metric_info.dest + (final_len));
+
+    assert(sizeof(int)*2 == sizeof(long));
+
+    shmem_barrier_all();
+
+    /* reset pointer we will be waiting on */
+    if(!snode)
+        *(end_dst_ptr) = *((long *)init);
+
+    shmem_barrier_all();
+    start = perf_shmemx_wtime();
+
+    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
+    if(!snode) {
+        shmem_long_wait_until(end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        end = perf_shmemx_wtime();
+
+        if(start_pe == metric_info.my_node)
+            printf("target: \n");
+
+        calc_and_print_results((end - start), len, metric_info);
+    } else if(snode) {
+        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
+            for(j = 0; j < metric_info.window_size; j++)
+                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
+
+            shmem_quiet();
+        }
+        end = perf_shmemx_wtime();
+    }
+
+    shmem_barrier_all();
+
+    if(start_pe == metric_info.my_node && snode)
+        printf("initator: \n");
+    if(snode)
+        calc_and_print_results((end - start), len, metric_info);
+}
+
+void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
+{
+    int nPEs = 0, stride = 0, start_pe = 0;
+    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    metric_info->start_len = TARGET_SZ_MAX;
+    len = TARGET_SZ_MAX;
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    /* stopping upper layer from iterating, we are done */
+    metric_info->max_len = TARGET_SZ_MIN;
+}
+
+
 void
 uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
+    if(metric_info->target_data) {
+        target_bw_itr(len, metric_info, !streaming_node(*metric_info));
+        return;
+    }
+
     uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/target_put.h
+++ b/test/performance/shmem_perf_suite/target_put.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, uint32_t start_pe)
+{
+    double start = 0.0, end = 0.0;
+    int i = 0, j = 0;
+    uint32_t dest = partner_node(metric_info);
+    int snode = (metric_info.num_pes != 1)? streaming_node : true;
+    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
+    uint32_t result[2] = {dest, dest};
+    uint64_t *end_dst_ptr = (uint64_t *)(metric_info.dest + (final_len));
+
+    shmem_barrier_all();
+
+    /* reset pointer we will be waiting on */
+    if(!snode)
+        *(end_dst_ptr) = 0;
+
+    shmem_barrier_all();
+    start = perf_shmemx_wtime();
+
+    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
+    if(!snode) {
+        shmem_long_wait_until((long *)end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        end = perf_shmemx_wtime();
+
+        if(start_pe == metric_info.my_node)
+            printf("target: \n");
+
+        calc_and_print_results((end - start), len, metric_info);
+    } else if(snode) {
+        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
+            for(j = 0; j < metric_info.window_size; j++)
+                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
+
+            shmem_quiet();
+        }
+        end = perf_shmemx_wtime();
+    }
+
+    shmem_barrier_all();
+
+    if(start_pe == metric_info.my_node && snode)
+        printf("initator: \n");
+    if(snode)
+        calc_and_print_results((end - start), len, metric_info);
+}
+
+void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
+{
+    int stride = 0;
+    uint32_t start_pe = 0, nPEs = 0;
+    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    metric_info->start_len = TARGET_SZ_MAX;
+    len = TARGET_SZ_MAX;
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    /* stopping upper layer from iterating, we are done */
+    metric_info->max_len = TARGET_SZ_MIN;
+}

--- a/test/performance/shmem_perf_suite/uni_dir.h
+++ b/test/performance/shmem_perf_suite/uni_dir.h
@@ -24,13 +24,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include <target_put.h>
 
-void static inline uni_bw(int len, perf_metrics_t *metric_info, int streaming_node)
+void inline uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
     uint32_t dest = partner_node(*metric_info);
-    int snode = (metric_info->num_pes != 1)? streaming_node : true;
+    int snode = (metric_info->num_pes != 1)? streaming_node(*metric_info) : true;
+
+    if(metric_info->target_data && metric_info->bwstyle == STYLE_PUT) {
+        target_bw_itr(len, metric_info);
+        return;
+    }
 
     shmem_barrier_all();
 

--- a/test/performance/shmem_perf_suite/uni_dir.h
+++ b/test/performance/shmem_perf_suite/uni_dir.h
@@ -29,7 +29,7 @@ void static inline uni_bw(int len, perf_metrics_t *metric_info, int streaming_no
 {
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
-    int dest = partner_node(*metric_info);
+    uint32_t dest = partner_node(*metric_info);
     int snode = (metric_info->num_pes != 1)? streaming_node : true;
 
     shmem_barrier_all();


### PR DESCRIPTION
@jdinan 

-measures the "target" side bw/mr for put at 8bytes & 4KB and compares it to initator 
-look at last commit for put target implementation in the target_put.h file
-enabled via -t option through shmem_bw_put_perf

sample output:
[target_sample.txt](https://github.com/Sandia-OpenSHMEM/SOS/files/869549/target_sample.txt)
