### PR TITLE
Whitespace fixes

### DIFF
--- a/src/accessibility_c.c
+++ b/src/accessibility_c.c
@@ -34,7 +34,7 @@
 
 #endif /* ENABLE_PROFILING */
 
-int 
+int
 shmem_pe_accessible(int pe)
 {
     SHMEM_ERR_CHECK_INITIALIZED();

--- a/src/atomic_f.c
+++ b/src/atomic_f.c
@@ -25,13 +25,13 @@
 
 
 #define FC_SHMEM_SWAP FC_FUNC_(shmem_swap, SHMEM_SWAP)
-fortran_integer_t FC_SHMEM_SWAP(fortran_integer_t *target, 
-				fortran_integer_t *value,
-				fortran_integer_t *pe);
+fortran_integer_t FC_SHMEM_SWAP(fortran_integer_t *target,
+                                fortran_integer_t *value,
+                                fortran_integer_t *pe);
 fortran_integer_t
 FC_SHMEM_SWAP(fortran_integer_t *target,
-	      fortran_integer_t *value, 
-	      fortran_integer_t *pe)
+              fortran_integer_t *value,
+              fortran_integer_t *pe)
 {
     fortran_integer_t newval;
 
@@ -39,20 +39,20 @@ FC_SHMEM_SWAP(fortran_integer_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, SIZEOF_FORTRAN_INTEGER);
 
-    shmem_internal_swap(target, value, &newval, SIZEOF_FORTRAN_INTEGER, 
-			*pe, SHM_INTERNAL_FORTRAN_INTEGER);
+    shmem_internal_swap(target, value, &newval, SIZEOF_FORTRAN_INTEGER,
+                        *pe, SHM_INTERNAL_FORTRAN_INTEGER);
     shmem_internal_get_wait();
     return newval;
 }
 
 
 #define FC_SHMEM_INT4_SWAP FC_FUNC_(shmem_int4_swap, SHMEM_INT4_SWAP)
