### PR TITLE
Use put_nbi when not requesting completion handle

### DIFF
--- a/src/collectives.c
+++ b/src/collectives.c
@@ -894,8 +894,8 @@ shmem_internal_collect_linear(void *target, const void *source, size_t len,
     peer = shmem_internal_my_pe;
     do {
         if (len > 0) {
-            shmem_internal_put_nb(((uint8_t *) target) + my_offset, source,
-                                  len, peer, NULL);
+            shmem_internal_put_nbi(((uint8_t *) target) + my_offset, source,
+                                  len, peer);
         }
         peer = shmem_internal_circular_iter_next(peer, PE_start, logPE_stride,
                                                  PE_size);
@@ -1107,8 +1107,8 @@ shmem_internal_alltoall(void *dest, const void *source, size_t len,
     do {
         int peer_as_rank = (peer - PE_start) / stride; /* Peer's index in active set */
 
-        shmem_internal_put_nb((void *) dest_ptr, (uint8_t *) source + peer_as_rank * len,
-                              len, peer, NULL);
+        shmem_internal_put_nbi((void *) dest_ptr, (uint8_t *) source + peer_as_rank * len,
+                              len, peer);
         peer = shmem_internal_circular_iter_next(peer, PE_start, logPE_stride,
                                                  PE_size);
     } while (peer != shmem_internal_my_pe);

--- a/src/data_f.c4
+++ b/src/data_f.c4
@@ -71,7 +71,7 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_PUT_SIZE')
         SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * *nelems);              \
         SHMEM_ERR_CHECK_NULL(source, *nelems);                          \
                                                                         \
-        shmem_internal_put_nb(target, source, SIZE * *nelems, *pe, NULL); \
+        shmem_internal_put_nbi(target, source, SIZE * *nelems, *pe);    \
     }
 
 define(`SHMEM_WRAP_FC_PUT_NBI',

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -428,6 +428,7 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
         uint64_t key;
         uint8_t *addr;
 
+        shmem_internal_assert(completion != NULL);
 
 	if (len <= shmem_transport_ofi_max_buffered_send) {
 
@@ -451,9 +452,7 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
 
     } else {
         shmem_transport_ofi_put_large(target, source,len, pe);
-        if (completion != NULL) {
-            (*completion)++;
-        }
+        (*completion)++;
     }
 }
 

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -480,35 +480,29 @@ shmem_transport_portals4_put_nb_internal(void *target, const void *source, size_
 
         shmem_internal_assert(len <= shmem_transport_portals4_max_msg_size);
 
-        /* If user requested completion notification, create a frag object and
+        /* User requested completion notification, create a frag object and
          * append the completion pointer */
-        if (NULL != completion) {
-            md = shmem_transport_portals4_put_event_md_h;
+        md = shmem_transport_portals4_put_event_md_h;
 
-            SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
-            while (0 >= --shmem_transport_portals4_event_slots) {
-                shmem_transport_portals4_event_slots++;
-                shmem_transport_portals4_drain_eq();
-            }
-            SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
-
-            long_frag = (shmem_transport_portals4_long_frag_t*)
-                shmem_free_list_alloc(shmem_transport_portals4_long_frags);
-            if (NULL == long_frag) { RAISE_ERROR(-1); }
-
-            shmem_internal_assert(long_frag->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_LONG);
-            shmem_internal_assert(long_frag->reference == 0);
-            long_frag->completion = completion;
-
-            /* NOTE-MT: Frag mutex is not needed here because the frag doesn't get
-             * exposed to other threads until the PtlPut. */
-            (*(long_frag->completion))++;
-            long_frag->reference++;
-
-        } else {
-            md = shmem_transport_portals4_put_cntr_md_h;
-            long_frag = NULL;
+        SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
+        while (0 >= --shmem_transport_portals4_event_slots) {
+            shmem_transport_portals4_event_slots++;
+            shmem_transport_portals4_drain_eq();
         }
+        SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
+
+        long_frag = (shmem_transport_portals4_long_frag_t*)
+            shmem_free_list_alloc(shmem_transport_portals4_long_frags);
+        if (NULL == long_frag) { RAISE_ERROR(-1); }
+
+        shmem_internal_assert(long_frag->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_LONG);
+        shmem_internal_assert(long_frag->reference == 0);
+        long_frag->completion = completion;
+
+        /* NOTE-MT: Frag mutex is not needed here because the frag doesn't get
+         * exposed to other threads until the PtlPut. */
+        (*(long_frag->completion))++;
+        long_frag->reference++;
 
         ret = PtlPut(md,
                      (ptl_size_t) source,
@@ -884,6 +878,8 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t len, int pe,
     ptl_pt_index_t pt;
     long offset;
     ptl_process_t peer;
+
+    shmem_internal_assert(completion != NULL);
 
     shmem_transport_portals4_fence_complete();
 


### PR DESCRIPTION
The transport_put_nb code assumes you want to bounce buffer, since it
was intended to support blocking put.  For a truly nonblocking put, we
should have been calling transport_put_nbi.  Since we were calling
put_nb, we have been unnecessarily bounce buffering in collect and
all-to-all collectives, which was causing some performance loss.

Signed-off-by: James Dinan <james.dinan@intel.com>