-int32_t FC_SHMEM_INT4_SWAP(int32_t *target, 
+int32_t FC_SHMEM_INT4_SWAP(int32_t *target,
                            int32_t *value,
                            fortran_integer_t *pe);
 int32_t
 FC_SHMEM_INT4_SWAP(int32_t *target,
-                   int32_t *value, 
+                   int32_t *value,
                    fortran_integer_t *pe)
 {
     int32_t newval;
@@ -61,20 +61,20 @@ FC_SHMEM_INT4_SWAP(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_swap(target, value, &newval, 4, 
-			*pe, SHM_INTERNAL_INT32);
+    shmem_internal_swap(target, value, &newval, 4,
+                        *pe, SHM_INTERNAL_INT32);
     shmem_internal_get_wait();
     return newval;
 }
 
 
 #define FC_SHMEM_INT8_SWAP FC_FUNC_(shmem_int8_swap, SHMEM_INT8_SWAP)
-int64_t FC_SHMEM_INT8_SWAP(int64_t *target, 
+int64_t FC_SHMEM_INT8_SWAP(int64_t *target,
                            int64_t *value,
                            fortran_integer_t *pe);
 int64_t
 FC_SHMEM_INT8_SWAP(int64_t *target,
-                   int64_t *value, 
+                   int64_t *value,
                    fortran_integer_t *pe)
 {
     int64_t newval;
@@ -83,20 +83,20 @@ FC_SHMEM_INT8_SWAP(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_swap(target, value, &newval, 8, 
-			*pe, SHM_INTERNAL_INT64);
+    shmem_internal_swap(target, value, &newval, 8,
+                        *pe, SHM_INTERNAL_INT64);
     shmem_internal_get_wait();
     return newval;
 }
 
 
 #define FC_SHMEM_REAL4_SWAP FC_FUNC_(shmem_real4_swap, SHMEM_REAL4_SWAP)
-float FC_SHMEM_REAL4_SWAP(float *target, 
+float FC_SHMEM_REAL4_SWAP(float *target,
                           float *value,
                           fortran_integer_t *pe);
 float
 FC_SHMEM_REAL4_SWAP(float *target,
-                    float *value, 
+                    float *value,
                     fortran_integer_t *pe)
 {
     float newval;
@@ -108,19 +108,19 @@ FC_SHMEM_REAL4_SWAP(float *target,
     shmem_internal_assert(sizeof(float) == 4);
 
     shmem_internal_swap(target, value, &newval, 4,
-			*pe, SHM_INTERNAL_FLOAT);
+                        *pe, SHM_INTERNAL_FLOAT);
     shmem_internal_get_wait();
     return newval;
 }
 
 
 #define FC_SHMEM_REAL8_SWAP FC_FUNC_(shmem_real8_swap, SHMEM_REAL8_SWAP)
-double FC_SHMEM_REAL8_SWAP(double *target, 
+double FC_SHMEM_REAL8_SWAP(double *target,
                            double *value,
                            fortran_integer_t *pe);
 double
 FC_SHMEM_REAL8_SWAP(double *target,
-                    double *value, 
+                    double *value,
                     fortran_integer_t *pe)
 {
     double newval;
@@ -132,21 +132,21 @@ FC_SHMEM_REAL8_SWAP(double *target,
     shmem_internal_assert(sizeof(double) == 8);
 
     shmem_internal_swap(target, value, &newval, 8,
-			*pe, SHM_INTERNAL_DOUBLE);
+                        *pe, SHM_INTERNAL_DOUBLE);
     shmem_internal_get_wait();
     return newval;
 }
 
 
 #define FC_SHMEM_INT4_CSWAP FC_FUNC_(shmem_int4_cswap, SHMEM_INT4_CSWAP)
-int32_t FC_SHMEM_INT4_CSWAP(int32_t *target, 
+int32_t FC_SHMEM_INT4_CSWAP(int32_t *target,
                             int32_t *cond,
                             int32_t *value,
                             fortran_integer_t *pe);
 int32_t
 FC_SHMEM_INT4_CSWAP(int32_t *target,
-                    int32_t *cond, 
-                    int32_t *value, 
+                    int32_t *cond,
+                    int32_t *value,
                     fortran_integer_t *pe)
 {
     int32_t newval;
@@ -155,8 +155,8 @@ FC_SHMEM_INT4_CSWAP(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_cswap(target, value, &newval, cond, 
-                         4, 
+    shmem_internal_cswap(target, value, &newval, cond,
+                         4,
                          *pe, SHM_INTERNAL_INT32);
     shmem_internal_get_wait();
     return newval;
@@ -164,14 +164,14 @@ FC_SHMEM_INT4_CSWAP(int32_t *target,
 
 
 #define FC_SHMEM_INT8_CSWAP FC_FUNC_(shmem_int8_cswap, SHMEM_INT8_CSWAP)
-int64_t FC_SHMEM_INT8_CSWAP(int64_t *target, 
+int64_t FC_SHMEM_INT8_CSWAP(int64_t *target,
                             int64_t *cond,
                             int64_t *value,
                             fortran_integer_t *pe);
 int64_t
 FC_SHMEM_INT8_CSWAP(int64_t *target,
-                    int64_t *cond, 
-                    int64_t *value, 
+                    int64_t *cond,
+                    int64_t *value,
                     fortran_integer_t *pe)
 {
     int64_t newval;
@@ -181,7 +181,7 @@ FC_SHMEM_INT8_CSWAP(int64_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
     shmem_internal_cswap(target, value, &newval, cond,
-                         8, 
+                         8,
                          *pe, SHM_INTERNAL_INT64);
     shmem_internal_get_wait();
     return newval;
@@ -189,12 +189,12 @@ FC_SHMEM_INT8_CSWAP(int64_t *target,
 
 
 #define FC_SHMEM_INT4_FADD FC_FUNC_(shmem_int4_fadd, SHMEM_INT4_FADD)
-int32_t FC_SHMEM_INT4_FADD(int32_t *target, 
+int32_t FC_SHMEM_INT4_FADD(int32_t *target,
                            int32_t *value,
                            fortran_integer_t *pe);
 int32_t
 FC_SHMEM_INT4_FADD(int32_t *target,
-                   int32_t *value, 
+                   int32_t *value,
                    fortran_integer_t *pe)
 {
     int32_t oldval;
@@ -203,7 +203,7 @@ FC_SHMEM_INT4_FADD(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_fetch_atomic(target, value, &oldval, 4, 
+    shmem_internal_fetch_atomic(target, value, &oldval, 4,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
     shmem_internal_get_wait();
     return oldval;
@@ -211,12 +211,12 @@ FC_SHMEM_INT4_FADD(int32_t *target,
 
 
 #define FC_SHMEM_INT8_FADD FC_FUNC_(shmem_int8_fadd, SHMEM_INT8_FADD)
-int64_t FC_SHMEM_INT8_FADD(int64_t *target, 
+int64_t FC_SHMEM_INT8_FADD(int64_t *target,
                            int64_t *value,
                            fortran_integer_t *pe);
 int64_t
 FC_SHMEM_INT8_FADD(int64_t *target,
-                   int64_t *value, 
+                   int64_t *value,
                    fortran_integer_t *pe)
 {
     int64_t oldval;
@@ -225,7 +225,7 @@ FC_SHMEM_INT8_FADD(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_fetch_atomic(target, value, &oldval, 8, 
+    shmem_internal_fetch_atomic(target, value, &oldval, 8,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
     shmem_internal_get_wait();
     return oldval;
@@ -233,7 +233,7 @@ FC_SHMEM_INT8_FADD(int64_t *target,
 
 
 #define FC_SHMEM_INT4_FINC FC_FUNC_(shmem_int4_finc, SHMEM_INT4_FINC)
-int32_t FC_SHMEM_INT4_FINC(int32_t *target, 
+int32_t FC_SHMEM_INT4_FINC(int32_t *target,
                            fortran_integer_t *pe);
 int32_t
 FC_SHMEM_INT4_FINC(int32_t *target,
@@ -245,7 +245,7 @@ FC_SHMEM_INT4_FINC(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_fetch_atomic(target, &tmp, &oldval, 4, 
+    shmem_internal_fetch_atomic(target, &tmp, &oldval, 4,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
     shmem_internal_get_wait();
     return oldval;
@@ -253,7 +253,7 @@ FC_SHMEM_INT4_FINC(int32_t *target,
 
 
 #define FC_SHMEM_INT8_FINC FC_FUNC_(shmem_int8_finc, SHMEM_INT8_FINC)
-int64_t FC_SHMEM_INT8_FINC(int64_t *target, 
+int64_t FC_SHMEM_INT8_FINC(int64_t *target,
                            fortran_integer_t *pe);
 int64_t
 FC_SHMEM_INT8_FINC(int64_t *target,
@@ -265,7 +265,7 @@ FC_SHMEM_INT8_FINC(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_fetch_atomic(target, &tmp, &oldval, 8, 
+    shmem_internal_fetch_atomic(target, &tmp, &oldval, 8,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
     shmem_internal_get_wait();
     return oldval;
@@ -273,43 +273,43 @@ FC_SHMEM_INT8_FINC(int64_t *target,
 
 
 #define FC_SHMEM_INT4_ADD FC_FUNC_(shmem_int4_add, SHMEM_INT4_ADD)
-void FC_SHMEM_INT4_ADD(int32_t *target, 
+void FC_SHMEM_INT4_ADD(int32_t *target,
                        int32_t *value,
                        fortran_integer_t *pe);
 void
 FC_SHMEM_INT4_ADD(int32_t *target,
-                  int32_t *value, 
+                  int32_t *value,
                   fortran_integer_t *pe)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_atomic_small(target, value, 4, 
+    shmem_internal_atomic_small(target, value, 4,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
 }
 
 
 #define FC_SHMEM_INT8_ADD FC_FUNC_(shmem_int8_add, SHMEM_INT8_ADD)
-void FC_SHMEM_INT8_ADD(int64_t *target, 
+void FC_SHMEM_INT8_ADD(int64_t *target,
                        int64_t *value,
                        fortran_integer_t *pe);
 void
 FC_SHMEM_INT8_ADD(int64_t *target,
-                  int64_t *value, 
+                  int64_t *value,
                   fortran_integer_t *pe)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_atomic_small(target, value, 8, 
+    shmem_internal_atomic_small(target, value, 8,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
 }
 
 
 #define FC_SHMEM_INT4_INC FC_FUNC_(shmem_int4_inc, SHMEM_INT4_INC)
-void FC_SHMEM_INT4_INC(int32_t *target, 
+void FC_SHMEM_INT4_INC(int32_t *target,
                        fortran_integer_t *pe);
 void
 FC_SHMEM_INT4_INC(int32_t *target,
@@ -321,13 +321,13 @@ FC_SHMEM_INT4_INC(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_atomic_small(target, &tmp, 4, 
+    shmem_internal_atomic_small(target, &tmp, 4,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
 }
 
 
 #define FC_SHMEM_INT8_INC FC_FUNC_(shmem_int8_inc, SHMEM_INT8_INC)
-void FC_SHMEM_INT8_INC(int64_t *target, 
+void FC_SHMEM_INT8_INC(int64_t *target,
                        fortran_integer_t *pe);
 void
 FC_SHMEM_INT8_INC(int64_t *target,
@@ -339,7 +339,7 @@ FC_SHMEM_INT8_INC(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_atomic_small(target, &tmp, 8, 
+    shmem_internal_atomic_small(target, &tmp, 8,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
 }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -121,7 +121,7 @@ shmem_internal_collectives_init(int requested_crossover,
     shmem_internal_tree_crossover = requested_crossover;
 
     /* initialize barrier_all psync array */
-    shmem_internal_barrier_all_psync = 
+    shmem_internal_barrier_all_psync =
         shmem_internal_shmalloc(sizeof(long) * SHMEM_BARRIER_SYNC_SIZE);
     if (NULL == shmem_internal_barrier_all_psync) return -1;
 
@@ -132,7 +132,7 @@ shmem_internal_collectives_init(int requested_crossover,
        entire tree */
     full_tree_num_children = 0;
     for (i = 1 ; i <= shmem_internal_num_pes ; i *= tree_radix) {
-        tmp_radix = (shmem_internal_num_pes / i < tree_radix) ? 
+        tmp_radix = (shmem_internal_num_pes / i < tree_radix) ?
             (shmem_internal_num_pes / i) + 1 : tree_radix;
         my_root = (shmem_internal_my_pe / (tmp_radix * i)) * (tmp_radix * i);
         if (my_root != shmem_internal_my_pe) break;
@@ -148,7 +148,7 @@ shmem_internal_collectives_init(int requested_crossover,
 
     k = full_tree_num_children - 1;
     for (i = 1 ; i <= shmem_internal_num_pes ; i *= tree_radix) {
-        tmp_radix = (shmem_internal_num_pes / i < tree_radix) ? 
+        tmp_radix = (shmem_internal_num_pes / i < tree_radix) ?
             (shmem_internal_num_pes / i) + 1 : tree_radix;
         my_root = (shmem_internal_my_pe / (tmp_radix * i)) * (tmp_radix * i);
         if (my_root != shmem_internal_my_pe) break;
@@ -254,27 +254,27 @@ shmem_internal_barrier_linear(int PE_start, int logPE_stride, int PE_size, long 
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
         /* Send acks down psync tree */
-        for (pe = PE_start + stride, i = 1 ; 
-             i < PE_size ;  
+        for (pe = PE_start + stride, i = 1 ;
+             i < PE_size ;
              i++, pe += stride) {
             shmem_internal_put_small(pSync, &one, sizeof(one), pe);
         }
 
     } else {
         /* send message to root */
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), PE_start, 
+        shmem_internal_atomic_small(pSync, &one, sizeof(one), PE_start,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -316,14 +316,14 @@ shmem_internal_barrier_tree(int PE_start, int logPE_stride, int PE_size, long *p
             /* The root of the tree */
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+            shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
-                shmem_internal_atomic_small(pSync, &one, sizeof(one), 
-                                            children[i], 
+                shmem_internal_atomic_small(pSync, &one, sizeof(one),
+                                            children[i],
                                             SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
             }
 
@@ -331,21 +331,21 @@ shmem_internal_barrier_tree(int PE_start, int logPE_stride, int PE_size, long *p
             /* Middle of the tree */
 
             /* send ack to parent */
-            shmem_internal_atomic_small(pSync, &one, sizeof(one), 
+            shmem_internal_atomic_small(pSync, &one, sizeof(one),
                                         parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
             /* wait for ack from parent */
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children  + 1);
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+            shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
                 shmem_internal_atomic_small(pSync, &one, sizeof(one),
-                                            children[i], 
+                                            children[i],
                                             SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
             }
         }
@@ -354,14 +354,14 @@ shmem_internal_barrier_tree(int PE_start, int logPE_stride, int PE_size, long *p
         /* Leaf node */
 
         /* send message up psync tree */
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), parent, 
+        shmem_internal_atomic_small(pSync, &one, sizeof(one), parent,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -437,9 +437,9 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             shmem_internal_put_nb(target, source, len, pe, &completion);
         }
         shmem_internal_put_wait(&completion);
-    
+
         shmem_internal_fence();
-    
+
         /* send completion ack to all peers */
         for (pe = PE_start,i=0; i < PE_size; pe += stride, i++) {
             if (pe == shmem_internal_my_pe) continue;
@@ -451,7 +451,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+            shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
         }
@@ -461,14 +461,14 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
-            
+
         if (1 == complete) {
             /* send ack back to root */
-            shmem_internal_atomic_small(pSync, &one, sizeof(one), 
-                                        real_root, 
+            shmem_internal_atomic_small(pSync, &one, sizeof(one),
+                                        real_root,
                                         SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
         }
     }
@@ -527,23 +527,23 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         shmem_internal_put_wait(&completion);
 
         shmem_internal_fence();
-    
+
         /* send completion ack to all peers */
         for (i = 0 ; i < num_children ; ++i) {
-            shmem_internal_put_small(pSync, &one, sizeof(long), 
+            shmem_internal_put_small(pSync, &one, sizeof(long),
                                      children[i]);
         }
 
         if (1 == complete) {
             /* wait for acks from everyone */
-            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 
-                                  num_children  + 
+            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ,
+                                  num_children  +
                                   ((parent == shmem_internal_my_pe) ?
                                    0 : 1));
         }
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
@@ -557,9 +557,9 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
                                         parent,
                                         SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
         }
-            
+
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), 
+        shmem_internal_put_small(pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -574,7 +574,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
 void
 shmem_internal_op_to_all_linear(void *target, const void *source, int count, int type_size,
                                 int PE_start, int logPE_stride, int PE_size,
-                                void *pWrk, long *pSync, 
+                                void *pWrk, long *pSync,
                                 shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     int stride = 1 << logPE_stride;
@@ -595,8 +595,8 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
         shmem_internal_quiet();
 
         /* let everyone know that it's safe to send to us */
-        for (pe = PE_start + stride, i = 1 ; 
-             i < PE_size ;  
+        for (pe = PE_start + stride, i = 1 ;
+             i < PE_size ;
              i++, pe += stride) {
             shmem_internal_put_small(pSync, &one, sizeof(one), pe);
         }
@@ -626,7 +626,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
     }
 
     /* broadcast out */
-    shmem_internal_bcast(target, target, count * type_size, 0, PE_start, 
+    shmem_internal_bcast(target, target, count * type_size, 0, PE_start,
                          logPE_stride, PE_size, pSync + 2, 0);
 }
 
@@ -634,7 +634,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
 void
 shmem_internal_op_to_all_tree(void *target, const void *source, int count, int type_size,
                               int PE_start, int logPE_stride, int PE_size,
-                              void *pWrk, long *pSync, 
+                              void *pWrk, long *pSync,
                               shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     int stride = 1 << logPE_stride;
@@ -706,7 +706,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
     }
 
     /* broadcast out */
-    shmem_internal_bcast(target, target, count * type_size, 0, PE_start, 
+    shmem_internal_bcast(target, target, count * type_size, 0, PE_start,
                          logPE_stride, PE_size, pSync + 2, 0);
 }
 
@@ -965,7 +965,7 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
         shmem_internal_atomic_small(pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
 
-    shmem_internal_bcast(target, target, len * PE_size, 0, PE_start, logPE_stride, 
+    shmem_internal_bcast(target, target, len * PE_size, 0, PE_start, logPE_stride,
                          PE_size, pSync + 1, 0);
 }
 
@@ -974,7 +974,7 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
  * highest neighbor, each time sending the data it received in the
  * previous iteration.  This algorithm works regardless of process
  * count and is efficient at larger message sizes.
- * 
+ *
  *   (p - 1) alpha + ((p - 1)/p)n beta
  */
 void
@@ -994,7 +994,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
     shmem_internal_assert(SHMEM_COLLECT_SYNC_SIZE >= 1);
 
     /* copy my portion to the right place */
-    memcpy((char*) target + (my_id * len), source, len); 
+    memcpy((char*) target + (my_id * len), source, len);
 
     /* send n - 1 messages to the next highest proc.  Each message
        contains what we received the previous step (including our own
@@ -1007,7 +1007,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
                              len, next_proc, &completion);
         shmem_internal_put_wait(&completion);
         shmem_internal_fence();
-        
+
         /* send completion for this round to next proc.  Note that we
            only ever sent to next_proc and there's a shmem_fence
            between successive calls to the put above.  So a rolling
@@ -1028,7 +1028,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
  * doubling amounts of data at each step.  This implementation only
  * supports power of two processes and is less efficient than the ring
  * algorithm at large messages.
- * 
+ *
  *   log(p) alpha + (p-1)/p n beta
  */
 void
@@ -1056,7 +1056,7 @@ shmem_internal_fcollect_recdbl(void *target, const void *source, size_t len,
 
     /* copy my portion to the right place */
     curr_offset = my_id * len;
-    memcpy((char*) target + curr_offset, source, len); 
+    memcpy((char*) target + curr_offset, source, len);
 
     for (i = 0, distance = 0x1 ; distance < PE_size ; i++, distance <<= 1) {
         int peer = my_id ^ distance;

--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -145,7 +145,7 @@ SHMEM_BIND_C_COLL_FLOATS(`SHMEM_DEF_TO_ALL', `prod', `SHM_INTERNAL_PROD')
 SHMEM_BIND_C_COLL_CMPLX(`SHMEM_DEF_TO_ALL', `prod', `SHM_INTERNAL_PROD')
 
 void
-shmem_broadcast32(void *target, const void *source, size_t nlong, 
+shmem_broadcast32(void *target, const void *source, size_t nlong,
                   int PE_root, int PE_start, int logPE_stride, int PE_size,
                   long *pSync)
 {

--- a/src/collectives_f.c4
+++ b/src/collectives_f.c4
@@ -4,7 +4,7 @@ dnl vi: set ft=m4
  * Copyright 2011 Sandia Corporation. Under the terms of Contract
  * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
  * retains certain rights in this software.
- * 
+ *
  * Copyright (c) 2016 Intel Corporation. All rights reserved.
  * This software is available to you under the BSD license.
  *

--- a/src/data_f.c4
+++ b/src/data_f.c4
@@ -7,7 +7,7 @@ dnl vi: set ft=m4
  *
  * Copyright (c) 2016 Intel Corporation. All rights reserved.
  * This software is available to you under the BSD license.
- * 
+ *
  * This file is part of the Sandia OpenSHMEM software package. For license
  * information, see the LICENSE file in the top level directory of the
  * distribution.

--- a/src/init.c
+++ b/src/init.c
@@ -253,7 +253,7 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     /* exchange information */
     ret = shmem_runtime_exchange();
     if (0 != ret) {
-        fprintf(stderr, "[%03d] ERROR: runtime exchange failed: %d\n", 
+        fprintf(stderr, "[%03d] ERROR: runtime exchange failed: %d\n",
                 shmem_internal_my_pe, ret);
         goto cleanup;
     }

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -222,7 +222,7 @@ shmem_runtime_exchange(void)
 
 
 int
-shmem_runtime_put(char *key, void *value, size_t valuelen) 
+shmem_runtime_put(char *key, void *value, size_t valuelen)
 {
     snprintf(kvs_key, max_key_len, "shmem-%lu-%s", (long unsigned) rank, key);
     if (0 != encode(value, valuelen, kvs_value, max_val_len)) {

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -173,7 +173,7 @@ shmem_runtime_exchange(void)
 
 
 int
-shmem_runtime_put(char *key, void *value, size_t valuelen) 
+shmem_runtime_put(char *key, void *value, size_t valuelen)
 {
     snprintf(kvs_key, max_key_len, "shmem-%lu-%s", (long unsigned) rank, key);
     if (0 != encode(value, valuelen, kvs_value, max_val_len)) {

--- a/src/shmem_accessibility.h
+++ b/src/shmem_accessibility.h
@@ -18,7 +18,7 @@
 
 #include "shmem_comm.h"
 
-static inline int 
+static inline int
 shmem_internal_pe_accessible(int pe)
 {
     return (pe >= 0 && pe < shmem_internal_num_pes) ? 1 : 0;

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -66,7 +66,7 @@ shmem_internal_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync)
         shmem_internal_barrier_dissem(PE_start, logPE_stride, PE_size, pSync);
         break;
     default:
-        fprintf(stderr, "[%03d] Illegal barrier type %d\n", 
+        fprintf(stderr, "[%03d] Illegal barrier type %d\n",
                 shmem_internal_my_pe, shmem_internal_barrier_type);
     }
 }
@@ -112,7 +112,7 @@ shmem_internal_bcast(void *target, const void *source, size_t len,
                                   logPE_stride, PE_size, pSync, complete);
         break;
     default:
-        fprintf(stderr, "[%03d] Illegal broadcast type %d\n", 
+        fprintf(stderr, "[%03d] Illegal broadcast type %d\n",
                 shmem_internal_my_pe, shmem_internal_bcast_type);
     }
 }
@@ -120,11 +120,11 @@ shmem_internal_bcast(void *target, const void *source, size_t len,
 
 void shmem_internal_op_to_all_linear(void *target, const void *source, int count, int type_size,
                                      int PE_start, int logPE_stride, int PE_size,
-                                     void *pWrk, long *pSync, 
+                                     void *pWrk, long *pSync,
                                      shm_internal_op_t op, shm_internal_datatype_t datatype);
 void shmem_internal_op_to_all_tree(void *target, const void *source, int count, int type_size,
                                    int PE_start, int logPE_stride, int PE_size,
-                                   void *pWrk, long *pSync, 
+                                   void *pWrk, long *pSync,
                                    shm_internal_op_t op, shm_internal_datatype_t datatype);
 
 void shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, int type_size,
@@ -187,7 +187,7 @@ shmem_internal_op_to_all(void *target, const void *source, int count,
                                                pWrk, pSync, op, datatype);
             break;
     default:
-        fprintf(stderr, "[%03d] Illegal reduction type %d\n", 
+        fprintf(stderr, "[%03d] Illegal reduction type %d\n",
                 shmem_internal_my_pe, shmem_internal_reduce_type);
     }
 }
@@ -211,7 +211,7 @@ shmem_internal_collect(void *target, const void *source, size_t len,
                                       PE_size, pSync);
         break;
     default:
-        fprintf(stderr, "[%03d] Illegal collect type %d\n", 
+        fprintf(stderr, "[%03d] Illegal collect type %d\n",
                 shmem_internal_my_pe, shmem_internal_collect_type);
     }
 }
@@ -252,7 +252,7 @@ shmem_internal_fcollect(void *target, const void *source, size_t len,
         }
         break;
     default:
-        fprintf(stderr, "[%03d] Illegal fcollect type %d\n", 
+        fprintf(stderr, "[%03d] Illegal fcollect type %d\n",
                 shmem_internal_my_pe, shmem_internal_fcollect_type);
     }
 }

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -206,7 +206,8 @@ shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t 
 static inline
 void
 shmem_internal_atomic_small(void *target, const void *source, size_t len,
-			   int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                            int pe, shm_internal_op_t op,
+                            shm_internal_datatype_t datatype)
 {
     shmem_transport_atomic_small(target, source, len, pe, op, datatype);
 }
@@ -233,8 +234,8 @@ shmem_internal_atomic_set(void *target, const void *source, size_t len,
 static inline
 void
 shmem_internal_atomic_nb(void *target, const void *source, size_t len,
-	              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype,
-                      long *completion)
+                         int pe, shm_internal_op_t op,
+                         shm_internal_datatype_t datatype, long *completion)
 {
     shmem_transport_atomic_nb(target, source, len, pe, op, datatype, completion);
 }
@@ -244,7 +245,8 @@ shmem_internal_atomic_nb(void *target, const void *source, size_t len,
 static inline
 void
 shmem_internal_fetch_atomic(void *target, void *source, void *dest, size_t len,
-			    int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                            int pe, shm_internal_op_t op,
+                            shm_internal_datatype_t datatype)
 {
     shmem_transport_fetch_atomic(target, source, dest, len, pe, op, datatype);
 }

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -27,12 +27,12 @@
 # Copyright (c) 2004-2010 The University of Tennessee and The University
 #                         of Tennessee Research Foundation.  All rights
 #                         reserved.
-# Copyright (c) 2004-2010 High Performance Computing Center Stuttgart, 
+# Copyright (c) 2004-2010 High Performance Computing Center Stuttgart,
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2008 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Los Alamos National Security, LLC.  All rights
-#                         reserved. 
+#                         reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2006-2010 Voltaire, Inc. All rights reserved.
 # Copyright (c) 2006-2011 Sandia National Laboratories. All rights reserved.
@@ -42,7 +42,7 @@
 # Copyright (c) 2006-2009 Myricom, Inc.  All rights reserved.
 # Copyright (c) 2007-2008 UT-Battelle, LLC. All rights reserved.
 # Copyright (c) 2007-2010 IBM Corporation.  All rights reserved.
-# Copyright (c) 1998-2005 Forschungszentrum Juelich, Juelich Supercomputing 
+# Copyright (c) 1998-2005 Forschungszentrum Juelich, Juelich Supercomputing
 #                         Centre, Federal Republic of Germany
 # Copyright (c) 2005-2008 ZIH, TU Dresden, Federal Republic of Germany
 # Copyright (c) 2007      Evergrid, Inc. All rights reserved.

--- a/src/shmem_free_list.c
+++ b/src/shmem_free_list.c
@@ -72,7 +72,7 @@ shmem_free_list_more(shmem_free_list_t *fl)
 
     num_elements = 2;
 
-    buf = malloc(sizeof(shmem_free_list_alloc_t) + 
+    buf = malloc(sizeof(shmem_free_list_alloc_t) +
                  num_elements * fl->element_size);
     if (NULL == buf) return 1;
 

--- a/src/shmem_free_list.h
+++ b/src/shmem_free_list.h
@@ -44,7 +44,7 @@ struct shmem_free_list_t {
 };
 typedef struct shmem_free_list_t shmem_free_list_t;
 
-shmem_free_list_t* shmem_free_list_init(unsigned int element_size, 
+shmem_free_list_t* shmem_free_list_init(unsigned int element_size,
                                         shmem_free_list_item_init_fn_t init_fn);
 void shmem_free_list_destroy(shmem_free_list_t *fl);
 int shmem_free_list_more(shmem_free_list_t *fl);
@@ -79,7 +79,7 @@ void
 shmem_free_list_free(shmem_free_list_t *fl, void *data)
 {
     shmem_free_list_item_t *item = (shmem_free_list_item_t*) data;
-    
+
     SHMEM_MUTEX_LOCK(fl->lock);
     item->next = fl->head;
     fl->head = item;

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -371,7 +371,7 @@ char *shmem_internal_nodename(void);
 
 int shmem_internal_symmetric_init(size_t requested_length, int use_malloc);
 int shmem_internal_symmetric_fini(void);
-int shmem_internal_collectives_init(int requested_crossover, 
+int shmem_internal_collectives_init(int requested_crossover,
                                     int requested_radix);
 
 /* internal allocation, without a barrier */

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -25,7 +25,7 @@ static inline void
 shmem_internal_quiet(void)
 {
     int ret;
- 
+
     ret = shmem_transport_quiet();
     if (0 != ret) { RAISE_ERROR(ret); }
 
@@ -34,13 +34,13 @@ shmem_internal_quiet(void)
     if (0 != ret) { RAISE_ERROR(ret); }
 #endif
 }
- 
- 
+
+
 static inline void
 shmem_internal_fence(void)
 {
     int ret;
- 
+
     ret = shmem_transport_fence();
     if (0 != ret) { RAISE_ERROR(ret); }
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -160,8 +160,8 @@ static void *mmap_alloc(size_t bytes)
     char *directory = NULL;
     const char basename[] = "hugepagefile.SOS";
     int size;
-    void *requested_base = 
-        (void*) (((unsigned long) shmem_internal_data_base + 
+    void *requested_base =
+        (void*) (((unsigned long) shmem_internal_data_base +
                   shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
     void *ret;
 
@@ -231,11 +231,11 @@ shmem_internal_symmetric_init(size_t requested_length, int use_malloc)
 
     if (0 == shmem_internal_use_malloc) {
         shmem_internal_heap_base =
-            shmem_internal_heap_curr = 
+            shmem_internal_heap_curr =
             mmap_alloc(shmem_internal_heap_length);
     } else {
-        shmem_internal_heap_base = 
-            shmem_internal_heap_curr = 
+        shmem_internal_heap_base =
+            shmem_internal_heap_curr =
             malloc(shmem_internal_heap_length);
     }
 

--- a/src/synchronization_f.c
+++ b/src/synchronization_f.c
@@ -49,7 +49,7 @@ FC_SHMEM_FENCE(void)
 
 
 #define FC_SHMEM_INT4_WAIT FC_FUNC_(shmem_int4_wait, SHMEM_INT4_WAIT)
-void FC_SHMEM_INT4_WAIT(volatile int32_t *var, 
+void FC_SHMEM_INT4_WAIT(volatile int32_t *var,
                         int32_t *value);
 void
 FC_SHMEM_INT4_WAIT(volatile int32_t *var,
@@ -63,7 +63,7 @@ FC_SHMEM_INT4_WAIT(volatile int32_t *var,
 
 
 #define FC_SHMEM_INT8_WAIT FC_FUNC_(shmem_int8_wait, SHMEM_INT8_WAIT)
-void FC_SHMEM_INT8_WAIT(volatile int64_t *var, 
+void FC_SHMEM_INT8_WAIT(volatile int64_t *var,
                         int64_t *value);
 void
 FC_SHMEM_INT8_WAIT(volatile int64_t *var,
@@ -77,7 +77,7 @@ FC_SHMEM_INT8_WAIT(volatile int64_t *var,
 
 
 #define FC_SHMEM_WAIT FC_FUNC_(shmem_wait, SHMEM_WAIT)
-void FC_SHMEM_WAIT(volatile fortran_integer_t *var, 
+void FC_SHMEM_WAIT(volatile fortran_integer_t *var,
                    fortran_integer_t *value);
 void
 FC_SHMEM_WAIT(volatile fortran_integer_t *var,
@@ -91,7 +91,7 @@ FC_SHMEM_WAIT(volatile fortran_integer_t *var,
 
 
 #define FC_SHMEM_INT4_WAIT_UNTIL FC_FUNC_(shmem_int4_wait_until, SHMEM_INT4_WAIT_UNTIL)
-void FC_SHMEM_INT4_WAIT_UNTIL(volatile int32_t *var, 
+void FC_SHMEM_INT4_WAIT_UNTIL(volatile int32_t *var,
                               fortran_integer_t *cond,
                               int32_t *value);
 void
@@ -108,7 +108,7 @@ FC_SHMEM_INT4_WAIT_UNTIL(volatile int32_t *var,
 
 
 #define FC_SHMEM_INT8_WAIT_UNTIL FC_FUNC_(shmem_int8_wait_until, SHMEM_INT8_WAIT_UNTIL)
-void FC_SHMEM_INT8_WAIT_UNTIL(volatile int64_t *var, 
+void FC_SHMEM_INT8_WAIT_UNTIL(volatile int64_t *var,
                               fortran_integer_t *cond,
                               int64_t *value);
 void
@@ -125,7 +125,7 @@ FC_SHMEM_INT8_WAIT_UNTIL(volatile int64_t *var,
 
 
 #define FC_SHMEM_WAIT_UNTIL FC_FUNC_(shmem_wait_until, SHMEM_WAIT_UNTIL)
-void FC_SHMEM_WAIT_UNTIL(volatile fortran_integer_t *var, 
+void FC_SHMEM_WAIT_UNTIL(volatile fortran_integer_t *var,
                          fortran_integer_t *cond,
                          fortran_integer_t *value);
 void

--- a/src/transport_cma.h
+++ b/src/transport_cma.h
@@ -37,7 +37,7 @@ int shmem_transport_cma_startup(void);
 int shmem_transport_cma_fini(void);
 
 /*
- * Validate address is within SHMEM bounds: data and/or symHeap. 
+ * Validate address is within SHMEM bounds: data and/or symHeap.
  */
 #ifdef ENABLE_ERROR_CHECKING
 #define CHK_ACCESS(target,name)                                         \

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -232,7 +232,7 @@ shmem_transport_init(long eager_size)
     SHMEM_MUTEX_INIT(shmem_internal_mutex_ptl4_nb_fence);
 
     shmem_transport_portals4_bounce_buffer_size = eager_size;
-    shmem_transport_portals4_bounce_buffers = 
+    shmem_transport_portals4_bounce_buffers =
         shmem_free_list_init(sizeof(shmem_transport_portals4_bounce_buffer_t) + eager_size,
                              init_bounce_buffer);
 
@@ -323,7 +323,7 @@ shmem_transport_init(long eager_size)
 
         bases[0] = (uintptr_t) shmem_internal_heap_base;
         bases[1] = (uintptr_t) shmem_internal_data_base;
-        
+
         ret = shmem_runtime_put("portals4-bases", bases, sizeof(uint64_t) * 2);
         if (0 != ret) {
             fprintf(stderr, "[%03d] ERROR: runtime_put failed: %d\n",
@@ -414,7 +414,7 @@ shmem_transport_startup(void)
     }
 
     ret = PtlSetMap(shmem_transport_portals4_ni_h,
-                    shmem_internal_num_pes,                    
+                    shmem_internal_num_pes,
                     desired);
     if (PTL_OK != ret && PTL_IGNORED != ret) {
         fprintf(stderr, "[%03d] ERROR: PtlSetMap failed: %d\n",
@@ -451,7 +451,7 @@ shmem_transport_startup(void)
     }
 
     /* create portal table entries */
-    ret = PtlEQAlloc(shmem_transport_portals4_ni_h, 
+    ret = PtlEQAlloc(shmem_transport_portals4_ni_h,
                      shmem_transport_portals4_event_slots,
                      &shmem_transport_portals4_eq_h);
     if (PTL_OK != ret) {
@@ -506,7 +506,7 @@ shmem_transport_startup(void)
     le.ct_handle = shmem_transport_portals4_target_ct_h;
 #endif
     le.uid = uid;
-    le.options = PTL_LE_OP_PUT | PTL_LE_OP_GET | 
+    le.options = PTL_LE_OP_PUT | PTL_LE_OP_GET |
         PTL_LE_EVENT_LINK_DISABLE |
         PTL_LE_EVENT_SUCCESS_DISABLE;
 #if !defined(ENABLE_HARD_POLLING)
@@ -628,7 +628,7 @@ shmem_transport_startup(void)
 
     md.start = 0;
     md.length = PTL_SIZE_MAX;
-    md.options = PTL_MD_EVENT_CT_REPLY | 
+    md.options = PTL_MD_EVENT_CT_REPLY |
         PTL_MD_EVENT_SUCCESS_DISABLE;
     if (1 == PORTALS4_TOTAL_DATA_ORDERING) {
         md.options |= PTL_MD_UNORDERED;
@@ -667,7 +667,7 @@ shmem_transport_fini(void)
     PtlAtomicSync();
 
     /* wait for remote completion (acks) of all pending events */
-    PtlCTWait(shmem_transport_portals4_put_ct_h, 
+    PtlCTWait(shmem_transport_portals4_put_ct_h,
               shmem_transport_portals4_pending_put_counter, &ct);
     if (shmem_transport_portals4_pending_put_counter != ct.success + ct.failure) {
         fprintf(stderr, "[%03d] WARNING: put count mismatch: %ld, %ld\n",
@@ -675,7 +675,7 @@ shmem_transport_fini(void)
                 (long) (ct.success + ct.failure));
     }
 
-    PtlCTWait(shmem_transport_portals4_get_ct_h, 
+    PtlCTWait(shmem_transport_portals4_get_ct_h,
               shmem_transport_portals4_pending_get_counter, &ct);
     if (shmem_transport_portals4_pending_get_counter != ct.success + ct.failure) {
         fprintf(stderr, "[%03d] WARNING: get count mismatch: %ld, %ld\n",

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -196,7 +196,7 @@ typedef struct shmem_transport_ct_t shmem_transport_ct_t;
         }                                                               \
     } while (0)
 #endif
-#else 
+#else
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
 #define PORTALS4_GET_REMOTE_ACCESS_ONEPT(target, pt, offset, shr_pt)    \
     do {                                                                \
@@ -260,7 +260,7 @@ shmem_transport_quiet(void)
     shmem_transport_get_wait();
 
     /* wait for remote completion (acks) of all pending put events */
-    ret = PtlCTWait(shmem_transport_portals4_put_ct_h, 
+    ret = PtlCTWait(shmem_transport_portals4_put_ct_h,
                     shmem_transport_portals4_pending_put_counter, &ct);
     if (PTL_OK != ret) { return ret; }
     if (ct.failure != 0) { return -1; }
@@ -347,7 +347,7 @@ shmem_transport_portals4_drain_eq(void)
 
     shmem_transport_portals4_event_slots++;
 
-    shmem_transport_portals4_frag_t *frag = 
+    shmem_transport_portals4_frag_t *frag =
          (shmem_transport_portals4_frag_t*) ev.user_ptr;
 
     /* NOTE-MT: A different thread may have created this frag, so we need a
@@ -361,7 +361,7 @@ shmem_transport_portals4_drain_eq(void)
                               frag);
     } else {
          /* it's one of the long messages we're waiting for */
-         shmem_transport_portals4_long_frag_t *long_frag = 
+         shmem_transport_portals4_long_frag_t *long_frag =
               (shmem_transport_portals4_long_frag_t*) frag;
 
          (*(long_frag->completion))--;
@@ -703,7 +703,7 @@ shmem_transport_get_wait(void)
     int ret;
     ptl_ct_event_t ct;
 
-    ret = PtlCTWait(shmem_transport_portals4_get_ct_h, 
+    ret = PtlCTWait(shmem_transport_portals4_get_ct_h,
                     shmem_transport_portals4_pending_get_counter,
                     &ct);
     if (PTL_OK != ret) { RAISE_ERROR(ret); }

--- a/src/transport_xpmem.c
+++ b/src/transport_xpmem.c
@@ -100,7 +100,7 @@ shmem_transport_xpmem_startup(void)
     }
 
     /* allocate space for local peers */
-    shmem_transport_xpmem_peers = calloc(num_on_node, 
+    shmem_transport_xpmem_peers = calloc(num_on_node,
                                          sizeof(struct shmem_transport_xpmem_peer_info_t));
     if (NULL == shmem_transport_xpmem_peers) return 1;
 
@@ -110,9 +110,9 @@ shmem_transport_xpmem_startup(void)
         if (-1 == peer_num) continue;
 
         if (shmem_internal_my_pe == i) {
-            shmem_transport_xpmem_peers[peer_num].data_ptr = 
+            shmem_transport_xpmem_peers[peer_num].data_ptr =
                 shmem_internal_data_base;
-            shmem_transport_xpmem_peers[peer_num].heap_ptr = 
+            shmem_transport_xpmem_peers[peer_num].heap_ptr =
                 shmem_internal_heap_base;
         } else {
             ret = shmem_runtime_get(i, "xpmem-segids", &info, sizeof(struct share_info_t));
@@ -133,14 +133,14 @@ shmem_transport_xpmem_startup(void)
             addr.apid = shmem_transport_xpmem_peers[peer_num].data_apid;
             addr.offset = 0;
 
-            shmem_transport_xpmem_peers[peer_num].data_attach_ptr = 
+            shmem_transport_xpmem_peers[peer_num].data_attach_ptr =
                 xpmem_attach(addr, info.data_len, NULL);
             if ((size_t) shmem_transport_xpmem_peers[peer_num].data_ptr == XPMEM_MAXADDR_SIZE) {
                 fprintf(stderr, "[%03d] ERROR: could not get data segment: %s\n",
                         shmem_internal_my_pe, strerror(errno));
                 return 1;
             }
-            shmem_transport_xpmem_peers[peer_num].data_ptr = 
+            shmem_transport_xpmem_peers[peer_num].data_ptr =
                 (char*) shmem_transport_xpmem_peers[peer_num].data_attach_ptr + info.data_off;
 
             shmem_transport_xpmem_peers[peer_num].heap_apid =
@@ -154,14 +154,14 @@ shmem_transport_xpmem_startup(void)
             addr.apid = shmem_transport_xpmem_peers[peer_num].heap_apid;
             addr.offset = 0;
 
-            shmem_transport_xpmem_peers[peer_num].heap_attach_ptr = 
+            shmem_transport_xpmem_peers[peer_num].heap_attach_ptr =
                 xpmem_attach(addr, info.heap_len, NULL);
             if ((size_t) shmem_transport_xpmem_peers[peer_num].heap_ptr == XPMEM_MAXADDR_SIZE) {
                 fprintf(stderr, "[%03d] ERROR: could not get data segment: %s\n",
                         shmem_internal_my_pe, strerror(errno));
                 return 1;
             }
-            shmem_transport_xpmem_peers[peer_num].heap_ptr = 
+            shmem_transport_xpmem_peers[peer_num].heap_ptr =
                 (char*) shmem_transport_xpmem_peers[peer_num].heap_attach_ptr + info.heap_off;
         }
     }
@@ -184,21 +184,21 @@ shmem_transport_xpmem_fini(void)
             if (NULL != shmem_transport_xpmem_peers[peer_num].data_ptr) {
                 xpmem_detach(shmem_transport_xpmem_peers[peer_num].data_attach_ptr);
             }
-                
+
             if (0 != shmem_transport_xpmem_peers[peer_num].data_apid) {
                 xpmem_release(shmem_transport_xpmem_peers[peer_num].data_apid);
             }
-                
+
             if (NULL != shmem_transport_xpmem_peers[peer_num].heap_ptr) {
                 xpmem_detach(shmem_transport_xpmem_peers[peer_num].heap_attach_ptr);
             }
-                
+
             if (0 != shmem_transport_xpmem_peers[peer_num].heap_apid) {
                 xpmem_release(shmem_transport_xpmem_peers[peer_num].heap_apid);
             }
         }
         free(shmem_transport_xpmem_peers);
-    } 
+    }
 
     if (0 != my_info.data_seg) {
         xpmem_remove(my_info.data_seg);

--- a/src/transport_xpmem.h
+++ b/src/transport_xpmem.h
@@ -96,7 +96,7 @@ shmem_transport_xpmem_fence(void)
 
 static inline
 void
-shmem_transport_xpmem_put(void *target, const void *source, size_t len, 
+shmem_transport_xpmem_put(void *target, const void *source, size_t len,
                           int pe, int noderank)
 {
     char *remote_ptr;
@@ -105,7 +105,7 @@ shmem_transport_xpmem_put(void *target, const void *source, size_t len,
 #ifdef ENABLE_ERROR_CHECKING
     if (NULL == remote_ptr) {
         fprintf(stderr, "[%03d] ERROR: target (0x%lx) outside of symmetric areas\n",
-                shmem_internal_my_pe, (unsigned long) target);      
+                shmem_internal_my_pe, (unsigned long) target);
         RAISE_ERROR(1);
     }
 #endif
@@ -117,7 +117,7 @@ shmem_transport_xpmem_put(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_xpmem_get(void *target, const void *source, size_t len, 
+shmem_transport_xpmem_get(void *target, const void *source, size_t len,
                           int pe, int noderank)
 {
     char *remote_ptr;
@@ -126,7 +126,7 @@ shmem_transport_xpmem_get(void *target, const void *source, size_t len,
 #ifdef ENABLE_ERROR_CHECKING
     if (NULL == remote_ptr) {
         fprintf(stderr, "[%03d] ERROR: target (0x%lx) outside of symmetric areas\n",
-                shmem_internal_my_pe, (unsigned long) target);      
+                shmem_internal_my_pe, (unsigned long) target);
         RAISE_ERROR(1);
     }
 #endif

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -195,64 +195,64 @@ int SHMEMRandomAccess(void);
 
 static double RTSEC(void)
 {
-	struct timeval tp;
-	gettimeofday (&tp, NULL);
-	return tp.tv_sec + tp.tv_usec/(double)1.0e6;
+  struct timeval tp;
+  gettimeofday (&tp, NULL);
+  return tp.tv_sec + tp.tv_usec/(double)1.0e6;
 }
 
 static void print_usage(void)
 {
-	fprintf(stderr, "\nOptions:\n");
-	fprintf(stderr, " %-20s %s\n", "-h", "display this help message");
-	fprintf(stderr, " %-20s %s\n", "-m", "memory in bytes per PE");
-	fprintf(stderr, " %-20s %s\n", "-n", "number of updates per PE");
+  fprintf(stderr, "\nOptions:\n");
+  fprintf(stderr, " %-20s %s\n", "-h", "display this help message");
+  fprintf(stderr, " %-20s %s\n", "-m", "memory in bytes per PE");
+  fprintf(stderr, " %-20s %s\n", "-n", "number of updates per PE");
 
-	return;
+  return;
 }
 
 static int64_t starts(uint64_t n)
 {
-	/* int64_t i, j; */
-	int i, j;
-	uint64_t m2[64];
-	uint64_t temp, ran;
+  /* int64_t i, j; */
+  int i, j;
+  uint64_t m2[64];
+  uint64_t temp, ran;
 
-	/*
-	 * this loop doesn't make sense
-	 * so commenting out.
-	 */
+  /*
+   * this loop doesn't make sense
+   * so commenting out.
+   */
 #if 0
-	while (n < 0)
-		n += PERIOD;
+  while (n < 0)
+    n += PERIOD;
 #endif
-	while (n > PERIOD)
-		n -= PERIOD;
-	if (n == 0)
-		return 0x1;
+  while (n > PERIOD)
+    n -= PERIOD;
+  if (n == 0)
+    return 0x1;
 
-	temp = 0x1;
-	for (i=0; i<64; i++) {
-		m2[i] = temp;
-		temp = (temp << 1) ^ ((int64_t) temp < 0 ? POLY : 0);
-		temp = (temp << 1) ^ ((int64_t) temp < 0 ? POLY : 0);
-	}
+  temp = 0x1;
+  for (i=0; i<64; i++) {
+    m2[i] = temp;
+    temp = (temp << 1) ^ ((int64_t) temp < 0 ? POLY : 0);
+    temp = (temp << 1) ^ ((int64_t) temp < 0 ? POLY : 0);
+  }
 
-	for (i=62; i>=0; i--)
-		if ((n >> i) & 1) break;
+  for (i=62; i>=0; i--)
+    if ((n >> i) & 1) break;
 
-	ran = 0x2;
+  ran = 0x2;
 
-	while (i > 0) {
-		temp = 0;
-		for (j=0; j<64; j++)
-			if ((ran >> j) & 1) temp ^= m2[j];
-		ran = temp;
-		i -= 1;
-		if ((n >> i) & 1)
-			ran = (ran << 1) ^ ((int64_t) ran < 0 ? POLY : 0);
-	}
+  while (i > 0) {
+    temp = 0;
+    for (j=0; j<64; j++)
+      if ((ran >> j) & 1) temp ^= m2[j];
+    ran = temp;
+    i -= 1;
+    if ((n >> i) & 1)
+      ran = (ran << 1) ^ ((int64_t) ran < 0 ? POLY : 0);
+  }
 
-	return ran;
+  return ran;
 }
 
 static void
@@ -482,9 +482,9 @@ SHMEMRandomAccess(void)
       NumErrors++;
   }
 
-  shmem_barrier_all(); 
+  shmem_barrier_all();
   shmem_longlong_sum_to_all( (long long *)&GlbNumErrors,  (long long *)&NumErrors, 1, 0,0, NumProcs,llpWrk, pSync_reduce);
-  shmem_barrier_all(); 
+  shmem_barrier_all();
 
   /* End timed section */
 
@@ -512,42 +512,42 @@ SHMEMRandomAccess(void)
 
 int main(int argc, char **argv)
 {
-	int op;
+  int op;
 
-	while ((op = getopt(argc, argv, "hm:n:")) != -1) {
-		switch (op) {
-		/*
-		 * memory per PE (used for determining table size)
-		 */
-		case 'm':
-			TotalMemOpt = atoll(optarg);
-			if (TotalMemOpt <= 0) {
-				print_usage();
-				return -1;
-			}
-			break;
+  while ((op = getopt(argc, argv, "hm:n:")) != -1) {
+    switch (op) {
+      /*
+       * memory per PE (used for determining table size)
+       */
+      case 'm':
+        TotalMemOpt = atoll(optarg);
+        if (TotalMemOpt <= 0) {
+          print_usage();
+          return -1;
+        }
+        break;
 
-		/*
-		 * num updates/PE
-		 */
-		case 'n':
-			NumUpdatesOpt = atoi(optarg);
-			if (NumUpdatesOpt <= 0) {
-				print_usage();
-				return -1;
-			}
-			break;
+        /*
+         * num updates/PE
+         */
+      case 'n':
+        NumUpdatesOpt = atoi(optarg);
+        if (NumUpdatesOpt <= 0) {
+          print_usage();
+          return -1;
+        }
+        break;
 
-		case '?':
-		case 'h':
-			print_usage();
-			return -1;
-		}
-	}
+      case '?':
+      case 'h':
+        print_usage();
+        return -1;
+    }
+  }
 
-	shmem_init();
-	SHMEMRandomAccess();
-	shmem_finalize();
+  shmem_init();
+  SHMEMRandomAccess();
+  shmem_finalize();
 
-	return 0;
+  return 0;
 }

--- a/test/performance/tests/Makefile.am
+++ b/test/performance/tests/Makefile.am
@@ -3,7 +3,7 @@
 # Copyright 2011 Sandia Corporation. Under the terms of Contract
 # DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
 # retains certain rights in this software.
-# 
+#
 # Copyright (c) 2016 Intel Corporation. All rights reserved.
 # This software is available to you under the BSD license.
 #

--- a/test/performance/tests/msgrate.c
+++ b/test/performance/tests/msgrate.c
@@ -16,7 +16,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  */
 
@@ -121,8 +121,8 @@ test_one_way(void)
 
                 tmp = timer();
                 for (k = 0 ; k < nmsgs ; ++k) {
-                    shmem_putmem(recv_buf + (nbytes * k), 
-                                 send_buf + (nbytes * k), 
+                    shmem_putmem(recv_buf + (nbytes * k),
+                                 send_buf + (nbytes * k),
                                  nbytes, rank + (world_size / 2));
                 }
                 shmem_quiet();
@@ -174,8 +174,8 @@ test_prepost(void)
         tmp = timer();
         for (j = 0 ; j < npeers ; ++j) {
             for (k = 0 ; k < nmsgs ; ++k) {
-                shmem_putmem(recv_buf + (nbytes * (k + j * nmsgs)), 
-                             send_buf + (nbytes * (k + j * nmsgs)), 
+                shmem_putmem(recv_buf + (nbytes * (k + j * nmsgs)),
+                             send_buf + (nbytes * (k + j * nmsgs)),
                              nbytes, send_peers[npeers - j - 1]);
             }
         }
@@ -226,7 +226,7 @@ main(int argc, char *argv[])
     /* root handles arguments and bcasts answers */
     if (0 == rank) {
         int ch;
-        while (start_err != 1 && 
+        while (start_err != 1 &&
                (ch = getopt(argc, argv, "p:i:m:s:c:n:oh")) != -1) {
             switch (ch) {
             case 'p':
@@ -264,7 +264,7 @@ main(int argc, char *argv[])
             if (world_size < 3) {
                 fprintf(stderr, "Error: At least three processes are required\n");
                 start_err = 1;
-            } else 
+            } else
 #endif
                 if (world_size <= npeers) {
                 fprintf(stderr, "Error: job size (%d) <= number of peers (%d)\n",
@@ -320,7 +320,7 @@ main(int argc, char *argv[])
             printf("cache size: %d\n", cache_size * (int)sizeof(int));
             printf("ppn:        %d\n", ppn);
         } else {
-            printf("%d %d %d %d %d %d %d ", 
+            printf("%d %d %d %d %d %d %d ",
                    world_size, npeers, niters, nmsgs, nbytes,
                    cache_size * (int)sizeof(int), ppn);
         }
@@ -357,7 +357,7 @@ main(int argc, char *argv[])
             } else {
                 recv_peers[i] = (rank + world_size + ((i - npeers / 2 + 1) * ppn)) % world_size;
             }
-        } 
+        }
     } else {
         /* odd */
         for (i = 0 ; i < npeers ; ++i) {

--- a/test/performance/tests/shmemlatency.c
+++ b/test/performance/tests/shmemlatency.c
@@ -30,8 +30,8 @@
  */
 
 /*
-**  This is a pingpong test used to calculate 
-**  latency and bandwidth for various message 
+**  This is a pingpong test used to calculate
+**  latency and bandwidth for various message
 **  sizes.
 **
 **  SHMEM version
@@ -43,7 +43,7 @@
 #include <shmem.h>
 #include <shmemx.h>
 
-#define SIZE		(10000000)
+#define SIZE  (10000000)
 
 #define TRUE  (1)
 #define FALSE (0)
@@ -56,13 +56,12 @@ char *buf;
 
 int my_node;
 
-int 
+int
 main(int argc, char *argv[])
 {
 
     extern char *optarg;
     int ch, error;
-	
     int len, start_len, end_len, increment, inc, trials, i;
     int mega;
     double latency, bandwidth;
@@ -88,7 +87,7 @@ main(int argc, char *argv[])
     increment = 16;
     trials= 1000;
     mega= TRUE;
- 
+
     /* check command line args */
     while ((ch= getopt(argc, argv, "i:e:s:n:m")) != EOF)   {
         switch (ch)   {
@@ -105,7 +104,7 @@ main(int argc, char *argv[])
         case 'n':
             trials= strtol(optarg, (char **)NULL, 0);
             break;
-        case 'm': 
+        case 'm':
             mega= FALSE;
             break;
         default:
@@ -113,7 +112,7 @@ main(int argc, char *argv[])
             break;
         }
     }
- 
+
     if (error)   {
         if (my_node == 0)   {
             fprintf(stderr, "Usage: %s [-s start_length] [-e end_length] [-i inc] [-n trials] [-m (millions)]\n", argv[0]);
@@ -124,7 +123,7 @@ main(int argc, char *argv[])
 
     if (my_node == 0)   {
         printf("\n");
-        printf("Results for %d trials each of length %d through %d in increments of %d\n\n", 
+        printf("Results for %d trials each of length %d through %d in increments of %d\n\n",
                trials, start_len, end_len, increment);
         printf("Length                  Latency                             Bandwidth\n");
         printf("in bytes            in micro seconds                ");
@@ -173,14 +172,14 @@ main(int argc, char *argv[])
             printf("%9d  %8.2f    %8.2f    %8.2f    ",
                    len, min_latency, tot_latency / trials, max_latency);
             if (mega)   {
-                printf("%8.2f    %8.2f    %8.2f\n", 
+                printf("%8.2f    %8.2f    %8.2f\n",
                        min_bandwidth / (1024 * 1024),
-                       (tot_bandwidth / trials) / (1024 * 1024), 
+                       (tot_bandwidth / trials) / (1024 * 1024),
                        max_bandwidth / (1024 * 1024));
             } else   {
-                printf("%8.2f    %8.2f    %8.2f\n", 
-                       min_bandwidth / 1000000.0, 
-                       (tot_bandwidth / trials) / 1000000.0, 
+                printf("%8.2f    %8.2f    %8.2f\n",
+                       min_bandwidth / 1000000.0,
+                       (tot_bandwidth / trials) / 1000000.0,
                        max_bandwidth / 1000000.0);
             }
         }

--- a/test/unit/atomic_inc.c
+++ b/test/unit/atomic_inc.c
@@ -33,7 +33,7 @@
  * test shmem_int_inc() atomic_inc {-v|q} {loop-cnt(default=10)(default=10)}
  * where: -q == quiet, -v == verbose/debug
  *  Loop for loop-cnt
- *   all PEs call shmem_int_inc(), PE-0 totals 
+ *   all PEs call shmem_int_inc(), PE-0 totals
  *
  */
 
@@ -71,7 +71,7 @@ main(int argc, char* argv[])
         shmem_finalize();
         return 0;
     }
- 
+
     while((c=getopt(argc,argv,"vq")) != -1) {
         switch(c) {
           case 'v':
@@ -103,7 +103,7 @@ main(int argc, char* argv[])
     {
         lock_cnt = 0;
         shmem_barrier_all();  /* sync all ranks */
-        
+
         for(c=0; c < num_ranks; c++)
             shmem_int_inc( &lock_cnt, c );
 

--- a/test/unit/barrier.c
+++ b/test/unit/barrier.c
@@ -49,62 +49,62 @@ int Verbose;
 int
 main(int argc, char* argv[])
 {
-	int c, j,loops;
-	int rank, num_ranks;
-	char *prog_name;
+    int c, j,loops;
+    int rank, num_ranks;
+    char *prog_name;
 
-	shmem_init();
-	rank = shmem_my_pe();
-	num_ranks = shmem_n_pes();
-	if (num_ranks == 1) {
-   		Rfprintf(stderr,
-			"ERR - Requires > 1 PEs\n");
-		shmem_finalize();
-		return 0;
-	}
-	prog_name = strrchr(argv[0],'/');
-	if ( prog_name )
-		prog_name++;
-	else
-		prog_name = argv[0];
-
-	while((c=getopt(argc,argv,"v")) != -1) {
-		switch(c) {
-		  case 'V':
-			Verbose++;
-			break;
-		  default:
-   			Rfprintf(stderr,"ERR - unknown -%c ?\n",c);
-			shmem_finalize();
-			return 1;
-		}
-	}
-
-	if (optind == argc)
-		loops = 30;
-	else {
-		loops = atoi(argv[optind++]);
-		if (loops <= 0 || loops > 1000000) {
-    			Rfprintf(stderr,
-				"ERR - loops arg out of bounds '%d'?\n", loops);
-			shmem_finalize();
-			return 1;
-		}
-	}
-
-	for(j=0; j < loops; j++) {
-		//if ( j==0 || (j % 10) == 0 )
-    		RDfprintf(stderr,"[%d] pre-barrier(%d)\n", rank,j);
-
-		shmem_barrier_all();  /* sync sender and receiver */
-
-		//if ( j==0 || (j % 10) == 0 )
-    		RDfprintf(stderr,"[%d] post barrier(%d)\n", rank,j);
-	}
-
-        RDprintf ("%d(%d) Exit\n", rank, num_ranks);
-
+    shmem_init();
+    rank = shmem_my_pe();
+    num_ranks = shmem_n_pes();
+    if (num_ranks == 1) {
+        Rfprintf(stderr,
+                 "ERR - Requires > 1 PEs\n");
         shmem_finalize();
+        return 0;
+    }
+    prog_name = strrchr(argv[0],'/');
+    if ( prog_name )
+        prog_name++;
+    else
+        prog_name = argv[0];
 
-	return 0;
+    while((c=getopt(argc,argv,"v")) != -1) {
+        switch(c) {
+            case 'V':
+                Verbose++;
+                break;
+            default:
+                Rfprintf(stderr,"ERR - unknown -%c ?\n",c);
+                shmem_finalize();
+                return 1;
+        }
+    }
+
+    if (optind == argc)
+        loops = 30;
+    else {
+        loops = atoi(argv[optind++]);
+        if (loops <= 0 || loops > 1000000) {
+            Rfprintf(stderr,
+                     "ERR - loops arg out of bounds '%d'?\n", loops);
+            shmem_finalize();
+            return 1;
+        }
+    }
+
+    for(j=0; j < loops; j++) {
+        //if ( j==0 || (j % 10) == 0 )
+        RDfprintf(stderr,"[%d] pre-barrier(%d)\n", rank,j);
+
+        shmem_barrier_all();  /* sync sender and receiver */
+
+        //if ( j==0 || (j % 10) == 0 )
+        RDfprintf(stderr,"[%d] post barrier(%d)\n", rank,j);
+    }
+
+    RDprintf ("%d(%d) Exit\n", rank, num_ranks);
+
+    shmem_finalize();
+
+    return 0;
 }

--- a/test/unit/bcast.c
+++ b/test/unit/bcast.c
@@ -117,7 +117,7 @@ main(int argc, char* argv[])
                 fprintf(stderr,"[%d] dst[%d] %ld != expected %ld\n",
                         mpe, i, dst[i],src[i]);
                 shmem_global_exit(1);
-            } else if (1 == mpe && dst[i] != 0) { 
+            } else if (1 == mpe && dst[i] != 0) {
                 fprintf(stderr,"[%d] dst[%d] %ld != expected 0\n",
                         mpe, i, dst[i]);
                 shmem_global_exit(1);

--- a/test/unit/bcast_flood.c
+++ b/test/unit/bcast_flood.c
@@ -183,11 +183,11 @@ static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;

--- a/test/unit/big_reduction.c
+++ b/test/unit/big_reduction.c
@@ -88,7 +88,7 @@ main(int argc, char* argv[])
     shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
 
     if (Verbose) {
-        printf("%d/%d	dst =", shmem_my_pe(), shmem_n_pes() );
+        printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );
         for (i = 0; i < N; i+= 1) {
             printf(" %ld", dst[i]);
         }

--- a/test/unit/bigget.c
+++ b/test/unit/bigget.c
@@ -57,11 +57,11 @@ static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;
@@ -112,40 +112,40 @@ main(int argc, char **argv)
     while ((i = getopt (argc, argv, "hve:l:st")) != EOF) {
         switch (i)
         {
-          case 'v':
-              Verbose++;
-              break;
-          case 'e':
-              if ((elements = atoi_scaled(optarg)) <= 0) {
-                  fprintf(stderr,"ERR: Bad elements count %d\n",elements);
-                  shmem_finalize();
-                  return 1;
-              }
-              break;
-          case 'l':
-              if ((loops = atoi_scaled(optarg)) <= 0) {
-                  fprintf(stderr,"ERR: Bad loop count %d\n",loops);
-                  shmem_finalize();
-                  return 1;
-              }
-              break;
-          case 's':
-              Sync++;
-              break;
-          case 't':
-              Track++;
-              break;
-          case 'h':
-              if (me == 0)
-                  usage(pgm);
-              return 0;
-          default:
-              if (me == 0) {
-                  fprintf(stderr,"%s: unknown switch '-%c'?\n",pgm,i);
-                  usage(pgm);
-              }
-              shmem_finalize();
-              return 1;
+            case 'v':
+                Verbose++;
+                break;
+            case 'e':
+                if ((elements = atoi_scaled(optarg)) <= 0) {
+                    fprintf(stderr,"ERR: Bad elements count %d\n",elements);
+                    shmem_finalize();
+                    return 1;
+                }
+                break;
+            case 'l':
+                if ((loops = atoi_scaled(optarg)) <= 0) {
+                    fprintf(stderr,"ERR: Bad loop count %d\n",loops);
+                    shmem_finalize();
+                    return 1;
+                }
+                break;
+            case 's':
+                Sync++;
+                break;
+            case 't':
+                Track++;
+                break;
+            case 'h':
+                if (me == 0)
+                    usage(pgm);
+                return 0;
+            default:
+                if (me == 0) {
+                    fprintf(stderr,"%s: unknown switch '-%c'?\n",pgm,i);
+                    usage(pgm);
+                }
+                shmem_finalize();
+                return 1;
         }
     }
 
@@ -153,55 +153,55 @@ main(int argc, char **argv)
 
     total_time = (double *) shmem_malloc( npes * sizeof(double) );
     if (!total_time) {
-      fprintf(stderr,"ERR: bad total_time shmem_malloc(%ld)\n",
-              (elements * sizeof(double)));
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad total_time shmem_malloc(%ld)\n",
+                (elements * sizeof(double)));
+        shmem_global_exit(1);
     }
 
     Source = (int *) shmem_malloc( elements * sizeof(*Source) );
     if (!Source) {
-      fprintf(stderr,"ERR: bad Source shmem_malloc(%ld)\n",
-              (elements * sizeof(*Target)));
-      shmem_free(total_time);
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad Source shmem_malloc(%ld)\n",
+                (elements * sizeof(*Target)));
+        shmem_free(total_time);
+        shmem_global_exit(1);
     }
 
     Target = (int *) shmem_malloc( elements * sizeof(*Target) );
     if (!Target) {
-      fprintf(stderr,"ERR: bad Target shmem_malloc(%ld)\n",
-              (elements * sizeof(*Target)));
-      shmem_free(Source);
-      shmem_free(total_time);
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad Target shmem_malloc(%ld)\n",
+                (elements * sizeof(*Target)));
+        shmem_free(Source);
+        shmem_free(total_time);
+        shmem_global_exit(1);
     }
 
     for (i = 0; i < elements; i++) {
-      Target[i] = -90;
-      Source[i] = i + 1;
+        Target[i] = -90;
+        Source[i] = i + 1;
     }
 
     bytes = loops * sizeof(int) * elements;
 
     if (Verbose && me==0)
-      fprintf(stderr, "%s: INFO - %d loops, get %d (int) elements from PE+1\n",
-                        pgm, loops, elements);
+        fprintf(stderr, "%s: INFO - %d loops, get %d (int) elements from PE+1\n",
+                pgm, loops, elements);
 
     shmem_barrier_all();
 
     for(i=0; i < loops; i++) {
 
-		start_time = shmemx_wtime();
+        start_time = shmemx_wtime();
 
-		shmem_int_get( Target, Source, elements, target_pe );
+        shmem_int_get( Target, Source, elements, target_pe );
 
-		time_taken += shmemx_wtime() - start_time;
+        time_taken += shmemx_wtime() - start_time;
 
-		if (me==0) {
-		  if ( Track && i > 0 && ((i % 200) == 0))
-		    fprintf(stderr,".%d",i);
-		}
-		if (Sync)
-		    shmem_barrier_all();
+        if (me==0) {
+            if ( Track && i > 0 && ((i % 200) == 0))
+                fprintf(stderr,".%d",i);
+        }
+        if (Sync)
+            shmem_barrier_all();
     }
 
     // collect time per node elapsed time.
@@ -210,15 +210,15 @@ main(int argc, char **argv)
     shmem_barrier_all();
 
     for (i = 0; i < elements; i++) {
-      if (Target[i] != i + 1) {
-          printf("%d: Error Target[%d] = %d, expected %d\n",
-                 me, i, Target[i], i + 1);
-          shmem_global_exit(1);
-      }
+        if (Target[i] != i + 1) {
+            printf("%d: Error Target[%d] = %d, expected %d\n",
+                   me, i, Target[i], i + 1);
+            shmem_global_exit(1);
+        }
     }
 
     if ( Track && me == 0 )
-		fprintf(stderr,"\n");
+        fprintf(stderr,"\n");
 
     if (Verbose && me == 0) {
         double rate,secs;
@@ -229,7 +229,7 @@ main(int argc, char **argv)
         secs /= (double)npes;
         rate = ((double)bytes/(1024.0*1024.0)) / secs;
         printf("%s: ave %5.3f MB/sec (bytes %ld secs %5.3f)\n",
-                pgm, rate, bytes, secs);
+               pgm, rate, bytes, secs);
     }
 
     shmem_free(total_time);

--- a/test/unit/bigput.c
+++ b/test/unit/bigput.c
@@ -60,11 +60,11 @@ static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;
@@ -123,40 +123,40 @@ main(int argc, char **argv)
     while ((i = getopt (argc, argv, "hve:l:st")) != EOF) {
         switch (i)
         {
-          case 'v':
-              Verbose++;
-              break;
-          case 'e':
-              if ((elements = atoi_scaled(optarg)) <= 0) {
-                  fprintf(stderr,"ERR: Bad elements count %d\n",elements);
-                  shmem_finalize();
-                  return 1;
-              }
-              break;
-          case 'l':
-              if ((loops = atoi_scaled(optarg)) <= 0) {
-                  fprintf(stderr,"ERR: Bad loop count %d\n",loops);
-                  shmem_finalize();
-                  return 1;
-              }
-              break;
-          case 's':
-              Sync++;
-              break;
-          case 't':
-              Track++;
-              break;
-          case 'h':
-              if (me == 0)
-                  usage(pgm);
-              return 0;
-          default:
-              if (me == 0) {
-                  fprintf(stderr,"%s: unknown switch '-%c'?\n",pgm,i);
-                  usage(pgm);
-              }
-              shmem_finalize();
-              return 1;
+            case 'v':
+                Verbose++;
+                break;
+            case 'e':
+                if ((elements = atoi_scaled(optarg)) <= 0) {
+                    fprintf(stderr,"ERR: Bad elements count %d\n",elements);
+                    shmem_finalize();
+                    return 1;
+                }
+                break;
+            case 'l':
+                if ((loops = atoi_scaled(optarg)) <= 0) {
+                    fprintf(stderr,"ERR: Bad loop count %d\n",loops);
+                    shmem_finalize();
+                    return 1;
+                }
+                break;
+            case 's':
+                Sync++;
+                break;
+            case 't':
+                Track++;
+                break;
+            case 'h':
+                if (me == 0)
+                    usage(pgm);
+                return 0;
+            default:
+                if (me == 0) {
+                    fprintf(stderr,"%s: unknown switch '-%c'?\n",pgm,i);
+                    usage(pgm);
+                }
+                shmem_finalize();
+                return 1;
         }
     }
 
@@ -167,58 +167,58 @@ main(int argc, char **argv)
 
     total_time = (double *) shmem_malloc( npes * sizeof(double) );
     if (!total_time) {
-      fprintf(stderr,"ERR: bad total_time shmem_malloc(%ld)\n",
-              (elements * sizeof(double)));
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad total_time shmem_malloc(%ld)\n",
+                (elements * sizeof(double)));
+        shmem_global_exit(1);
     }
     for(i=0; i < npes; i++)
         total_time[i] = -1.0;
 
     Source = (int *) shmem_malloc( elements * sizeof(*Source) );
     if (!Source) {
-      fprintf(stderr,"ERR: bad Source shmem_malloc(%ld)\n",
-              (elements * sizeof(*Target)));
-      shmem_free(total_time);
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad Source shmem_malloc(%ld)\n",
+                (elements * sizeof(*Target)));
+        shmem_free(total_time);
+        shmem_global_exit(1);
     }
 
     Target = (int *) shmem_malloc( elements * sizeof(*Target) );
     if (!Target) {
-      fprintf(stderr,"ERR: bad Target shmem_malloc(%ld)\n",
-              (elements * sizeof(*Target)));
-      shmem_free(Source);
-      shmem_free(total_time);
-      shmem_global_exit(1);
+        fprintf(stderr,"ERR: bad Target shmem_malloc(%ld)\n",
+                (elements * sizeof(*Target)));
+        shmem_free(Source);
+        shmem_free(total_time);
+        shmem_global_exit(1);
     }
 
     for (i = 0; i < elements; i++) {
-      Target[i] = -90;
-      Source[i] = i + 1;
+        Target[i] = -90;
+        Source[i] = i + 1;
     }
 
     bytes = loops * sizeof(int) * elements;
 
     if (Verbose && me==0) {
-      fprintf(stderr,
-        "%s: INFO - %d loops, put %d (int) elements to PE+1 Max put ??\n",
-              pgm, loops, elements);
+        fprintf(stderr,
+                "%s: INFO - %d loops, put %d (int) elements to PE+1 Max put ??\n",
+                pgm, loops, elements);
     }
     shmem_barrier_all();
 
     for(i=0; i < loops; i++) {
 
-		start_time = shmemx_wtime();
+        start_time = shmemx_wtime();
 
-		shmem_int_put(Target, Source, elements, target_PE);
+        shmem_int_put(Target, Source, elements, target_PE);
 
-		time_taken += (shmemx_wtime() - start_time);
+        time_taken += (shmemx_wtime() - start_time);
 
-		if (me==0) {
-		  if ( Track && i > 0 && ((i % 200) == 0))
-		    fprintf(stderr,".%d",i);
-		}
-		if (Sync)
-		    shmem_barrier_all();
+        if (me==0) {
+            if ( Track && i > 0 && ((i % 200) == 0))
+                fprintf(stderr,".%d",i);
+        }
+        if (Sync)
+            shmem_barrier_all();
     }
 
     // collect time per node.
@@ -228,11 +228,11 @@ main(int argc, char **argv)
     shmem_barrier_all();
 
     for (i = 0; i < elements; i++) {
-      if (Target[i] != i + 1) {
-          printf("%d: Error Target[%d] = %d, expected %d\n",
-                 me, i, Target[i], i + 1);
-          shmem_global_exit(1);
-      }
+        if (Target[i] != i + 1) {
+            printf("%d: Error Target[%d] = %d, expected %d\n",
+                   me, i, Target[i], i + 1);
+            shmem_global_exit(1);
+        }
     }
 
     if ( Track && me == 0 ) fprintf(stderr,"\n");
@@ -252,11 +252,11 @@ main(int argc, char **argv)
         comp_time /= (double)npes;
         if (sum_time != comp_time)
             printf("%s: computed_time %7.5f != sum_to_all_time %7.5f)\n",
-                pgm, comp_time, sum_time );
+                   pgm, comp_time, sum_time );
 
         rate = ((double)bytes/(1024.0*1024.0)) / comp_time;
         printf("%s: shmem_int_put() %7.4f MB/sec (bytes %ld secs %7.4f)\n",
-                pgm, rate, bytes, sum_time);
+               pgm, rate, bytes, sum_time);
     }
 
     shmem_free(total_time);

--- a/test/unit/circular_shift.c
+++ b/test/unit/circular_shift.c
@@ -35,7 +35,7 @@
 
 int aaa, bbb;
 
-int 
+int
 main(int argc, char* argv[])
 {
     int me, neighbor;

--- a/test/unit/complex_reductions_f.f90
+++ b/test/unit/complex_reductions_f.f90
@@ -28,7 +28,7 @@
       program complex_reductions_f
       implicit none
       include "shmem.fh"
-      
+
       integer psync(shmem_reduce_sync_size), i, j, nr
       data psync /shmem_reduce_sync_size*shmem_sync_value/
       parameter (nr=10)
@@ -41,10 +41,10 @@
       integer shmem_my_pe, shmem_n_pes, npes, me
       complex(kind=4) exp_result(nr)
       complex(kind=8) exp_result_d(nr)
-      
-      
+
+
       call shmem_init()
-      
+
       npes = shmem_n_pes()
       me = shmem_my_pe()
 
@@ -93,15 +93,15 @@
       do i=1,nr
         zd_src(i) = dcmplx(-7.123123123123123123123, 2.32132132132132132132)
         exp_result_d(i) = zd_src(i)*npes
-      end do 
+      end do
 
       ! Test double precision complex sum_to_all reductions:
       call shmem_comp8_sum_to_all(zd_target, zd_src, nr, 0, 0, npes, pwrkd, psync)
-      
+
       call check_result_complex_dbl(zd_target, exp_result_d, nr, 3)
 
       call shmem_barrier_all()
-      
+
       ! Test double precision sum reductions on a PE subset with a stride of 2
       if ( mod(me,2) .eq. 0) then
         if ( mod(shmem_n_pes(),2) .eq. 0) then
@@ -135,9 +135,9 @@
 
       ! Check the result:
       call check_result_complex(z_target, exp_result, nr, 5)
-      
+
       call shmem_barrier_all()
-      
+
       ! Test single precision product reduction on a PE subset with a stride of 2
       if ( mod(me,2) .eq. 0) then
         if ( mod(shmem_n_pes(),2) .eq. 0) then
@@ -157,9 +157,9 @@
 
         endif
       endif
-      
+
       call shmem_barrier_all()
-      
+
       ! Re-initialize the double precision buffers and expected result
       do i=1,nr
         zd_src(i) = dcmplx(me, me+1)
@@ -169,15 +169,15 @@
             exp_result_d(i) = exp_result_d(i) * dcmplx(j,j+1)
           end if
         end do
-      end do 
+      end do
 
       ! Test double precision complex product_to_all reductions:
       call shmem_comp8_prod_to_all(zd_target, zd_src, nr, 0, 0, npes, pwrkd, psync)
-      
+
       call check_result_complex_dbl(zd_target, exp_result_d, nr, 7)
 
       call shmem_barrier_all()
-      
+
       ! Test double precision product reduction on a PE subset with a stride of 2
       if ( mod(me,2) .eq. 0) then
         if ( mod(shmem_n_pes(),2) .eq. 0) then
@@ -197,7 +197,7 @@
 
         endif
       endif
-      
+
       call shmem_finalize()
 
       contains
@@ -244,5 +244,5 @@
         endif
         end do
       end subroutine check_result_complex_dbl
-      
+
       end program complex_reductions_f

--- a/test/unit/cswap.c
+++ b/test/unit/cswap.c
@@ -63,7 +63,7 @@ main(int argc, char* argv[])
     me = shmem_my_pe();
     num_pes = shmem_n_pes();
 
-    if (num_pes == 1) { 
+    if (num_pes == 1) {
         printf("%s: Requires number of PEs > 1\n", argv[0]);
         shmem_finalize();
         return 0;

--- a/test/unit/get_g.c
+++ b/test/unit/get_g.c
@@ -111,9 +111,9 @@ main(int argc, char* argv[])
         }
         *src_long = 8;
 
-    	shmem_barrier_all();
+        shmem_barrier_all();
 
-    	for (pe=0 ; pe < num_pes; ++pe) {
+        for (pe=0 ; pe < num_pes; ++pe) {
             if (!shmem_addr_accessible(src_short,pe)) {
                 printf("PE-%d local addr %p not accessible from PE-%d?\n",
                        me, (void*)src_short, pe);
@@ -149,9 +149,9 @@ main(int argc, char* argv[])
                 printf("PE-%d dst_long %ld != 8?\n",me,dst_long);
                 shmem_global_exit(1);
             }
-    	}
+        }
 
-    	shmem_barrier_all();
+        shmem_barrier_all();
 
         shmem_free(src_short);
         shmem_free(src_int);
@@ -161,7 +161,7 @@ main(int argc, char* argv[])
     }
 
     if (Verbose)
-		fprintf(stderr,"[%d] exit\n",shmem_my_pe());
+        fprintf(stderr,"[%d] exit\n",shmem_my_pe());
 
     shmem_finalize();
 

--- a/test/unit/ipgm.c
+++ b/test/unit/ipgm.c
@@ -251,7 +251,7 @@ main(int argc, char **argv)
                 (rc/sizeof(DataType)),ridx,(prev_sz/sizeof(DataType)));
             for(j=1; j < nProcs; j++) {
                 printf("  PE[%d] results[%d...%d]\n",
-                            j,idx,(idx+(nWords-1))); 
+                            j,idx,(idx+(nWords-1)));
                 idx += nWords;
             }
         }
@@ -291,7 +291,7 @@ main(int argc, char **argv)
         if (Debug > 3)
             printf("shmem_malloc() target %p (%d bytes)\n",(void*)target,rc);
 
-        shmem_barrier_all(); 
+        shmem_barrier_all();
 
         if (me == 0) {
             /* put nWords of DataType into target on PE's [1 to (nProcs-1)] */
@@ -302,7 +302,7 @@ main(int argc, char **argv)
         shmem_barrier_all();
 
         if (me != 0) {
-            // Verify iput target data 
+            // Verify iput target data
             rc = target_data_good(target, nWords, 0, __LINE__);
             if (rc)
                 shmem_global_exit(1);
@@ -322,7 +322,7 @@ main(int argc, char **argv)
             for(j=1; j < nProcs; j++) {
                 if (Debug > 1)
                     printf("PE[0] iget(%d words PE[%d]) results[%d...%d]\n",
-                                    nWords,j,ridx,(ridx+(nWords-1))); 
+                                    nWords,j,ridx,(ridx+(nWords-1)));
                 IGET(&results[ridx], target, 1, 1, nWords, j);
                 rc = target_data_good( &results[ridx], nWords, j, __LINE__);
                 if (rc)

--- a/test/unit/iput128.c
+++ b/test/unit/iput128.c
@@ -46,37 +46,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %Lf %Lf %Lf %Lf %Lf\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %Lf %Lf %Lf %Lf %Lf\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput32.c
+++ b/test/unit/iput32.c
@@ -48,37 +48,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %u %u %u %u %u\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %u %u %u %u %u\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput64.c
+++ b/test/unit/iput64.c
@@ -48,41 +48,41 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %ld %ld %ld %ld %ld\n"
-				"  Expected 1,3,5,7,9?\n",
-                               me, 
-                               (long int) target[0], 
-                               (long int) target[1], 
-                               (long int) target[2],
-                               (long int) target[3], 
-                               (long int) target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %ld %ld %ld %ld %ld\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me,
+                   (long int) target[0],
+                   (long int) target[1],
+                   (long int) target[2],
+                   (long int) target[3],
+                   (long int) target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_double.c
+++ b/test/unit/iput_double.c
@@ -46,37 +46,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %f %f %f %f %f\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %f %f %f %f %f\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_float.c
+++ b/test/unit/iput_float.c
@@ -46,37 +46,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %f %f %f %f %f\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %f %f %f %f %f\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_long.c
+++ b/test/unit/iput_long.c
@@ -45,37 +45,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %ld %ld %ld %ld %ld\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %ld %ld %ld %ld %ld\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_longdouble.c
+++ b/test/unit/iput_longdouble.c
@@ -46,37 +46,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %Lf %Lf %Lf %Lf %Lf\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %Lf %Lf %Lf %Lf %Lf\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_longlong.c
+++ b/test/unit/iput_longlong.c
@@ -46,37 +46,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %lld %lld %lld %lld %lld\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %lld %lld %lld %lld %lld\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/iput_short.c
+++ b/test/unit/iput_short.c
@@ -45,37 +45,37 @@ static DataType target[10];
 
 int main(int argc, char **argv)
 {
-	int me, nProcs, rc=0;
+    int me, nProcs, rc=0;
 
-	shmem_init();
-	me = shmem_my_pe();
-	nProcs = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    nProcs = shmem_n_pes();
 
-	if (me == 0) {
-		int j;
-		/* put 5 words into target on PE's [1 to (nProcs-1)] */
-		for(j=1; j < nProcs; j++)
-			IPUT (target, source, 1, 2, 5, j);
-	}
+    if (me == 0) {
+        int j;
+        /* put 5 words into target on PE's [1 to (nProcs-1)] */
+        for(j=1; j < nProcs; j++)
+            IPUT (target, source, 1, 2, 5, j);
+    }
 
-	shmem_barrier_all(); /* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
-	if (me != 0) {
-		if (target[0] != 1 ||
-		    target[1] != 3 ||
-		    target[2] != 5 ||
-		    target[3] != 7 ||
-		    target[4] != 9)
-		{
-			printf("ERR: target on PE %d is %hd %hd %hd %hd %hd\n"
-				"  Expected 1,3,5,7,9?\n",
-				me, target[0], target[1], target[2],
-				target[3], target[4] );
-			rc = 1;
-		}
-	}
+    if (me != 0) {
+        if (target[0] != 1 ||
+            target[1] != 3 ||
+            target[2] != 5 ||
+            target[3] != 7 ||
+            target[4] != 9)
+        {
+            printf("ERR: target on PE %d is %hd %hd %hd %hd %hd\n"
+                   "  Expected 1,3,5,7,9?\n",
+                   me, target[0], target[1], target[2],
+                   target[3], target[4] );
+            rc = 1;
+        }
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return rc;
+    return rc;
 }

--- a/test/unit/max_reduction.c
+++ b/test/unit/max_reduction.c
@@ -86,7 +86,7 @@ main(int argc, char* argv[])
     shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
 
     if (Verbose) {
-        printf("%d/%d	dst =", shmem_my_pe(), shmem_n_pes() );
+        printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );
         for (i = 0; i < N; i+= 1) {
             printf(" %ld", dst[i]);
         }

--- a/test/unit/micro_unit_shmem.c
+++ b/test/unit/micro_unit_shmem.c
@@ -2,11 +2,11 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
- *	without modification, are permitted provided that the following
- *	conditions are met:
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
  *
- *	- Redistributions of source code must retain the above
+ *      - Redistributions of source code must retain the above
  *        copyright notice, this list of conditions and the following
  *        disclaimer.
  *
@@ -40,9 +40,9 @@
 #include <ctype.h>
 
 typedef enum {
-	NUM_WRITE = 8,
-	NUM_READ =  5,
-	NUM_SYNC = 3
+    NUM_WRITE = 8,
+    NUM_READ =  5,
+    NUM_SYNC = 3
 } max_ops;
 
 int target[NUM_WRITE];
@@ -56,60 +56,60 @@ int debug;
 static inline void wait_until(int *wait_var, int iterations, int pe)
 {
 
-	if (debug)
-		printf("PE %d waiting...%d\n", pe, *wait_var);
+    if (debug)
+        printf("PE %d waiting...%d\n", pe, *wait_var);
 
-	shmem_int_wait_until(wait_var, SHMEM_CMP_EQ, iterations);
+    shmem_int_wait_until(wait_var, SHMEM_CMP_EQ, iterations);
 
-	if (debug)
-		printf("PE %d wait_until passed\n", pe);
+    if (debug)
+        printf("PE %d wait_until passed\n", pe);
 
 }
 
 static inline void pre_op_check(const char *op,
-		int check_var, int iterations, int pe)
+                                int check_var, int iterations, int pe)
 {
-	if (verbose)
-		printf("SHMEM %s, performing %d iterations\n",
-				op, iterations);
+    if (verbose)
+        printf("SHMEM %s, performing %d iterations\n",
+               op, iterations);
 
-	if (debug)
-		printf("BEFORE operation PE %d target = %d\n",
-				pe, check_var);
+    if (debug)
+        printf("BEFORE operation PE %d target = %d\n",
+               pe, check_var);
 }
 
 static inline void post_op_check(const char *op,
-		int check_var, int iterations, int pe)
+                                 int check_var, int iterations, int pe)
 {
 
-	if (check_var != iterations) {
-		fprintf(stderr, "%s ERR: PE %d source = %d != %d\n",
-				op, pe, check_var, iterations);
-		shmem_global_exit(EXIT_FAILURE);
-	}
+    if (check_var != iterations) {
+        fprintf(stderr, "%s ERR: PE %d source = %d != %d\n",
+                op, pe, check_var, iterations);
+        shmem_global_exit(EXIT_FAILURE);
+    }
 }
 
 static inline void putfence(int me, int iterations, int T)
 {
-	int i;
+    int i;
 
-	if (me == 1)
-		pre_op_check(__func__, target[T], iterations, 1);
+    if (me == 1)
+        pre_op_check(__func__, target[T], iterations, 1);
 
-	if (me == 0) {
-		for (i = 1; i < iterations; i++) {
-			shmem_int_p(&target[T], i, 1);
-			shmem_fence();
-		}
+    if (me == 0) {
+        for (i = 1; i < iterations; i++) {
+            shmem_int_p(&target[T], i, 1);
+            shmem_fence();
+        }
 
-		shmem_int_p(&target[T], i, 1);
+        shmem_int_p(&target[T], i, 1);
 
-	} else
-		wait_until(&target[T], iterations, 1);
+    } else
+        wait_until(&target[T], iterations, 1);
 
-	if (verbose)
-		if (me == 0)
-			printf("SHMEM %s finished\n", __func__);
+    if (verbose)
+        if (me == 0)
+            printf("SHMEM %s finished\n", __func__);
 
 }
 
@@ -117,346 +117,346 @@ static inline void putfence(int me, int iterations, int T)
 static inline void gettest(int me, int iterations, int T, int S, int P)
 {
 
-	int i;
+    int i;
 
-	if (me == 1) {
-		pre_op_check(__func__, target[T], iterations, 1);
+    if (me == 1) {
+        pre_op_check(__func__, target[T], iterations, 1);
 
-		shmem_int_p(&source[S], iterations, 0);
-		shmem_fence();
+        shmem_int_p(&source[S], iterations, 0);
+        shmem_fence();
 
-		for (i = 0; i < iterations; i++)
-			target[T] = shmem_int_g(&source[S], 0);
+        for (i = 0; i < iterations; i++)
+            target[T] = shmem_int_g(&source[S], 0);
 
-		shmem_int_p(&sync_pes[P], iterations, 0);
+        shmem_int_p(&sync_pes[P], iterations, 0);
 
-		post_op_check("get", target[T], iterations, 1);
+        post_op_check("get", target[T], iterations, 1);
 
-	} else
-		wait_until(&sync_pes[P], iterations, 0);
+    } else
+        wait_until(&sync_pes[P], iterations, 0);
 
-	if (verbose) {
-		if (me == 0)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 0)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 static inline void atomic_inc(int me, int iterations, int T)
 {
 
-	int i;
+    int i;
 
-	if (me == 1)
-		pre_op_check(__func__, target[T], iterations, 1);
+    if (me == 1)
+        pre_op_check(__func__, target[T], iterations, 1);
 
-        target[T] = 0;
-        shmem_barrier_all();
+    target[T] = 0;
+    shmem_barrier_all();
 
-	if (me == 0) {
-		for (i = 0; i < iterations; i++) {
-			shmem_int_inc(&target[T], 1);
-			shmem_fence();
-		}
-		shmem_int_inc(&target[T], 1);
+    if (me == 0) {
+        for (i = 0; i < iterations; i++) {
+            shmem_int_inc(&target[T], 1);
+            shmem_fence();
+        }
+        shmem_int_inc(&target[T], 1);
 
-		if (debug)
-			printf("PE 0 done with operation\n");
+        if (debug)
+            printf("PE 0 done with operation\n");
 
-	} else
-		wait_until(&target[T], (iterations+1), 1);
+    } else
+        wait_until(&target[T], (iterations+1), 1);
 
-	if (verbose) {
-		if (me == 1)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 1)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 static inline void atomic_add(int me, int iterations, int T)
 {
 
-	int i;
+    int i;
 
-	if (me == 0)
-		pre_op_check(__func__, target[T], iterations, 0);
+    if (me == 0)
+        pre_op_check(__func__, target[T], iterations, 0);
 
-        target[T] = 0;
-        shmem_barrier_all();
+    target[T] = 0;
+    shmem_barrier_all();
 
-	if (me == 1) {
-		for (i = 0; i < iterations; i++) {
-			shmem_int_add(&target[T], 1, 0);
-			shmem_fence();
-		}
-		shmem_int_add(&target[T], 1, 0);
+    if (me == 1) {
+        for (i = 0; i < iterations; i++) {
+            shmem_int_add(&target[T], 1, 0);
+            shmem_fence();
+        }
+        shmem_int_add(&target[T], 1, 0);
 
-		if (debug)
-			printf("PE 1 done with operation\n");
+        if (debug)
+            printf("PE 1 done with operation\n");
 
-	} else
-		wait_until(&target[T], (iterations+1), 0);
+    } else
+        wait_until(&target[T], (iterations+1), 0);
 
-	if (verbose) {
-		if (me == 1)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 1)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 
 static inline void swaptest(int me, int iterations, int T, int S, int P)
 {
 
-	int i;
-	const int tswap = 5, sswap = 2;
-	target[T] = tswap;
-	source[S] = sswap;
+    int i;
+    const int tswap = 5, sswap = 2;
+    target[T] = tswap;
+    source[S] = sswap;
 
-	shmem_barrier_all(); /* Ensure target/source initialization completed */
+    shmem_barrier_all(); /* Ensure target/source initialization completed */
 
-	if (me == 0)
-		pre_op_check(__func__, source[S], iterations, 0);
+    if (me == 0)
+        pre_op_check(__func__, source[S], iterations, 0);
 
-	if (me == 0) {
-		for (i = 0; i < iterations; i++)
-			source[S] = shmem_int_swap(&target[T], source[S], 1);
+    if (me == 0) {
+        for (i = 0; i < iterations; i++)
+            source[S] = shmem_int_swap(&target[T], source[S], 1);
 
-		shmem_int_p(&sync_pes[P], i, 1);
+        shmem_int_p(&sync_pes[P], i, 1);
 
-		if (debug)
-			printf("AFTER flag PE 0 value of source is %d"
-					" = 5?\n", source[S]);
+        if (debug)
+            printf("AFTER flag PE 0 value of source is %d"
+                   " = 5?\n", source[S]);
 
-		if (((iterations % 2 == 1) && (source[S] != tswap)) ||
-			((iterations % 2 == 0) &&
-			 (source[S] != sswap))) {
-			fprintf(stderr, "swap ERR: PE 0 source = %d\n",
-					source[S]);
-			shmem_global_exit(EXIT_FAILURE);
-		}
+        if (((iterations % 2 == 1) && (source[S] != tswap)) ||
+            ((iterations % 2 == 0) &&
+             (source[S] != sswap))) {
+            fprintf(stderr, "swap ERR: PE 0 source = %d\n",
+                    source[S]);
+            shmem_global_exit(EXIT_FAILURE);
+        }
 
-	} else {
-		wait_until(&sync_pes[P], iterations, 1);
+    } else {
+        wait_until(&sync_pes[P], iterations, 1);
 
-		if (((iterations % 2 == 1) && (target[T] != sswap)) ||
-			((iterations % 2 == 0) &&
-			 (target[T] != tswap))) {
-			fprintf(stderr, "swap ERR: PE 0 target = %d \n",
-					target[T]);
-			shmem_global_exit(EXIT_FAILURE);
-		}
+        if (((iterations % 2 == 1) && (target[T] != sswap)) ||
+            ((iterations % 2 == 0) &&
+             (target[T] != tswap))) {
+            fprintf(stderr, "swap ERR: PE 0 target = %d \n",
+                    target[T]);
+            shmem_global_exit(EXIT_FAILURE);
+        }
 
-	}
+    }
 
-	if (verbose) {
-		if (me == 0)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 0)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 static inline void cswaptest(int me, int iterations, int T, int S, int P)
 {
 
-	int i;
-	source[S] = -100;
+    int i;
+    source[S] = -100;
 
-        target[T] = 0;
-        shmem_barrier_all();
+    target[T] = 0;
+    shmem_barrier_all();
 
-	if (me == 1) {
-		pre_op_check(__func__, source[S], iterations, 1);
+    if (me == 1) {
+        pre_op_check(__func__, source[S], iterations, 1);
 
-		for (i = 0; i < iterations; i++)
-			source[S] = shmem_int_cswap(&(target[T]), i, (i+1), 0);
+        for (i = 0; i < iterations; i++)
+            source[S] = shmem_int_cswap(&(target[T]), i, (i+1), 0);
 
-		shmem_int_p(&sync_pes[P], i, 0);
+        shmem_int_p(&sync_pes[P], i, 0);
 
-		post_op_check("cswap", source[S], (iterations-1), 1);
+        post_op_check("cswap", source[S], (iterations-1), 1);
 
-	} else {
-		wait_until(&sync_pes[P], iterations, 0);
+    } else {
+        wait_until(&sync_pes[P], iterations, 0);
 
-		if (target[T] != iterations) {
-			fprintf(stderr, "cswap ERR: PE 1 target = %d != %d\n",
-					target[T], iterations);
-			shmem_global_exit(EXIT_FAILURE);
-		}
-	}
+        if (target[T] != iterations) {
+            fprintf(stderr, "cswap ERR: PE 1 target = %d != %d\n",
+                    target[T], iterations);
+            shmem_global_exit(EXIT_FAILURE);
+        }
+    }
 
-	if (verbose) {
-		if (me == 1)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 1)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 static inline void fetchatomic_add(int me, int iterations, int T, int S)
 {
 
-	int i;
+    int i;
 
-	if (me == 1)
-		pre_op_check(__func__, target[T], iterations, 1);
+    if (me == 1)
+        pre_op_check(__func__, target[T], iterations, 1);
 
-        target[T] = 0;
-        shmem_barrier_all();
+    target[T] = 0;
+    shmem_barrier_all();
 
-	if (me == 0) {
-		if (debug) {
-			printf("BEFORE flag PE 0 value of source is"
-					" %d = 0?\n", source[S]);
-		}
+    if (me == 0) {
+        if (debug) {
+            printf("BEFORE flag PE 0 value of source is"
+                   " %d = 0?\n", source[S]);
+        }
 
-		for (i = 0; i < iterations; i++) {
-			source[S] = shmem_int_fadd(&target[T], 1, 1);
-			shmem_fence();
-		}
-		source[S] = shmem_int_fadd(&target[T], 1, 1);
+        for (i = 0; i < iterations; i++) {
+            source[S] = shmem_int_fadd(&target[T], 1, 1);
+            shmem_fence();
+        }
+        source[S] = shmem_int_fadd(&target[T], 1, 1);
 
-		post_op_check("fadd", source[S], iterations, 0);
+        post_op_check("fadd", source[S], iterations, 0);
 
-	} else
-		wait_until(&target[T], (iterations+1), 1);
+    } else
+        wait_until(&target[T], (iterations+1), 1);
 
-	if (verbose) {
-		if (me == 0)
-			printf("SHMEM %s finished\n", __func__);
-	}
+    if (verbose) {
+        if (me == 0)
+            printf("SHMEM %s finished\n", __func__);
+    }
 }
 
 static inline void fetchatomic_inc(int me, int iterations, int T, int S)
 {
 
-	int i;
+    int i;
 
-	if (me == 0)
-		pre_op_check(__func__, target[T], iterations, 0);
+    if (me == 0)
+        pre_op_check(__func__, target[T], iterations, 0);
 
-        target[T] = 0;
-        shmem_barrier_all();
+    target[T] = 0;
+    shmem_barrier_all();
 
-	if (me == 1) {
-		if (debug) {
-			printf("BEFORE flag PE 1 value of source is %d\n",
-					source[S]);
-		}
+    if (me == 1) {
+        if (debug) {
+            printf("BEFORE flag PE 1 value of source is %d\n",
+                   source[S]);
+        }
 
-		for (i = 0; i < iterations; i++) {
-			source[S] = shmem_int_finc(&target[T], 0);
-			shmem_fence();
-		}
+        for (i = 0; i < iterations; i++) {
+            source[S] = shmem_int_finc(&target[T], 0);
+            shmem_fence();
+        }
 
-		post_op_check("finc", source[S], (iterations-1), 1);
-	} else
-		wait_until(&target[T], iterations, 0);
+        post_op_check("finc", source[S], (iterations-1), 1);
+    } else
+        wait_until(&target[T], iterations, 0);
 
-	if (verbose) {
-		if (me == 1)
-			printf("SHMEM int_finc finished\n");
-	}
+    if (verbose) {
+        if (me == 1)
+            printf("SHMEM int_finc finished\n");
+    }
 
 }
 
 int main(int argc, char **argv)
 {
-	int        me, nproc;
-	int	   c, all_ops = 1;
-	int        T = 0, S = 0, P = 0;
-	const int  DEFAULT_ITR = 7;
-	int	   iterations = DEFAULT_ITR;
+    int        me, nproc;
+    int        c, all_ops = 1;
+    int        T = 0, S = 0, P = 0;
+    const int  DEFAULT_ITR = 7;
+    int        iterations = DEFAULT_ITR;
 
-	shmem_init();
+    shmem_init();
 
-	me = shmem_my_pe();
-	nproc = shmem_n_pes();
+    me = shmem_my_pe();
+    nproc = shmem_n_pes();
 
-	memset(target, -1, NUM_WRITE * sizeof(int));
-	memset(source, -1, NUM_READ * sizeof(int));
-	memset(sync_pes, -1, NUM_SYNC * sizeof(int));
+    memset(target, -1, NUM_WRITE * sizeof(int));
+    memset(source, -1, NUM_READ * sizeof(int));
+    memset(sync_pes, -1, NUM_SYNC * sizeof(int));
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	if (nproc != 2) {
-		if (me == 0) {
-			fprintf(stderr, "This is a micro test and is only "
-				"intended to run on exactly two processes you"
-				" are using %d\n", nproc);
-		}
-		shmem_finalize();
-		return 0;
-	}
+    if (nproc != 2) {
+        if (me == 0) {
+            fprintf(stderr, "This is a micro test and is only "
+                    "intended to run on exactly two processes you"
+                    " are using %d\n", nproc);
+        }
+        shmem_finalize();
+        return 0;
+    }
 
-	while ((c = getopt(argc, argv, "i:vdpgaAscfFh")) != -1) {
-		switch (c) {
-		case 'i':
-			iterations = atoi(optarg);
-			assert(iterations > 0);
-			all_ops += 2;
-			break;
-		case 'v':
-			verbose = 1;
-			all_ops++;
-			break;
-		case 'd':
-			debug = 1;
-			break;
-		case 'p':
-			putfence(me, iterations, T++);
-			break;
-		case 'g':
-			gettest(me, iterations, T++, S++, P++);
-			break;
-		case 'a':
-			atomic_add(me, iterations, T++);
-			break;
-		case 'A':
-			atomic_inc(me, iterations, T++);
-			break;
-		case 's':
-			swaptest(me, iterations, T++, S++, P++);
-			break;
-		case 'c':
-			cswaptest(me, iterations, T++, S++, P++);
-			break;
-		case 'f':
-			fetchatomic_add(me, iterations, T++, S++);
-			break;
-		case 'F':
-			fetchatomic_inc(me, iterations, T++, S++);
-			break;
-		case 'h':
-		default:
-			if (me == 0) {
-				fprintf(stderr, "input options:\n 1) single"
-				" argument option will run all tests by default"
-				"and additionally request:  -v (verbose) | "
-				"-i <number of interations>\n");
-				fprintf(stderr, " 2) two argument options "
-				"choose any combination of the following "
-				"to run individual tests:  -i <iterations>, -v"
-				", -d, -p, -g, -a, -A, -s, -c, -f, -F, -h\n");
-			}
-			shmem_finalize();
-			return 1;
-		}
-	}
+    while ((c = getopt(argc, argv, "i:vdpgaAscfFh")) != -1) {
+        switch (c) {
+            case 'i':
+                iterations = atoi(optarg);
+                assert(iterations > 0);
+                all_ops += 2;
+                break;
+            case 'v':
+                verbose = 1;
+                all_ops++;
+                break;
+            case 'd':
+                debug = 1;
+                break;
+            case 'p':
+                putfence(me, iterations, T++);
+                break;
+            case 'g':
+                gettest(me, iterations, T++, S++, P++);
+                break;
+            case 'a':
+                atomic_add(me, iterations, T++);
+                break;
+            case 'A':
+                atomic_inc(me, iterations, T++);
+                break;
+            case 's':
+                swaptest(me, iterations, T++, S++, P++);
+                break;
+            case 'c':
+                cswaptest(me, iterations, T++, S++, P++);
+                break;
+            case 'f':
+                fetchatomic_add(me, iterations, T++, S++);
+                break;
+            case 'F':
+                fetchatomic_inc(me, iterations, T++, S++);
+                break;
+            case 'h':
+            default:
+                if (me == 0) {
+                    fprintf(stderr, "input options:\n 1) single"
+                            " argument option will run all tests by default"
+                            "and additionally request:  -v (verbose) | "
+                            "-i <number of interations>\n");
+                    fprintf(stderr, " 2) two argument options "
+                            "choose any combination of the following "
+                            "to run individual tests:  -i <iterations>, -v"
+                            ", -d, -p, -g, -a, -A, -s, -c, -f, -F, -h\n");
+                }
+                shmem_finalize();
+                return 1;
+        }
+    }
 
-	if (argc == all_ops || argc == 1) {
-		putfence(me, iterations,  T++);
-		gettest(me, iterations, T++, S++, P++);
-		atomic_add(me, iterations, T++);
-		atomic_inc(me, iterations, T++);
-		swaptest(me, iterations, T++, S++, P++);
-		cswaptest(me, iterations, T++, S++, P++);
-		fetchatomic_add(me, iterations, T++, S++);
-		fetchatomic_inc(me, iterations, T++, S++);
-	}
+    if (argc == all_ops || argc == 1) {
+        putfence(me, iterations,  T++);
+        gettest(me, iterations, T++, S++, P++);
+        atomic_add(me, iterations, T++);
+        atomic_inc(me, iterations, T++);
+        swaptest(me, iterations, T++, S++, P++);
+        cswaptest(me, iterations, T++, S++, P++);
+        fetchatomic_add(me, iterations, T++, S++);
+        fetchatomic_inc(me, iterations, T++, S++);
+    }
 
-	if (verbose) {
-		if (me == 1)
-			printf("PE 1: PASS: %8d iterations\n", iterations);
-		else
-			printf("PE 0 Successful exit\n");
-	}
+    if (verbose) {
+        if (me == 1)
+            printf("PE 1: PASS: %8d iterations\n", iterations);
+        else
+            printf("PE 0 Successful exit\n");
+    }
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return 0;
+    return 0;
 }

--- a/test/unit/ns.c
+++ b/test/unit/ns.c
@@ -54,14 +54,14 @@ int
 main(int argc, char *argv[])
 {
     char *pgm;
-	int l, laps = DFLT_LAPS;
-	long *target;
-	int me, npes;
-	long swapped_val, new_val;
+    int l, laps = DFLT_LAPS;
+    long *target;
+    int me, npes;
+    long swapped_val, new_val;
 
-	shmem_init();
-	me = shmem_my_pe();
-	npes = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
 
     if ((pgm=strrchr(argv[0],'/')))
         pgm++;
@@ -95,34 +95,33 @@ main(int argc, char *argv[])
         }
     }
 
-    for(l=0; l < laps; l++) {
-
-    	target = (long *) shmem_malloc(sizeof (*target));
+    for (l=0; l < laps; l++) {
+        target = (long *) shmem_malloc(sizeof (*target));
         if (!target) {
             fprintf(stderr,"[%d] shmem_malloc() failed?\n",me);
             shmem_global_exit(1);
         }
 
-	    *target = me;
-	    new_val = me;
+        *target = me;
+        new_val = me;
 
-	    shmem_barrier_all();
+        shmem_barrier_all();
 
-	    if (me & 1) {
-	        swapped_val = shmem_long_swap (target, new_val, (me + 1) % npes);
-	        if (Verbose > 1)
+        if (me & 1) {
+            swapped_val = shmem_long_swap (target, new_val, (me + 1) % npes);
+            if (Verbose > 1)
                 printf("[%d] target %ld, swapped %ld\n",
-                        me, *target, swapped_val);
-	    }
-	    shmem_barrier_all();
-	    shmem_free (target);
-	    if (Verbose == 1 && me == 0)  fprintf(stderr,".");
+                       me, *target, swapped_val);
+        }
+        shmem_barrier_all();
+        shmem_free (target);
+        if (Verbose == 1 && me == 0)  fprintf(stderr,".");
     }
-	if (Verbose && me == 0)  fprintf(stderr,"\n");
+    if (Verbose && me == 0)  fprintf(stderr,"\n");
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return 0;
+    return 0;
 }
 
 
@@ -130,11 +129,11 @@ static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;

--- a/test/unit/pi.c
+++ b/test/unit/pi.c
@@ -2,11 +2,11 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
- *	without modification, are permitted provided that the following
- *	conditions are met:
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
  *
- *	- Redistributions of source code must retain the above
+ *      - Redistributions of source code must retain the above
  *        copyright notice, this list of conditions and the following
  *        disclaimer.
  *

--- a/test/unit/ping.c
+++ b/test/unit/ping.c
@@ -49,7 +49,7 @@
 #define RDfprintf if (Verbose && shmem_my_pe() == 0) fprintf
 
 /* option flags */
-#define OUTPUT_MOD 1	// output debug every X loops
+#define OUTPUT_MOD 1 // output debug every X loops
 int output_mod = OUTPUT_MOD;
 int Verbose;
 int Slow;
@@ -64,140 +64,140 @@ long src[TARGET_SZ];
 int
 main(int argc, char* argv[])
 {
-	int c, j, loops, k;
-	int proc, num_procs;
-	int  nWords=1;
-	int  failures=0;
-	char *prog_name;
+    int c, j, loops, k;
+    int proc, num_procs;
+    int  nWords=1;
+    int  failures=0;
+    char *prog_name;
 
-	shmem_init();
-	proc = shmem_my_pe();
-	num_procs = shmem_n_pes();
+    shmem_init();
+    proc = shmem_my_pe();
+    num_procs = shmem_n_pes();
 
-	if (num_procs == 1) {
-   		Rfprintf(stderr,
-			"ERR - Requires > 1 PEs\n");
-		shmem_finalize();
-		return 0;
-	}
+    if (num_procs == 1) {
+        Rfprintf(stderr,
+                 "ERR - Requires > 1 PEs\n");
+        shmem_finalize();
+        return 0;
+    }
 
-	prog_name = strrchr(argv[0],'/');
-	if ( prog_name )
-		prog_name++;
-	else
-		prog_name = argv[0];
+    prog_name = strrchr(argv[0],'/');
+    if ( prog_name )
+        prog_name++;
+    else
+        prog_name = argv[0];
 
-	while((c=getopt(argc,argv,"hVM:s")) != -1) {
-		switch(c) {
-		  case 's':
-			Slow++;
-			break;
-		  case 'V':
-			Verbose++;
-			break;
-		  case 'M':
-			output_mod = atoi(optarg);
-			if (output_mod <= 0) {
-    				Rfprintf(stderr, "ERR - output modulo arg out of "
-						"bounds '%d'?]\n", output_mod);
-				shmem_finalize();
-				return 1;
-			}
-   			Rfprintf(stderr,"%s: output modulo %d\n",
-					prog_name,output_mod);
-			break;
-		  case 'h':
-			Rfprintf(stderr,
-				"usage: %s {nWords-2-put} {Loop-count}\n",
-				prog_name);
-			shmem_finalize();
-			return 1;
-		  default:
-			shmem_finalize();
-			return 1;
-		}
-	}
+    while((c=getopt(argc,argv,"hVM:s")) != -1) {
+        switch(c) {
+            case 's':
+                Slow++;
+                break;
+            case 'V':
+                Verbose++;
+                break;
+            case 'M':
+                output_mod = atoi(optarg);
+                if (output_mod <= 0) {
+                    Rfprintf(stderr, "ERR - output modulo arg out of "
+                             "bounds '%d'?]\n", output_mod);
+                    shmem_finalize();
+                    return 1;
+                }
+                Rfprintf(stderr,"%s: output modulo %d\n",
+                         prog_name,output_mod);
+                break;
+            case 'h':
+                Rfprintf(stderr,
+                         "usage: %s {nWords-2-put} {Loop-count}\n",
+                         prog_name);
+                shmem_finalize();
+                return 1;
+            default:
+                shmem_finalize();
+                return 1;
+        }
+    }
 
-	if (optind == argc)
-		nWords = DFLT_NWORDS;
-	else {
-		nWords = atoi(argv[optind++]);
-		if (nWords <= 0 || nWords > TARGET_SZ) {
-    			Rfprintf(stderr,
-				"ERR - nWords arg out of bounds '%d' [1..%d]?\n",
-				 nWords, TARGET_SZ);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        nWords = DFLT_NWORDS;
+    else {
+        nWords = atoi(argv[optind++]);
+        if (nWords <= 0 || nWords > TARGET_SZ) {
+            Rfprintf(stderr,
+                     "ERR - nWords arg out of bounds '%d' [1..%d]?\n",
+                     nWords, TARGET_SZ);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
-	if (optind == argc)
-		loops = 10;
-	else {
-		loops = atoi(argv[optind++]);
-		if (loops <= 0 || loops > 1000000) {
-    			Rfprintf(stderr,
-				"ERR - loops arg out of bounds '%d'?\n", loops);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        loops = 10;
+    else {
+        loops = atoi(argv[optind++]);
+        if (loops <= 0 || loops > 1000000) {
+            Rfprintf(stderr,
+                     "ERR - loops arg out of bounds '%d'?\n", loops);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
-	//Rprintf("%s: %d loops of %d longs per put\n",prog_name,loops,nWords);
+    //Rprintf("%s: %d loops of %d longs per put\n",prog_name,loops,nWords);
 
-	for(j=0; j < nWords; j++)
-		src[j] = VAL;
+    for(j=0; j < nWords; j++)
+        src[j] = VAL;
 
-	for(j=0; j < loops; j++) {
+    for(j=0; j < loops; j++) {
 
-		shmem_barrier_all();
+        shmem_barrier_all();
 
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] +(%d)\n", shmem_my_pe(),j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] +(%d)\n", shmem_my_pe(),j);
 
-		if ( proc == 0 ) {
-			int p;
-			for(p=1; p < num_procs; p++)
-				shmem_long_put(Target, src, nWords, p);
-		}
-		else {
-			if (Slow) {
-				/* wait for each put to complete */
-				for(k=0; k < nWords; k++)
-					shmem_wait(&Target[k],proc);
-			} else {
-				/* wait for last word to be written */
-				shmem_wait(&Target[nWords-1],proc);
-			}
-		}
+        if ( proc == 0 ) {
+            int p;
+            for(p=1; p < num_procs; p++)
+                shmem_long_put(Target, src, nWords, p);
+        }
+        else {
+            if (Slow) {
+                /* wait for each put to complete */
+                for(k=0; k < nWords; k++)
+                    shmem_wait(&Target[k],proc);
+            } else {
+                /* wait for last word to be written */
+                shmem_wait(&Target[nWords-1],proc);
+            }
+        }
 
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] -(%d)\n", shmem_my_pe(),j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] -(%d)\n", shmem_my_pe(),j);
 
-		shmem_barrier_all();
+        shmem_barrier_all();
 
-		if ( proc != 0 ) {
-			for(k=0; k < nWords; k++) {
-				if (Target[k] != VAL) {
-					fprintf(stderr, "[%d] Target[%d] %#lx "
-							"!= %#x\?\n",
-							proc,k,Target[k],VAL);
-					failures++;
-				}
-				//assert(Target[proc] == VAL);
-				Target[k] = 0;
-			}
-		}
-		else
-			memset(Target, 0, sizeof(Target));
-	}
+        if ( proc != 0 ) {
+            for(k=0; k < nWords; k++) {
+                if (Target[k] != VAL) {
+                    fprintf(stderr, "[%d] Target[%d] %#lx "
+                            "!= %#x\?\n",
+                            proc,k,Target[k],VAL);
+                    failures++;
+                }
+                //assert(Target[proc] == VAL);
+                Target[k] = 0;
+            }
+        }
+        else
+            memset(Target, 0, sizeof(Target));
+    }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	if (failures || Verbose)
-		Rprintf ("%d(%d) Exit(%d)\n", proc, num_procs, failures);
+    if (failures || Verbose)
+        Rprintf ("%d(%d) Exit(%d)\n", proc, num_procs, failures);
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return failures;
+    return failures;
 }

--- a/test/unit/pingpong-short.c
+++ b/test/unit/pingpong-short.c
@@ -57,7 +57,7 @@ static int atoi_scaled(char *s);
 #define RDfprintf if (Verbose && shmem_my_pe() == 0) fprintf
 
 /* option flags */
-#define OUTPUT_MOD 1	// output debug every X loops on -V
+#define OUTPUT_MOD 1 // output debug every X loops on -V
 int output_mod = OUTPUT_MOD;
 int Verbose;
 int Slow;
@@ -81,97 +81,97 @@ DataType *work;
 int
 main(int argc, char* argv[])
 {
-	int c, j, loops, k, l;
-	int my_pe, nProcs, nWorkers;
-	int  nWords=1;
-	int  failures=0;
-	char *prog_name;
-	DataType *wp;
-	long work_sz;
+    int c, j, loops, k, l;
+    int my_pe, nProcs, nWorkers;
+    int  nWords=1;
+    int  failures=0;
+    char *prog_name;
+    DataType *wp;
+    long work_sz;
 
     for(j=0; j < SHMEM_BARRIER_SYNC_SIZE; j++) {
         pSync0[j] = pSync1[j] = pSync2[j] = pSync3[j] =
             pSync4[j] = SHMEM_SYNC_VALUE;
     }
 
-	shmem_init();
-	my_pe = shmem_my_pe();
-	nProcs = shmem_n_pes();
-	nWorkers = nProcs - 1;
+    shmem_init();
+    my_pe = shmem_my_pe();
+    nProcs = shmem_n_pes();
+    nWorkers = nProcs - 1;
 
-	if (nProcs == 1) {
-   		Rfprintf(stderr,
-			"ERR - Requires > 1 PEs\n");
-		shmem_finalize();
-		return 0;
-	}
+    if (nProcs == 1) {
+        Rfprintf(stderr,
+                 "ERR - Requires > 1 PEs\n");
+        shmem_finalize();
+        return 0;
+    }
 
-	for(j=0; j < nProcs; j++)
-		if ( shmem_pe_accessible(j) != 1 ) {
-			fprintf(stderr,
-				"ERR - pe %d not accessible from pe %d\n",
-				j, my_pe);
-		}
+    for(j=0; j < nProcs; j++)
+        if ( shmem_pe_accessible(j) != 1 ) {
+            fprintf(stderr,
+                    "ERR - pe %d not accessible from pe %d\n",
+                    j, my_pe);
+        }
 
-	prog_name = strrchr(argv[0],'/');
-	if ( prog_name )
-		prog_name++;
-	else
-		prog_name = argv[0];
+    prog_name = strrchr(argv[0],'/');
+    if ( prog_name )
+        prog_name++;
+    else
+        prog_name = argv[0];
 
-	while((c=getopt(argc,argv,"hvM:s")) != -1) {
-		switch(c) {
-		  case 's':
-			Slow++;
-			break;
-		  case 'v':
-			Verbose++;
-			break;
-		  case 'M':
-			output_mod = atoi(optarg);
-			if (output_mod <= 0) {
-    				Rfprintf(stderr, "ERR - output modulo arg out of "
-						"bounds '%d'?\n", output_mod);
-				shmem_finalize();
-				return 1;
-			}
-   			Rfprintf(stderr,"%s: output modulo %d\n",
-					prog_name,output_mod);
-			break;
-		  case 'h':
-			Rfprintf(stderr,
-				"usage: %s {nWords-2-put(%d)K/M} {Loop-count(%d)K/M}\n",
-				prog_name, DFLT_NWORDS, DFLT_LOOPS);
-			shmem_finalize();
-			return 1;
-		  default:
-			shmem_finalize();
-			return 1;
-		}
-	}
+    while((c=getopt(argc,argv,"hvM:s")) != -1) {
+        switch(c) {
+            case 's':
+                Slow++;
+                break;
+            case 'v':
+                Verbose++;
+                break;
+            case 'M':
+                output_mod = atoi(optarg);
+                if (output_mod <= 0) {
+                    Rfprintf(stderr, "ERR - output modulo arg out of "
+                             "bounds '%d'?\n", output_mod);
+                    shmem_finalize();
+                    return 1;
+                }
+                Rfprintf(stderr,"%s: output modulo %d\n",
+                         prog_name,output_mod);
+                break;
+            case 'h':
+                Rfprintf(stderr,
+                         "usage: %s {nWords-2-put(%d)K/M} {Loop-count(%d)K/M}\n",
+                         prog_name, DFLT_NWORDS, DFLT_LOOPS);
+                shmem_finalize();
+                return 1;
+            default:
+                shmem_finalize();
+                return 1;
+        }
+    }
 
-	if (optind == argc)
-		nWords = DFLT_NWORDS;
-	else {
-		nWords = atoi_scaled(argv[optind++]);
-		if (nWords <= 0) {
-    			Rfprintf(stderr, "ERR - Bad nWords '%d'?\n", nWords);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        nWords = DFLT_NWORDS;
+    else {
+        nWords = atoi_scaled(argv[optind++]);
+        if (nWords <= 0) {
+            Rfprintf(stderr, "ERR - Bad nWords '%d'?\n", nWords);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
-	if (optind == argc)
-		loops = DFLT_LOOPS;
-	else {
-		loops = atoi_scaled(argv[optind++]);
-		if (loops <= 0 || loops > 1000000) {
-    			Rfprintf(stderr,
-				"ERR - loops arg out of bounds '%d'?\n", loops);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        loops = DFLT_LOOPS;
+    else {
+        loops = atoi_scaled(argv[optind++]);
+        if (loops <= 0 || loops > 1000000) {
+            Rfprintf(stderr,
+                     "ERR - loops arg out of bounds '%d'?\n", loops);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
     work_sz = (nProcs*nWords) * sizeof(DataType);
     work = shmem_malloc( work_sz );
@@ -188,133 +188,133 @@ main(int argc, char* argv[])
     }
     src = &Target[nWords];
 
-	if (Verbose) Rprintf("%s: %d loops of %d shorts per put/get cycle\n",
-		prog_name,loops,nWords);
+    if (Verbose) Rprintf("%s: %d loops of %d shorts per put/get cycle\n",
+                         prog_name,loops,nWords);
 
-	for(j=0; j < nWords; j++)
-		src[j] = (DataType)VAL;
+    for(j=0; j < nWords; j++)
+        src[j] = (DataType)VAL;
 
-	for(j=0; j < loops; j++) {
+    for(j=0; j < loops; j++) {
 
 #if _DEBUG
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] +(%d)\n", shmem_my_pe(),j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] +(%d)\n", shmem_my_pe(),j);
 #endif
-	    shmem_barrier(0, 0, nProcs, pSync0);
-		if ( my_pe == 0 ) {
-			int p;
-			for(p=1; p < nProcs; p++)
-				shmem_short_put(Target, src, nWords, p);
-		}
-		else {
-			if (Slow) {
-				/* wait for each put to complete */
-				for(k=0; k < nWords; k++)
-					shmem_short_wait(&Target[k],my_pe);
-			} else {
-				/* wait for last word to be written */
-				shmem_short_wait(&Target[nWords-1],my_pe);
-			}
-		}
+        shmem_barrier(0, 0, nProcs, pSync0);
+        if ( my_pe == 0 ) {
+            int p;
+            for(p=1; p < nProcs; p++)
+                shmem_short_put(Target, src, nWords, p);
+        }
+        else {
+            if (Slow) {
+                /* wait for each put to complete */
+                for(k=0; k < nWords; k++)
+                    shmem_short_wait(&Target[k],my_pe);
+            } else {
+                /* wait for last word to be written */
+                shmem_short_wait(&Target[nWords-1],my_pe);
+            }
+        }
 #if _DEBUG
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] -(%d)\n", my_pe,j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] -(%d)\n", my_pe,j);
 #endif
-	    shmem_barrier(0, 0, nProcs, pSync1);
+        shmem_barrier(0, 0, nProcs, pSync1);
 
-		RDprintf("Workers[1 ... %d] verify Target data put by my_pe 0\n",
-			nWorkers);
+        RDprintf("Workers[1 ... %d] verify Target data put by my_pe 0\n",
+                 nWorkers);
 
-		/* workers verify put data is expected */
-		if ( my_pe != 0 ) {
-			for(k=0; k < nWords; k++) {
-				if (Target[k] != (DataType)VAL) {
-					fprintf(stderr, "[%d] Target[%d] %#hx "
-							"!= %#hx?\n",
-							my_pe,k,Target[k],(DataType)VAL);
-					failures++;
-				}
-				assert(Target[k] == (DataType)VAL);
-				Target[k] = my_pe;
-			}
-		}
-		else	/* clear results buffer, workers will put here */
-			memset(work, 0, work_sz);
+        /* workers verify put data is expected */
+        if ( my_pe != 0 ) {
+            for(k=0; k < nWords; k++) {
+                if (Target[k] != (DataType)VAL) {
+                    fprintf(stderr, "[%d] Target[%d] %#hx "
+                            "!= %#hx?\n",
+                            my_pe,k,Target[k],(DataType)VAL);
+                    failures++;
+                }
+                assert(Target[k] == (DataType)VAL);
+                Target[k] = my_pe;
+            }
+        }
+        else /* clear results buffer, workers will put here */
+            memset(work, 0, work_sz);
 
-	    shmem_barrier(0, 0, nProcs, pSync2);
+        shmem_barrier(0, 0, nProcs, pSync2);
 
-		RDprintf("Workers[1 ... %d] put Target data to PE0 work "
-			"vector\n",nWorkers);
+        RDprintf("Workers[1 ... %d] put Target data to PE0 work "
+                 "vector\n",nWorkers);
 
-		if ( my_pe != 0 ) {
-			/* push nWords of val my_pe back to PE zero */
-			shmem_short_put(&work[my_pe*nWords], Target, nWords, 0);
-		}
-		else {
-			/* wait for procs 1 ... nProcs to complete put()s */
-			for(l=1; l < nProcs; l++) {
-				wp = &work[ l*nWords ]; // procs nWords chunk
+        if ( my_pe != 0 ) {
+            /* push nWords of val my_pe back to PE zero */
+            shmem_short_put(&work[my_pe*nWords], Target, nWords, 0);
+        }
+        else {
+            /* wait for procs 1 ... nProcs to complete put()s */
+            for(l=1; l < nProcs; l++) {
+                wp = &work[ l*nWords ]; // procs nWords chunk
 #if 1
-				/* wait for last DataType to be written from each PE */
-				shmem_short_wait(&wp[nWords-1],0);
+                /* wait for last DataType to be written from each PE */
+                shmem_short_wait(&wp[nWords-1],0);
 #else
-				for(k=0; k < nWords; k++)
-					shmem_short_wait(&wp[k],0);
+                for(k=0; k < nWords; k++)
+                    shmem_short_wait(&wp[k],0);
 #endif
-			}
-		}
+            }
+        }
 
-	    shmem_barrier(0, 0, nProcs, pSync3);
+        shmem_barrier(0, 0, nProcs, pSync3);
 
-		if ( my_pe == 0 ) {
-			RDprintf("Loop(%d) PE0 verifing work data.\n",j);
-			for(l=1; l < nProcs; l++) {
-				wp = &work[ l*nWords ]; // procs nWords chunk
-				for(k=0; k < nWords; k++) {
-					if (wp[k] != l) {
-						fprintf(stderr,
-						"[0] PE(%d)_work[%d] %hd "
-							"!= %hd?\n",
-							l,k,work[k],(DataType)l);
-						failures++;
-					}
-					assert(wp[k] == l);
-					break;
-				}
-				if (failures)
-					break;
-			}
-		}
-	    shmem_barrier(0, 0, nProcs, pSync4);
+        if ( my_pe == 0 ) {
+            RDprintf("Loop(%d) PE0 verifing work data.\n",j);
+            for(l=1; l < nProcs; l++) {
+                wp = &work[ l*nWords ]; // procs nWords chunk
+                for(k=0; k < nWords; k++) {
+                    if (wp[k] != l) {
+                        fprintf(stderr,
+                                "[0] PE(%d)_work[%d] %hd "
+                                "!= %hd?\n",
+                                l,k,work[k],(DataType)l);
+                        failures++;
+                    }
+                    assert(wp[k] == l);
+                    break;
+                }
+                if (failures)
+                    break;
+            }
+        }
+        shmem_barrier(0, 0, nProcs, pSync4);
 
-		if (loops > 1) {
-			RDfprintf(stderr,".");
-			RDprintf("Loop(%d) Pass.\n",j);
-		}
-	}
-	RDfprintf(stderr,"\n");fflush(stderr);
+        if (loops > 1) {
+            RDfprintf(stderr,".");
+            RDprintf("Loop(%d) Pass.\n",j);
+        }
+    }
+    RDfprintf(stderr,"\n");fflush(stderr);
 
     shmem_free( work );
     shmem_free( Target );
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	RDprintf("%d(%d) Exit(%d)\n", my_pe, nProcs, failures);
+    RDprintf("%d(%d) Exit(%d)\n", my_pe, nProcs, failures);
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return failures;
+    return failures;
 }
 
 static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;

--- a/test/unit/pingpong.c
+++ b/test/unit/pingpong.c
@@ -56,7 +56,7 @@ static int atoi_scaled(char *s);
 #define RDfprintf if (Verbose && shmem_my_pe() == 0) fprintf
 
 /* option flags */
-#define OUTPUT_MOD 1	// output debug every X loops on -V
+#define OUTPUT_MOD 1 // output debug every X loops on -V
 int output_mod = OUTPUT_MOD;
 int Verbose;
 int Slow;
@@ -79,231 +79,231 @@ long *work;
 int
 main(int argc, char* argv[])
 {
-	int c, j, loops, k, l;
-	int my_pe, nProcs, nWorkers;
-	int  nWords=1;
-	int  failures=0;
-	char *prog_name;
-	long *wp,work_sz;
+    int c, j, loops, k, l;
+    int my_pe, nProcs, nWorkers;
+    int  nWords=1;
+    int  failures=0;
+    char *prog_name;
+    long *wp,work_sz;
 
     for(j=0; j < SHMEM_BARRIER_SYNC_SIZE; j++) {
         pSync0[j] = pSync1[j] = pSync2[j] = pSync3[j] =
             pSync4[j] = SHMEM_SYNC_VALUE;
     }
 
-	shmem_init();
-	my_pe = shmem_my_pe();
-	nProcs = shmem_n_pes();
-	nWorkers = nProcs - 1;
+    shmem_init();
+    my_pe = shmem_my_pe();
+    nProcs = shmem_n_pes();
+    nWorkers = nProcs - 1;
 
-	if (nProcs == 1) {
-   		Rfprintf(stderr,
-			"ERR - Requires > 1 PEs\n");
-		shmem_finalize();
-		return 0;
-	}
+    if (nProcs == 1) {
+        Rfprintf(stderr,
+                 "ERR - Requires > 1 PEs\n");
+        shmem_finalize();
+        return 0;
+    }
 
-	for(j=0; j < nProcs; j++)
-		if ( shmem_pe_accessible(j) != 1 ) {
-			fprintf(stderr,
-				"ERR - pe %d not accessible from pe %d\n",
-				j, my_pe);
-		}
+    for(j=0; j < nProcs; j++)
+        if ( shmem_pe_accessible(j) != 1 ) {
+            fprintf(stderr,
+                    "ERR - pe %d not accessible from pe %d\n",
+                    j, my_pe);
+        }
 
-	prog_name = strrchr(argv[0],'/');
-	if ( prog_name )
-		prog_name++;
-	else
-		prog_name = argv[0];
+    prog_name = strrchr(argv[0],'/');
+    if ( prog_name )
+        prog_name++;
+    else
+        prog_name = argv[0];
 
-	while((c=getopt(argc,argv,"hvM:s")) != -1) {
-		switch(c) {
-		  case 's':
-			Slow++;
-			break;
-		  case 'v':
-			Verbose++;
-			break;
-		  case 'M':
-			output_mod = atoi(optarg);
-			if (output_mod <= 0) {
-    				Rfprintf(stderr, "ERR - output modulo arg out of "
-						"bounds '%d'?\n", output_mod);
-				shmem_finalize();
-				return 1;
-			}
-   			Rfprintf(stderr,"%s: output modulo %d\n",
-					prog_name,output_mod);
-			break;
-		  case 'h':
-			Rfprintf(stderr,
-				"usage: %s {nWords-2-put(%d)K/M} {Loop-count(%d)K/M}\n",
-				prog_name, DFLT_NWORDS, DFLT_LOOPS);
-			shmem_finalize();
-			return 1;
-		  default:
-			shmem_finalize();
-			return 1;
-		}
-	}
+    while((c=getopt(argc,argv,"hvM:s")) != -1) {
+        switch(c) {
+            case 's':
+                Slow++;
+                break;
+            case 'v':
+                Verbose++;
+                break;
+            case 'M':
+                output_mod = atoi(optarg);
+                if (output_mod <= 0) {
+                    Rfprintf(stderr, "ERR - output modulo arg out of "
+                             "bounds '%d'?\n", output_mod);
+                    shmem_finalize();
+                    return 1;
+                }
+                Rfprintf(stderr,"%s: output modulo %d\n",
+                         prog_name,output_mod);
+                break;
+            case 'h':
+                Rfprintf(stderr,
+                         "usage: %s {nWords-2-put(%d)K/M} {Loop-count(%d)K/M}\n",
+                         prog_name, DFLT_NWORDS, DFLT_LOOPS);
+                shmem_finalize();
+                return 1;
+            default:
+                shmem_finalize();
+                return 1;
+        }
+    }
 
-	if (optind == argc)
-		nWords = DFLT_NWORDS;
-	else {
-		nWords = atoi_scaled(argv[optind++]);
-		if (nWords <= 0) {
-    			Rfprintf(stderr, "ERR - Bad nWords arg '%d'?\n", nWords);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        nWords = DFLT_NWORDS;
+    else {
+        nWords = atoi_scaled(argv[optind++]);
+        if (nWords <= 0) {
+            Rfprintf(stderr, "ERR - Bad nWords arg '%d'?\n", nWords);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
-	if (optind == argc)
-		loops = DFLT_LOOPS;
-	else {
-		loops = atoi_scaled(argv[optind++]);
-		if (loops <= 0 || loops > 1000000) {
-    			Rfprintf(stderr,
-				"ERR - loops arg out of bounds '%d'?\n", loops);
-			shmem_finalize();
-			return 1;
-		}
-	}
+    if (optind == argc)
+        loops = DFLT_LOOPS;
+    else {
+        loops = atoi_scaled(argv[optind++]);
+        if (loops <= 0 || loops > 1000000) {
+            Rfprintf(stderr,
+                     "ERR - loops arg out of bounds '%d'?\n", loops);
+            shmem_finalize();
+            return 1;
+        }
+    }
 
     work_sz = (nProcs*nWords) * sizeof(long);
-	work = shmem_malloc( work_sz );
-	if ( !work ) {
-   		fprintf(stderr,"[%d] ERR - work = shmem_malloc(%ld) ?\n",my_pe,work_sz);
-		shmem_global_exit(1);
-	}
+    work = shmem_malloc( work_sz );
+    if ( !work ) {
+        fprintf(stderr,"[%d] ERR - work = shmem_malloc(%ld) ?\n",my_pe,work_sz);
+        shmem_global_exit(1);
+    }
 
-	Target = shmem_malloc( 2 * nWords * sizeof(long) );
-	if ( !Target ) {
-   		fprintf(stderr,"[%d] ERR - Target = shmem_malloc(%ld) ?\n",
+    Target = shmem_malloc( 2 * nWords * sizeof(long) );
+    if ( !Target ) {
+        fprintf(stderr,"[%d] ERR - Target = shmem_malloc(%ld) ?\n",
                 my_pe, (nWords * sizeof(long)));
-		shmem_global_exit(1);
-	}
+        shmem_global_exit(1);
+    }
     src = &Target[nWords];
 
 #if _DEBUG
-	Rprintf("%s: %d loops of %d longs per put\n",prog_name,loops,nWords);
+    Rprintf("%s: %d loops of %d longs per put\n",prog_name,loops,nWords);
 #endif
 
-	for(j=0; j < nWords; j++)
-		src[j] = VAL;
+    for(j=0; j < nWords; j++)
+        src[j] = VAL;
 
-	for(j=0; j < loops; j++) {
+    for(j=0; j < loops; j++) {
 
 #if _DEBUG
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] +(%d)\n", my_pe,j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] +(%d)\n", my_pe,j);
 #endif
         shmem_barrier(0, 0, nProcs, pSync0);
-		if ( my_pe == 0 ) {
-			int p;
-			for(p=1; p < nProcs; p++)
-				shmem_long_put(Target, src, nWords, p);
-		}
-		else {
-			if (Slow) {
-				/* wait for each put to complete */
-				for(k=0; k < nWords; k++)
-					shmem_wait(&Target[k],my_pe);
-			} else {
-				/* wait for last word to be written */
-				shmem_wait(&Target[nWords-1],my_pe);
-			}
-		}
+        if ( my_pe == 0 ) {
+            int p;
+            for(p=1; p < nProcs; p++)
+                shmem_long_put(Target, src, nWords, p);
+        }
+        else {
+            if (Slow) {
+                /* wait for each put to complete */
+                for(k=0; k < nWords; k++)
+                    shmem_wait(&Target[k],my_pe);
+            } else {
+                /* wait for last word to be written */
+                shmem_wait(&Target[nWords-1],my_pe);
+            }
+        }
 #if _DEBUG
-		if ( Verbose && (j==0 || (j % output_mod) == 0) )
-    			fprintf(stderr,"[%d] -(%d)\n", shmem_my_pe(),j);
+        if ( Verbose && (j==0 || (j % output_mod) == 0) )
+            fprintf(stderr,"[%d] -(%d)\n", shmem_my_pe(),j);
 #endif
         shmem_barrier(0, 0, nProcs, pSync1);
 
-		RDprintf("Workers[1 ... %d] verify Target data put by proc0\n",
-			nWorkers);
+        RDprintf("Workers[1 ... %d] verify Target data put by proc0\n",
+                 nWorkers);
 
-		/* workers verify put data is expected */
-		if ( my_pe != 0 ) {
-			for(k=0; k < nWords; k++) {
-				if (Target[k] != VAL) {
-					fprintf(stderr, "[%d] Target[%d] %#lx "
-							"!= %#x?\n",
-							my_pe,k,Target[k],VAL);
-					failures++;
-				}
-				assert(Target[k] == VAL);
-				Target[k] = my_pe;
-			}
-		}
-		else	/* clear results buffer, workers will put here */
-			memset(work, 0, work_sz);
+        /* workers verify put data is expected */
+        if ( my_pe != 0 ) {
+            for(k=0; k < nWords; k++) {
+                if (Target[k] != VAL) {
+                    fprintf(stderr, "[%d] Target[%d] %#lx "
+                            "!= %#x?\n",
+                            my_pe,k,Target[k],VAL);
+                    failures++;
+                }
+                assert(Target[k] == VAL);
+                Target[k] = my_pe;
+            }
+        }
+        else /* clear results buffer, workers will put here */
+            memset(work, 0, work_sz);
 
         shmem_barrier(0, 0, nProcs, pSync2);
 
-		RDprintf("Workers[1 ... %d] put Target data to PE0 work "
-			"vector\n",nWorkers);
+        RDprintf("Workers[1 ... %d] put Target data to PE0 work "
+                 "vector\n",nWorkers);
 
-		if ( my_pe != 0 ) {
-			/* push nWords of val my_pe back to PE zero */
-			shmem_long_put(&work[my_pe * nWords], Target, nWords, 0);
-		}
-		else {
-			/* wait for procs 1 ... nProcs to complete put()s */
-			for(l=1; l < nProcs; l++) {
-				wp = &work[ l*nWords ]; // procs nWords chunk
+        if ( my_pe != 0 ) {
+            /* push nWords of val my_pe back to PE zero */
+            shmem_long_put(&work[my_pe * nWords], Target, nWords, 0);
+        }
+        else {
+            /* wait for procs 1 ... nProcs to complete put()s */
+            for(l=1; l < nProcs; l++) {
+                wp = &work[ l*nWords ]; // procs nWords chunk
 #if 1
-				/* wait for last long to be written from each PE */
-				shmem_wait(&wp[nWords-1],0);
+                /* wait for last long to be written from each PE */
+                shmem_wait(&wp[nWords-1],0);
 #else
-				for(k=0; k < nWords; k++)
-					shmem_wait(&wp[k],0);
+                for(k=0; k < nWords; k++)
+                    shmem_wait(&wp[k],0);
 #endif
-			}
-		}
+            }
+        }
 
         shmem_barrier(0, 0, nProcs, pSync3);
 
-		if ( my_pe == 0 ) {
-			RDprintf("Loop(%d) PE0 verifing work data.\n",j);
-			for(l=1; l < nProcs; l++) {
-				wp = &work[ l*nWords ]; // procs nWords chunk
-				for(k=0; k < nWords; k++) {
-					if (wp[k] != l) {
-						fprintf(stderr,
-						"[0] PE(%d)_work[%d] %ld "
-							"!= %d?\n",
-							l,k,work[k],l);
-						failures++;
-					}
-					assert(wp[k] == l);
-					break;
-				}
-				if (failures)
-					break;
-			}
-		}
+        if ( my_pe == 0 ) {
+            RDprintf("Loop(%d) PE0 verifing work data.\n",j);
+            for(l=1; l < nProcs; l++) {
+                wp = &work[ l*nWords ]; // procs nWords chunk
+                for(k=0; k < nWords; k++) {
+                    if (wp[k] != l) {
+                        fprintf(stderr,
+                                "[0] PE(%d)_work[%d] %ld "
+                                "!= %d?\n",
+                                l,k,work[k],l);
+                        failures++;
+                    }
+                    assert(wp[k] == l);
+                    break;
+                }
+                if (failures)
+                    break;
+            }
+        }
         shmem_barrier(0, 0, nProcs, pSync4);
 #if _DEBUG
-		if (loops > 1) {
-			Rfprintf(stderr,".");
-			RDprintf("Loop(%d) Pass.\n",j);
-		}
+        if (loops > 1) {
+            Rfprintf(stderr,".");
+            RDprintf("Loop(%d) Pass.\n",j);
+        }
 #endif
-	}
+    }
 
     shmem_free( work );
     shmem_free( Target );
 
 #if _DEBUG
-	Rfprintf(stderr,"\n");fflush(stderr);
-	shmem_barrier_all();
-	RDprintf("%d(%d) Exit(%d)\n", my_pe, nProcs, failures);
+    Rfprintf(stderr,"\n");fflush(stderr);
+    shmem_barrier_all();
+    RDprintf("%d(%d) Exit(%d)\n", my_pe, nProcs, failures);
 #endif
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return failures;
+    return failures;
 }
 
 
@@ -311,11 +311,11 @@ static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;

--- a/test/unit/rma_coverage.c
+++ b/test/unit/rma_coverage.c
@@ -2,11 +2,11 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
- *	without modification, are permitted provided that the following
- *	conditions are met:
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
  *
- *	- Redistributions of source code must retain the above
+ *      - Redistributions of source code must retain the above
  *        copyright notice, this list of conditions and the following
  *        disclaimer.
  *

--- a/test/unit/set_lock.c
+++ b/test/unit/set_lock.c
@@ -102,9 +102,9 @@ main(int argc, char* argv[])
 
         lock_cnt = 0;
         lock = 0;
-    
+
         shmem_barrier_all();  /* sync all ranks */
-        
+
         shmem_set_lock(&lock);
 
         for(pe=0; pe < num_ranks; pe++) {
@@ -114,7 +114,7 @@ main(int argc, char* argv[])
             printf("[%d] locked: lock_cnt(%d)\n", my_rank, lock_cnt);
 
         shmem_clear_lock( &lock );
-    
+
         shmem_int_wait_until( &lock_cnt, SHMEM_CMP_GE, num_ranks );
 
         shmem_barrier_all();  /* sync all ranks */

--- a/test/unit/shmalloc.c
+++ b/test/unit/shmalloc.c
@@ -225,7 +225,7 @@ main(int argc, char **argv)
 #if 0
         printf("[%d] source %p target %p result %p\n",
             me, (void*)source,(void*)target,(void*)result);
-        shmem_barrier_all(); 
+        shmem_barrier_all();
 #endif
 
         shmem_barrier_all(); /* sync sender and receiver */

--- a/test/unit/shmem_info_f.f90
+++ b/test/unit/shmem_info_f.f90
@@ -1,20 +1,20 @@
-! 
+!
 !   Copyright (c) 2015 Intel Corporation. All rights reserved.
 !   This software is available to you under the BSD license below:
-! 
+!
 !       Redistribution and use in source and binary forms, with or
 !       without modification, are permitted provided that the following
 !       conditions are met:
-! 
+!
 !       - Redistributions of source code must retain the above
 !         copyright notice, this list of conditions and the following
 !         disclaimer.
-! 
+!
 !       - Redistributions in binary form must reproduce the above
 !         copyright notice, this list of conditions and the following
 !         disclaimer in the documentation and/or other materials
 !         provided with the distribution.
-! 
+!
 !  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 !  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 !  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -23,7 +23,7 @@
 !  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 !  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 !  SOFTWARE.
-! 
+!
 
 program shmem_info
     include 'shmem.fh'

--- a/test/unit/spam.c
+++ b/test/unit/spam.c
@@ -85,14 +85,14 @@ int
 main(int argc, char **argv)
 {
     int i;
-	int *target;
-	int *source;
-	int me, npes, elements=N_ELEMENTS, loops=DFLT_LOOPS;
+    int *target;
+    int *source;
+    int me, npes, elements=N_ELEMENTS, loops=DFLT_LOOPS;
     char *pgm;
 
-	shmem_init();
-	me = shmem_my_pe();
-	npes = shmem_n_pes();
+    shmem_init();
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
 
     if ((pgm=strrchr(argv[0],'/')))
         pgm++;
@@ -156,15 +156,15 @@ main(int argc, char **argv)
     if (All2==0 && Bcast==0 && Collect==0 && Many==0 && Neighbor==0)
         All2 = Bcast = Collect = Many = Neighbor = 1;
 
-	source = (int *) shmem_malloc( elements * sizeof(*source) );
-	target = (int *) shmem_malloc( elements * sizeof(*target) );
+    source = (int *) shmem_malloc( elements * sizeof(*source) );
+    target = (int *) shmem_malloc( elements * sizeof(*target) );
 
-	for (i = 0; i < elements; i += 1) {
-	    source[i] = i + 1;
-	    target[i] = -90;
-	}
+    for (i = 0; i < elements; i += 1) {
+        source[i] = i + 1;
+        target[i] = -90;
+    }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     if (Neighbor) {
         neighbor_put( target, source, elements, me, npes, loops );
@@ -188,88 +188,88 @@ main(int argc, char **argv)
         fcollect( NULL, source, elements, me, npes, loops );
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	shmem_free(target);
-	shmem_free(source);
+    shmem_free(target);
+    shmem_free(source);
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return 0;
+    return 0;
 }
 
 void
 one2many_put(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src) * (npes - 1);
 
-	if (me == 0) {
+    if (me == 0) {
         fprintf(stdout,"%s: %d loops of put(%ld bytes) to %d PEs: ",
                 __FUNCTION__, loops, (elements*sizeof(*src)), npes-1);
         fflush(stdout);
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	if (me == 0) {
-	    start_time = shmemx_wtime();
-	    for(i = 0; i < loops; i++) {
-	        for(pe = 1; pe < npes; pe++)
-	            shmem_int_put(target, src, elements, pe);
-	    }
-	    elapsed_time = shmemx_wtime() - start_time;
+    if (me == 0) {
+        start_time = shmemx_wtime();
+        for(i = 0; i < loops; i++) {
+            for(pe = 1; pe < npes; pe++)
+                shmem_int_put(target, src, elements, pe);
+        }
+        elapsed_time = shmemx_wtime() - start_time;
 
-	    if (Verbose) {
+        if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
             printf("  %7.5f usecs / put(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*(npes-1)))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+                   (elapsed_time/((double)loops*(npes-1)))*1000000.0,
+                   (total_bytes/1024),
+                   ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
         }
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 void
 many2one_get(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src) * (npes - 1);
 
-	if (me == 0) {
+    if (me == 0) {
         fprintf(stdout,"%s: %d loops of get(%ld bytes) from %d PEs: ",
                 __FUNCTION__, loops, (elements*sizeof(*src)), npes-1);
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	if (me == 0) {
-	    start_time = shmemx_wtime();
-	    for(i = 0; i < loops; i++) {
-	        for(pe = 1; pe < npes; pe++)
-	            shmem_int_get(target, src, elements, pe);
-	    }
-	    elapsed_time = shmemx_wtime() - start_time;
+    if (me == 0) {
+        start_time = shmemx_wtime();
+        for(i = 0; i < loops; i++) {
+            for(pe = 1; pe < npes; pe++)
+                shmem_int_get(target, src, elements, pe);
+        }
+        elapsed_time = shmemx_wtime() - start_time;
 
-	    if (Verbose) {
+        if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
             printf("  %7.5f usecs / get(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*(npes-1)))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+                   (elapsed_time/((double)loops*(npes-1)))*1000000.0,
+                   (total_bytes/1024),
+                   ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
         }
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 void
 all2all_get(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src) * npes;
 
     if (me==0 && Verbose) {
@@ -277,7 +277,7 @@ all2all_get(int *target, int *src, int elements, int me, int npes, int loops)
                 __FUNCTION__, loops, (elements*sizeof(*src)), npes);
         fflush(stdout);
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     start_time = shmemx_wtime();
     for(i = 0; i < loops; i++) {
@@ -289,12 +289,12 @@ all2all_get(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / get(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 
@@ -302,7 +302,7 @@ void
 all2all_put(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src) * npes;
 
     if (me==0 && Verbose) {
@@ -311,7 +311,7 @@ all2all_put(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     start_time = shmemx_wtime();
     for(i = 0; i < loops; i++) {
@@ -323,19 +323,19 @@ all2all_put(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / put(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 void
 neighbor_put(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, neighbor_pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
 
     if (me==0 && Verbose) {
@@ -344,7 +344,7 @@ neighbor_put(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     neighbor_pe = (me + 1) % npes;
 
@@ -356,18 +356,18 @@ neighbor_put(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / put(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 void
 neighbor_get(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i, neighbor_pe;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
 
     if (me==0 && Verbose) {
@@ -376,7 +376,7 @@ neighbor_get(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     neighbor_pe = (me + 1) % npes;
 
@@ -388,11 +388,11 @@ neighbor_get(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / get(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 
@@ -400,12 +400,12 @@ void
 bcast(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long *ps, *pSync, *pSync1;
     long total_bytes = loops * elements * sizeof(*src);
 
-	pSync = (long*)shmem_malloc( 2 * sizeof(long) * SHMEM_BCAST_SYNC_SIZE );
-	pSync1 = &pSync[SHMEM_BCAST_SYNC_SIZE];
+    pSync = (long*)shmem_malloc( 2 * sizeof(long) * SHMEM_BCAST_SYNC_SIZE );
+    pSync1 = &pSync[SHMEM_BCAST_SYNC_SIZE];
     for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
@@ -416,7 +416,7 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     start_time = shmemx_wtime();
     for(i = 0; i < loops; i++) {
@@ -428,11 +428,11 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / broadcast32(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
-	shmem_barrier_all();
+    shmem_barrier_all();
     shmem_free( pSync );
 }
 
@@ -441,16 +441,16 @@ void
 collect(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
     long *ps, *pSync, *pSync1;
 
-	pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
-	pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
+    pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
+    pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
     for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
-	target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
+    target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
 
     if (me==0 && Verbose) {
         fprintf(stdout,"%s: %d loops of collect32(%ld bytes) over %d PEs: ",
@@ -458,7 +458,7 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     start_time = shmemx_wtime();
     for(i = 0; i < loops; i++) {
@@ -470,32 +470,32 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / collect32(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
-	shmem_barrier_all();
-	shmem_free(target);
+    shmem_barrier_all();
+    shmem_free(target);
     shmem_free( pSync );
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
-  
+
 
 void
 fcollect(int *target, int *src, int elements, int me, int npes, int loops)
 {
     int i;
-	double start_time, elapsed_time;
+    double start_time, elapsed_time;
     long total_bytes = loops * elements * sizeof(*src);
     long *ps, *pSync, *pSync1;
 
-	pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
-	pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
+    pSync = (long*) shmem_malloc( 2 * sizeof(long) * SHMEM_COLLECT_SYNC_SIZE );
+    pSync1 = &pSync[SHMEM_COLLECT_SYNC_SIZE];
     for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++) {
         pSync[i] = pSync1[i] = SHMEM_SYNC_VALUE;
     }
-	target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
+    target = (int *) shmem_malloc( elements * sizeof(*target) * npes );
 
     if (me==0 && Verbose) {
         fprintf(stdout,"%s: %d loops of fcollect32(%ld bytes) over %d PEs: ",
@@ -503,7 +503,7 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
         fflush(stdout);
     }
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
     start_time = shmemx_wtime();
     for(i = 0; i < loops; i++) {
@@ -515,25 +515,25 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
         printf("  %7.5f usecs / fcollect32(), %ld Kbytes @ %7.4f MB/sec\n\n",
-                (elapsed_time/((double)loops*npes))*1000000.0,
-                (total_bytes/1024),
-                ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
+               (elapsed_time/((double)loops*npes))*1000000.0,
+               (total_bytes/1024),
+               ((double)total_bytes/(1024.0*1024.0)) / elapsed_time );
     }
-	shmem_barrier_all();
-	shmem_free(target);
+    shmem_barrier_all();
+    shmem_free(target);
     shmem_free( pSync );
-	shmem_barrier_all();
+    shmem_barrier_all();
 }
 
 static int
 atoi_scaled(char *s)
 {
     long val;
-    char *e; 
+    char *e;
 
     val = strtol(s,&e,0);
     if (e == NULL || *e =='\0')
-        return (int)val; 
+        return (int)val;
 
     if (*e == 'k' || *e == 'K')
         val *= 1024;

--- a/test/unit/sping.c
+++ b/test/unit/sping.c
@@ -56,203 +56,203 @@ int Verbose=0;
 
 int getSize (char *str)
 {
-	int size;
-	char mod[32];
+    int size;
+    char mod[32];
 
-	switch (sscanf (str, "%d%1[mMkK]", &size, mod))
-	{
-	case 1:
-		return (size);
+    switch (sscanf (str, "%d%1[mMkK]", &size, mod))
+    {
+        case 1:
+            return (size);
 
-	case 2:
-		switch (*mod)
-		{
-		case 'm':
-		case 'M':
-			return (size << 20);
+        case 2:
+            switch (*mod)
+            {
+                case 'm':
+                case 'M':
+                    return (size << 20);
 
-		case 'k':
-		case 'K':
-			return (size << 10);
+                case 'k':
+                case 'K':
+                    return (size << 10);
 
-		default:
-			return (size);
-		}
+                default:
+                    return (size);
+            }
 
-	default:
-		return (-1);
-	}
+        default:
+            return (-1);
+    }
 }
 
 double gettime()
 {
-	struct timeval tv;
-	gettimeofday(&tv, 0);
-	return (tv.tv_sec * 1000000 + tv.tv_usec);
+    struct timeval tv;
+    gettimeofday(&tv, 0);
+    return (tv.tv_sec * 1000000 + tv.tv_usec);
 }
 
 double dt (double *tv1, double *tv2)
 {
-	return (*tv1 - *tv2);
+    return (*tv1 - *tv2);
 }
 
 void usage (char *name)
 {
-	fprintf (stderr, "Usage: %s [flags] nwords [maxWords] [incWords]\n", name);
-	fprintf (stderr, " %s -h\n", name);
-	exit (1);
+    fprintf (stderr, "Usage: %s [flags] nwords [maxWords] [incWords]\n", name);
+    fprintf (stderr, " %s -h\n", name);
+    exit (1);
 }
 
 void help (char *name)
 {
-	if (shmem_my_pe() == 0) {
-		printf ("Usage: %s [flags] nwords [maxWords] [incWords]\n\n", name);
-		printf (" Flags may be any of\n");
-		printf (" -n number repititions\n");
-		printf (" -e everyone print timing info\n");
-		printf (" -h print this info\n\n");
-		printf (" Numbers may be postfixed with 'k' or 'm'\n\n");
-	}
-	shmem_barrier_all();
-	exit (0);
+    if (shmem_my_pe() == 0) {
+        printf ("Usage: %s [flags] nwords [maxWords] [incWords]\n\n", name);
+        printf (" Flags may be any of\n");
+        printf (" -n number repititions\n");
+        printf (" -e everyone print timing info\n");
+        printf (" -h print this info\n\n");
+        printf (" Numbers may be postfixed with 'k' or 'm'\n\n");
+    }
+    shmem_barrier_all();
+    exit (0);
 }
 
 void printStats (int proc, int peer, int doprint, int now, double t)
 {
-	if (doprint || (proc & 1))
-		printf("%3d pinged %3d: %8d words %9.2f uSec %8.2f MB/s\n",
-				proc, peer, now, t, sizeof(long)*now/(t));
+    if (doprint || (proc & 1))
+        printf("%3d pinged %3d: %8d words %9.2f uSec %8.2f MB/s\n",
+               proc, peer, now, t, sizeof(long)*now/(t));
 }
 
 int main (int argc, char *argv[])
 {
-	double t,tv[2];
-	int reps = DFLT_REPS;
-	int doprint = 1/*0*/;
-	char *progName;
-	int minWords;
-	int maxWords;
-	int incWords, nwords, nproc, proc, peer, c, r, i;
-	long *rbuf;	/* remote buffer - sink */
-	long *tbuf;	/* transmit buffer - src */
+    double t,tv[2];
+    int reps = DFLT_REPS;
+    int doprint = 1/*0*/;
+    char *progName;
+    int minWords;
+    int maxWords;
+    int incWords, nwords, nproc, proc, peer, c, r, i;
+    long *rbuf; /* remote buffer - sink */
+    long *tbuf; /* transmit buffer - src */
 
-	shmem_init();
-	proc = shmem_my_pe();
-	nproc = shmem_n_pes();
-	if (nproc == 1) {
-		fprintf(stderr, "ERR - Requires > 1 Processing Elements\n");
-		shmem_finalize();
-		return 0;
-	}
+    shmem_init();
+    proc = shmem_my_pe();
+    nproc = shmem_n_pes();
+    if (nproc == 1) {
+        fprintf(stderr, "ERR - Requires > 1 Processing Elements\n");
+        shmem_finalize();
+        return 0;
+    }
 
-	for (progName = argv[0] + strlen(argv[0]);
-		 progName > argv[0] && *(progName - 1) != '/';
-		 progName--)
-		;
+    for (progName = argv[0] + strlen(argv[0]);
+         progName > argv[0] && *(progName - 1) != '/';
+         progName--)
+        ;
 
-	while ((c = getopt (argc, argv, "n:evh")) != -1)
-		switch (c)
-		{
-		case 'n':
-			if ((reps = getSize (optarg)) <= 0)
-				usage (progName);
-			break;
-		case 'e':
-			doprint++;
-			break;
-		case 'v':
-			Verbose++;
-			break;
-		case 'h':
-			help (progName);
-		default:
-			usage (progName);
-		}
+    while ((c = getopt (argc, argv, "n:evh")) != -1)
+        switch (c)
+        {
+            case 'n':
+                if ((reps = getSize (optarg)) <= 0)
+                    usage (progName);
+                break;
+            case 'e':
+                doprint++;
+                break;
+            case 'v':
+                Verbose++;
+                break;
+            case 'h':
+                help (progName);
+            default:
+                usage (progName);
+        }
 
-	if (optind == argc)
-		minWords = DFLT_MIN_WORDS;
-	else if ((minWords = getSize (argv[optind++])) <= 0)
-		usage (progName);
+    if (optind == argc)
+        minWords = DFLT_MIN_WORDS;
+    else if ((minWords = getSize (argv[optind++])) <= 0)
+        usage (progName);
 
-	if (optind == argc)
-		maxWords = minWords;
-	else if ((maxWords = getSize (argv[optind++])) < minWords)
-		usage (progName);
+    if (optind == argc)
+        maxWords = minWords;
+    else if ((maxWords = getSize (argv[optind++])) < minWords)
+        usage (progName);
 
-	if (optind == argc)
-		incWords = 0;
-	else if ((incWords = getSize (argv[optind++])) < 0)
-		usage (progName);
+    if (optind == argc)
+        incWords = 0;
+    else if ((incWords = getSize (argv[optind++])) < 0)
+        usage (progName);
 
-	if (!(rbuf = (long *)shmem_malloc(maxWords * sizeof(long))))
-	{
-		perror ("Failed memory allocation");
-		exit (1);
-	}
-	memset (rbuf, 0, maxWords * sizeof (long));
+    if (!(rbuf = (long *)shmem_malloc(maxWords * sizeof(long))))
+    {
+        perror ("Failed memory allocation");
+        exit (1);
+    }
+    memset (rbuf, 0, maxWords * sizeof (long));
 
-	if (!(tbuf = (long *)shmem_malloc(maxWords * sizeof(long))))
-	{
-		perror ("Failed memory allocation");
-		exit (1);
-	}
+    if (!(tbuf = (long *)shmem_malloc(maxWords * sizeof(long))))
+    {
+        perror ("Failed memory allocation");
+        exit (1);
+    }
 
-	for (i = 0; i < maxWords; i++)
-		tbuf[i] = 1000 + (i & 255);
+    for (i = 0; i < maxWords; i++)
+        tbuf[i] = 1000 + (i & 255);
 
-	if (doprint)
-		printf ("%d(%d): Shmem PING reps %d minWords %d maxWords %d "
-				"incWords %d\n",
-				proc, nproc, reps, minWords, maxWords, incWords);
+    if (doprint)
+        printf ("%d(%d): Shmem PING reps %d minWords %d maxWords %d "
+                "incWords %d\n",
+                proc, nproc, reps, minWords, maxWords, incWords);
 
-        dprint("[%d] rbuf: %ld\n", proc, (unsigned long) rbuf);
+    dprint("[%d] rbuf: %ld\n", proc, (unsigned long) rbuf);
 
-	shmem_barrier_all();
+    shmem_barrier_all();
 
-	peer = proc ^ 1;
-	if (peer >= nproc)
-		doprint = 0;
+    peer = proc ^ 1;
+    if (peer >= nproc)
+        doprint = 0;
 
-	for (nwords = minWords;
-		 nwords <= maxWords;
-		 nwords = incWords ? nwords + incWords : nwords ? 2 * nwords : 1)
-	{
-		r = reps;
-		shmem_barrier_all();
-		tv[0] = gettime();
-		if (peer < nproc)
-		{
-			if (proc & 1)
-			{
-				r--;
-				shmem_wait(&rbuf[nwords-1], 0);
-				rbuf[nwords-1] = 0;
-			}
+    for (nwords = minWords;
+         nwords <= maxWords;
+         nwords = incWords ? nwords + incWords : nwords ? 2 * nwords : 1)
+    {
+        r = reps;
+        shmem_barrier_all();
+        tv[0] = gettime();
+        if (peer < nproc)
+        {
+            if (proc & 1)
+            {
+                r--;
+                shmem_wait(&rbuf[nwords-1], 0);
+                rbuf[nwords-1] = 0;
+            }
 
-			while (r-- > 0)
-			{
-				shmem_long_put(rbuf, tbuf, nwords, peer);
-				shmem_wait(&rbuf[nwords-1], 0);
-				rbuf[nwords-1] = 0;
-			}
+            while (r-- > 0)
+            {
+                shmem_long_put(rbuf, tbuf, nwords, peer);
+                shmem_wait(&rbuf[nwords-1], 0);
+                rbuf[nwords-1] = 0;
+            }
 
-			if (proc & 1)
-			{
-				shmem_long_put(rbuf, tbuf, nwords, peer);
-			}
-		}
-		tv[1] = gettime();
-		t = dt (&tv[1], &tv[0]) / (2 * reps);
+            if (proc & 1)
+            {
+                shmem_long_put(rbuf, tbuf, nwords, peer);
+            }
+        }
+        tv[1] = gettime();
+        t = dt (&tv[1], &tv[0]) / (2 * reps);
 
-		shmem_barrier_all();
+        shmem_barrier_all();
 
-		printStats (proc, peer, doprint, nwords, t);
-	}
+        printStats (proc, peer, doprint, nwords, t);
+    }
 
     shmem_free(rbuf);
     shmem_free(tbuf);
 
-	shmem_finalize();
+    shmem_finalize();
 
-	return 0;
+    return 0;
 }

--- a/test/unit/strided_put.c
+++ b/test/unit/strided_put.c
@@ -61,7 +61,7 @@ main(int argc, char* argv[])
         shmem_short_iput(target, source, 1, 2, 5, 1);
     }
 
-    shmem_barrier_all();	/* sync sender and receiver */
+    shmem_barrier_all(); /* sync sender and receiver */
 
     if (me == 1) {
         if (! (target[0] == source[0] &&

--- a/test/unit/test_lock.c
+++ b/test/unit/test_lock.c
@@ -39,8 +39,8 @@
  * For n loops:
  *   Each pe attempts to lock the global lock, if lock is taken, increment the
  *   lock count on all pes and then waits until the lock count reaches num_pes()
- *   which is the exit condition. 
- *   On a failed lock attempt, increment local lock_tries counter and repeat. 
+ *   which is the exit condition.
+ *   On a failed lock attempt, increment local lock_tries counter and repeat.
  */
 #include <shmem.h>
 #include <stdio.h>
@@ -131,7 +131,7 @@ main(int argc, char* argv[])
         lock = 0;
         lock_cnt = 0;
         tries = 0;
-    
+
         shmem_barrier_all();  /* sync all ranks */
 
         while( *(&lock_cnt) < num_ranks ) {

--- a/test/unit/to_all.c
+++ b/test/unit/to_all.c
@@ -130,7 +130,7 @@ max_to_all(int me, int npes)
     shmem_double_max_to_all(    dst4, src4, N, 0, 0, npes, pWrk4, pSync);
     shmem_longdouble_max_to_all(dst5, src5, N, 0, 0, npes, pWrk5, pSync1);
     shmem_longlong_max_to_all(  dst6, src6, N, 0, 0, npes, pWrk6, pSync);
-  
+
     if (me == 0) {
         for (i = 0,j=-1; i < N; i++,j++) {
           if(dst0[i] != npes+j) ok[0] = 1;
@@ -144,49 +144,49 @@ max_to_all(int me, int npes)
 
         if(ok[0]==1){
             printf("Reduction operation shmem_short_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_short_max_to_all: Passed\n");
             pass++;
         }
         if(ok[1]==1){
             printf("Reduction operation shmem_int_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_int_max_to_all: Passed\n");
             pass++;
         }
         if(ok[2]==1){
             printf("Reduction operation shmem_long_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_long_max_to_all: Passed\n");
             pass++;
         }
         if(ok[3]==1){
             printf("Reduction operation shmem_float_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_float_max_to_all: Passed\n");
             pass++;
         }
         if(ok[4]==1){
             printf("Reduction operation shmem_double_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_double_max_to_all: Passed\n");
             pass++;
         }
         if(ok[5]==1){
           printf("Reduction operation shmem_longdouble_max_to_all: Failed\n");
-        }  
+        }
         else{
            Vprintf("Reduction operation shmem_longdouble_max_to_all: Passed\n");
            pass++;
         }
         if(ok[6]==1){
             printf("Reduction operation shmem_longlong_max_to_all: Failed\n");
-        }  
+        }
         else{
             Vprintf("Reduction operation shmem_longlong_max_to_all: Passed\n");
             pass++;
@@ -216,9 +216,9 @@ min_to_all(int me, int npes)
       dst5[i] = -9;
       dst6[i] = -9;
     }
- 
+
     shmem_barrier_all();
-  
+
     shmem_short_min_to_all(dst0, src0, N, 0, 0, npes, pWrk0, pSync);
     shmem_int_min_to_all(dst1, src1, N, 0, 0, npes, pWrk1, pSync1);
     shmem_long_min_to_all(dst2, src2, N, 0, 0, npes, pWrk2, pSync);
@@ -226,7 +226,7 @@ min_to_all(int me, int npes)
     shmem_double_min_to_all(dst4, src4, N, 0, 0, npes, pWrk4, pSync);
     shmem_longdouble_min_to_all(dst5, src5, N, 0, 0, npes, pWrk5, pSync1);
     shmem_longlong_min_to_all(dst6, src6, N, 0, 0, npes, pWrk6, pSync);
-  
+
     if(me == 0) {
       for (i = 0; i < N; i++) {
          if(dst0[i] != i) ok[0] = 1;
@@ -239,49 +239,49 @@ min_to_all(int me, int npes)
       }
       if(ok[0]==1){
         printf("Reduction operation shmem_short_min_to_all: Failed\n");
-      }  
+      }
       else{
         Vprintf("Reduction operation shmem_short_min_to_all: Passed\n");
         pass++;
         }
         if(ok[1]==1){
         printf("Reduction operation shmem_int_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_int_min_to_all: Passed\n");
         pass++;
         }
         if(ok[2]==1){
         printf("Reduction operation shmem_long_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_long_min_to_all: Passed\n");
         pass++;
         }
         if(ok[3]==1){
         printf("Reduction operation shmem_float_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_float_min_to_all: Passed\n");
         pass++;
         }
         if(ok[4]==1){
         printf("Reduction operation shmem_double_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_double_min_to_all: Passed\n");
         pass++;
         }
         if(ok[5]==1){
         printf("Reduction operation shmem_longdouble_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_longdouble_min_to_all: Passed\n");
         pass++;
         }
         if(ok[6]==1){
         printf("Reduction operation shmem_longlong_min_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_longlong_min_to_all: Passed\n");
         pass++;
@@ -334,49 +334,49 @@ sum_to_all(int me, int npes)
     }
     if(ok[0]==1){
       printf("Reduction operation shmem_short_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_short_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[1]==1){
       printf("Reduction operation shmem_int_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_int_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[2]==1){
       printf("Reduction operation shmem_long_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_long_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[3]==1){
       printf("Reduction operation shmem_float_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_float_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[4]==1){
       printf("Reduction operation shmem_double_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_double_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[5]==1){
       printf("Reduction operation shmem_longdouble_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_longdouble_sum_to_all: Passed\n");
       pass++;
     }
     if(ok[6]==1){
       printf("Reduction operation shmem_longlong_sum_to_all: Failed\n");
-    }  
+    }
     else{
       Vprintf("Reduction operation shmem_longlong_sum_to_all: Passed\n");
       pass++;
@@ -388,7 +388,7 @@ sum_to_all(int me, int npes)
     return (pass == 7 ? 1 : 0);
 }
 
-  
+
 int
 and_to_all(int me, int num_pes)
 {
@@ -407,7 +407,7 @@ and_to_all(int me, int num_pes)
     shmem_int_and_to_all(dst1, src1, N, 0, 0, num_pes, pWrk1, pSync1);
     shmem_long_and_to_all(dst2, src2, N, 0, 0, num_pes, pWrk2, pSync);
     shmem_longlong_and_to_all(dst6, src6, N, 0, 0, num_pes, pWrk6, pSync1);
-  
+
     if (me==0) {
       for (i = 0; i < N; i++) {
           if(dst0[i] != 0) ok[0] = 1;
@@ -418,28 +418,28 @@ and_to_all(int me, int num_pes)
 
       if(ok[0]==1){
         printf("Reduction operation shmem_short_and_to_all: Failed\n");
-      }  
+      }
       else{
         Vprintf("Reduction operation shmem_short_and_to_all: Passed\n");
         pass++;
         }
         if(ok[1]==1){
         printf("Reduction operation shmem_int_and_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_int_and_to_all: Passed\n");
         pass++;
         }
         if(ok[2]==1){
         printf("Reduction operation shmem_long_and_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_long_and_to_all: Passed\n");
         pass++;
         }
         if(ok[3]==1){
         printf("Reduction operation shmem_longlong_and_to_all: Failed\n");
-        }  
+        }
       else{
         Vprintf("Reduction operation shmem_longlong_and_to_all: Passed\n");
         pass++;
@@ -473,11 +473,11 @@ prod_to_all(int me, int npes)
         dst5[i] = -9;
         dst6[i] = -9;
     }
-  
+
     expected_result0 = expected_result1 = expected_result2 =
     expected_result6 = 1;
     expected_result3 = expected_result4 = expected_result5 = 1.0;
-    
+
 
     for(i=1; i <= npes; i++) {
         expected_result0 *= i;
@@ -498,9 +498,9 @@ prod_to_all(int me, int npes)
         }
         expected_result6 *= i;
     }
-   
+
     shmem_barrier_all();
- 
+
     shmem_short_prod_to_all(dst0, src0, N, 0, 0, npes, pWrk0, pSync);
     shmem_int_prod_to_all(dst1, src1, N, 0, 0, npes, pWrk1, pSync1);
     shmem_long_prod_to_all(dst2, src2, N, 0, 0, npes, pWrk2, pSync);
@@ -508,7 +508,7 @@ prod_to_all(int me, int npes)
     shmem_double_prod_to_all(dst4, src4, N, 0, 0, npes, pWrk4, pSync);
     shmem_longdouble_prod_to_all(dst5, src5, N, 0, 0, npes, pWrk5, pSync1);
     shmem_longlong_prod_to_all(dst6, src6, N, 0, 0, npes, pWrk6, pSync);
- 
+
     if(me == 0) {
       for (i = 0; i < N; i++) {
         if(dst0[i] != expected_result0) ok[0] = 1;
@@ -597,7 +597,7 @@ prod_to_all(int me, int npes)
 
     return (pass == 7 ? 1 : 0);
 }
- 
+
 
 int
 or_to_all(int me, int npes)
@@ -613,14 +613,14 @@ or_to_all(int me, int npes)
       dst2[i] = -9;
       dst6[i] = -9;
     }
- 
+
     shmem_barrier_all();
-  
+
     shmem_short_or_to_all(dst0, src0, N, 0, 0, npes, pWrk0, pSync);
     shmem_int_or_to_all(dst1, src1, N, 0, 0, npes, pWrk1, pSync1);
     shmem_long_or_to_all(dst2, src2, N, 0, 0, npes, pWrk2, pSync);
     shmem_longlong_or_to_all(dst6, src6, N, 0, 0, npes, pWrk6, pSync1);
-  
+
     if (me==0) {
         for (i = 0; i < N; i++) {
             int expected = (npes == 1) ? 1 : 3;
@@ -681,14 +681,14 @@ xor_to_all(int me, int npes)
         dst2[i] = -9;
         dst6[i] = -9;
     }
-    
+
     shmem_barrier_all();
-    
+
     shmem_short_xor_to_all(dst0, src0, N, 0, 0, npes, pWrk0, pSync);
     shmem_int_xor_to_all(dst1, src1, N, 0, 0, npes, pWrk1, pSync1);
     shmem_long_xor_to_all(dst2, src2, N, 0, 0, npes, pWrk2, pSync);
     shmem_longlong_xor_to_all(dst6, src6, N, 0, 0, npes, pWrk6, pSync1);
-    
+
     if (me==0) {
       for (i = 0; i < N; i++) {
           if(dst0[i] != expected_result) ok[0] = 1;


### PR DESCRIPTION
Remote hard tabs, trailing whitespace, and cleanup formatting across all sources except transport_ofi.[ch] (because of code delta with contexts branch).

Excluding whitespace, here's the diff:
```
diff --git a/src/shmem_comm.h b/src/shmem_comm.h
index be24a30c..8bb4e04c 100644
--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -206,7 +206,8 @@ shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t
 static inline
 void
 shmem_internal_atomic_small(void *target, const void *source, size_t len,
-			   int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                            int pe, shm_internal_op_t op,
+                            shm_internal_datatype_t datatype)
 {
     shmem_transport_atomic_small(target, source, len, pe, op, datatype);
 }
@@ -233,8 +234,8 @@ shmem_internal_atomic_set(void *target, const void *source, size_t len,
 static inline
 void
 shmem_internal_atomic_nb(void *target, const void *source, size_t len,
-	              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype,
-                      long *completion)
+                         int pe, shm_internal_op_t op,
+                         shm_internal_datatype_t datatype, long *completion)
 {
     shmem_transport_atomic_nb(target, source, len, pe, op, datatype, completion);
 }
@@ -244,7 +245,8 @@ shmem_internal_atomic_nb(void *target, const void *source, size_t len,
 static inline
 void
 shmem_internal_fetch_atomic(void *target, void *source, void *dest, size_t len,
-			    int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                            int pe, shm_internal_op_t op,
+                            shm_internal_datatype_t datatype)
 {
     shmem_transport_fetch_atomic(target, source, dest, len, pe, op, datatype);
 }
diff --git a/test/performance/tests/shmemlatency.c b/test/performance/tests/shmemlatency.c
index 15ebc5eb..a2cd3998 100644
--- a/test/performance/tests/shmemlatency.c
+++ b/test/performance/tests/shmemlatency.c
@@ -62,7 +62,6 @@ main(int argc, char *argv[])
 
     extern char *optarg;
     int ch, error;
-	
     int len, start_len, end_len, increment, inc, trials, i;
     int mega;
     double latency, bandwidth;
diff --git a/test/unit/big_reduction.c b/test/unit/big_reduction.c
index db7cf0af..51fd5ccd 100644
--- a/test/unit/big_reduction.c
+++ b/test/unit/big_reduction.c
@@ -88,7 +88,7 @@ main(int argc, char* argv[])
     shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
 
     if (Verbose) {
-        printf("%d/%d	dst =", shmem_my_pe(), shmem_n_pes() );
+        printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );
         for (i = 0; i < N; i+= 1) {
             printf(" %ld", dst[i]);
         }
diff --git a/test/unit/max_reduction.c b/test/unit/max_reduction.c
index 98add002..b5008073 100644
--- a/test/unit/max_reduction.c
+++ b/test/unit/max_reduction.c
@@ -86,7 +86,7 @@ main(int argc, char* argv[])
     shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
 
     if (Verbose) {
-        printf("%d/%d	dst =", shmem_my_pe(), shmem_n_pes() );
+        printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );
         for (i = 0; i < N; i+= 1) {
             printf(" %ld", dst[i]);
         }
diff --git a/test/unit/micro_unit_shmem.c b/test/unit/micro_unit_shmem.c
index 3088b7aa..2dd1d8d5 100644
--- a/test/unit/micro_unit_shmem.c
+++ b/test/unit/micro_unit_shmem.c
@@ -2,7 +2,7 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
+ *      Redistribution and use in source and binary forms, with or
  *      without modification, are permitted provided that the following
  *      conditions are met:
  *
diff --git a/test/unit/ns.c b/test/unit/ns.c
index cf67b666..a3548193 100644
--- a/test/unit/ns.c
+++ b/test/unit/ns.c
@@ -95,8 +95,7 @@ main(int argc, char *argv[])
         }
     }
 
-    for(l=0; l < laps; l++) {
-
+    for (l=0; l < laps; l++) {
         target = (long *) shmem_malloc(sizeof (*target));
         if (!target) {
             fprintf(stderr,"[%d] shmem_malloc() failed?\n",me);
diff --git a/test/unit/pi.c b/test/unit/pi.c
index 7525d0a7..a6a05278 100644
--- a/test/unit/pi.c
+++ b/test/unit/pi.c
@@ -2,7 +2,7 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
+ *      Redistribution and use in source and binary forms, with or
  *      without modification, are permitted provided that the following
  *      conditions are met:
  *
diff --git a/test/unit/rma_coverage.c b/test/unit/rma_coverage.c
index edcebde5..a6913837 100644
--- a/test/unit/rma_coverage.c
+++ b/test/unit/rma_coverage.c
@@ -2,7 +2,7 @@
  *  Copyright (c) 2015 Intel Corporation. All rights reserved.
  *  This software is available to you under the BSD license below:
  *
- * *	Redistribution and use in source and binary forms, with or
+ *      Redistribution and use in source and binary forms, with or
  *      without modification, are permitted provided that the following
  *      conditions are met:
  *
```