### PR TITLE
Whitespace update to OFI transport

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -43,21 +43,21 @@ struct fabric_info {
     int npes;
 };
 
-struct fid_fabric*          	shmem_transport_ofi_fabfd;
-struct fid_domain*          	shmem_transport_ofi_domainfd;
-struct fid_ep*			shmem_transport_ofi_epfd;
-struct fid_ep*			shmem_transport_ofi_cntr_epfd;
-struct fid_stx*  		shmem_transport_ofi_stx;
-struct fid_av*             	shmem_transport_ofi_avfd;
-struct fid_cq*              	shmem_transport_ofi_put_nb_cqfd;
+struct fid_fabric*              shmem_transport_ofi_fabfd;
+struct fid_domain*              shmem_transport_ofi_domainfd;
+struct fid_ep*                  shmem_transport_ofi_epfd;
+struct fid_ep*                  shmem_transport_ofi_cntr_epfd;
+struct fid_stx*                 shmem_transport_ofi_stx;
+struct fid_av*                  shmem_transport_ofi_avfd;
+struct fid_cq*                  shmem_transport_ofi_put_nb_cqfd;
 #ifndef ENABLE_HARD_POLLING
-struct fid_cntr*            	shmem_transport_ofi_target_cntrfd;
+struct fid_cntr*                shmem_transport_ofi_target_cntrfd;
 #endif
-struct fid_cntr*            	shmem_transport_ofi_put_cntrfd;
-struct fid_cntr*            	shmem_transport_ofi_get_cntrfd;
+struct fid_cntr*                shmem_transport_ofi_put_cntrfd;
+struct fid_cntr*                shmem_transport_ofi_get_cntrfd;
 #ifdef ENABLE_MR_SCALABLE
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-struct fid_mr*              	shmem_transport_ofi_target_mrfd;
+struct fid_mr*                  shmem_transport_ofi_target_mrfd;
 #else  /* !ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
@@ -72,18 +72,18 @@ uint8_t**                       shmem_transport_ofi_target_heap_addrs;
 uint8_t**                       shmem_transport_ofi_target_data_addrs;
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 #endif /* ENABLE_MR_SCALABLE */
-uint64_t	          	shmem_transport_ofi_pending_put_counter;
-uint64_t        	 	shmem_transport_ofi_pending_get_counter;
-uint64_t			shmem_transport_ofi_pending_cq_count;
-uint64_t			shmem_transport_ofi_max_poll;
-size_t           		shmem_transport_ofi_max_buffered_send;
-size_t    			shmem_transport_ofi_max_msg_size;
-size_t    			shmem_transport_ofi_bounce_buffer_size;
-size_t    			shmem_transport_ofi_addrlen;
-fi_addr_t			*addr_table;
+uint64_t                        shmem_transport_ofi_pending_put_counter;
+uint64_t                        shmem_transport_ofi_pending_get_counter;
+uint64_t                        shmem_transport_ofi_pending_cq_count;
+uint64_t                        shmem_transport_ofi_max_poll;
+size_t                          shmem_transport_ofi_max_buffered_send;
+size_t                          shmem_transport_ofi_max_msg_size;
+size_t                          shmem_transport_ofi_bounce_buffer_size;
+size_t                          shmem_transport_ofi_addrlen;
+fi_addr_t                       *addr_table;
 #ifdef USE_ON_NODE_COMMS
 #define EPHOSTNAMELEN  _POSIX_HOST_NAME_MAX + 1
-static char         myephostname[EPHOSTNAMELEN];
+static char                     myephostname[EPHOSTNAMELEN];
 #endif
 
 size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
@@ -93,55 +93,55 @@ static char * SHMEM_OpName[FI_ATOMIC_OP_LAST];
 
 static inline void init_ofi_tables(void)
 {
-  SHMEM_Dtsize[FI_INT8]                = sizeof(int8_t);
-  SHMEM_Dtsize[FI_UINT8]               = sizeof(uint8_t);
-  SHMEM_Dtsize[FI_INT16]               = sizeof(int16_t);
-  SHMEM_Dtsize[FI_UINT16]              = sizeof(uint16_t);
-  SHMEM_Dtsize[FI_INT32]               = sizeof(int32_t);
-  SHMEM_Dtsize[FI_UINT32]              = sizeof(uint32_t);
-  SHMEM_Dtsize[FI_INT64]               = sizeof(int64_t);
-  SHMEM_Dtsize[FI_UINT64]              = sizeof(uint64_t);
-  SHMEM_Dtsize[FI_FLOAT]               = sizeof(float);
-  SHMEM_Dtsize[FI_DOUBLE]              = sizeof(double);
-  SHMEM_Dtsize[FI_FLOAT_COMPLEX]       = sizeof(float complex);
-  SHMEM_Dtsize[FI_DOUBLE_COMPLEX]      = sizeof(double complex);
-  SHMEM_Dtsize[FI_LONG_DOUBLE]         = sizeof(long double);
-  SHMEM_Dtsize[FI_LONG_DOUBLE_COMPLEX] = sizeof(long double complex);
+    SHMEM_Dtsize[FI_INT8]                = sizeof(int8_t);
+    SHMEM_Dtsize[FI_UINT8]               = sizeof(uint8_t);
+    SHMEM_Dtsize[FI_INT16]               = sizeof(int16_t);
+    SHMEM_Dtsize[FI_UINT16]              = sizeof(uint16_t);
+    SHMEM_Dtsize[FI_INT32]               = sizeof(int32_t);
+    SHMEM_Dtsize[FI_UINT32]              = sizeof(uint32_t);
+    SHMEM_Dtsize[FI_INT64]               = sizeof(int64_t);
+    SHMEM_Dtsize[FI_UINT64]              = sizeof(uint64_t);
+    SHMEM_Dtsize[FI_FLOAT]               = sizeof(float);
+    SHMEM_Dtsize[FI_DOUBLE]              = sizeof(double);
+    SHMEM_Dtsize[FI_FLOAT_COMPLEX]       = sizeof(float complex);
+    SHMEM_Dtsize[FI_DOUBLE_COMPLEX]      = sizeof(double complex);
+    SHMEM_Dtsize[FI_LONG_DOUBLE]         = sizeof(long double);
+    SHMEM_Dtsize[FI_LONG_DOUBLE_COMPLEX] = sizeof(long double complex);
 
-  SHMEM_DtName[FI_INT8]                = "int8";
-  SHMEM_DtName[FI_UINT8]               = "uint8";
-  SHMEM_DtName[FI_INT16]               = "int16";
-  SHMEM_DtName[FI_UINT16]              = "uint16";
-  SHMEM_DtName[FI_INT32]               = "int32";
-  SHMEM_DtName[FI_UINT32]              = "uint32";
-  SHMEM_DtName[FI_INT64]               = "int64";
-  SHMEM_DtName[FI_UINT64]              = "uint64";
-  SHMEM_DtName[FI_FLOAT]               = "float";
-  SHMEM_DtName[FI_DOUBLE]              = "double";
-  SHMEM_DtName[FI_FLOAT_COMPLEX]       = "float complex";
-  SHMEM_DtName[FI_DOUBLE_COMPLEX]      = "double complex";
-  SHMEM_DtName[FI_LONG_DOUBLE]         = "long double";
-  SHMEM_DtName[FI_LONG_DOUBLE_COMPLEX] = "long double complex";
+    SHMEM_DtName[FI_INT8]                = "int8";
+    SHMEM_DtName[FI_UINT8]               = "uint8";
+    SHMEM_DtName[FI_INT16]               = "int16";
+    SHMEM_DtName[FI_UINT16]              = "uint16";
+    SHMEM_DtName[FI_INT32]               = "int32";
+    SHMEM_DtName[FI_UINT32]              = "uint32";
+    SHMEM_DtName[FI_INT64]               = "int64";
+    SHMEM_DtName[FI_UINT64]              = "uint64";
+    SHMEM_DtName[FI_FLOAT]               = "float";
+    SHMEM_DtName[FI_DOUBLE]              = "double";
+    SHMEM_DtName[FI_FLOAT_COMPLEX]       = "float complex";
+    SHMEM_DtName[FI_DOUBLE_COMPLEX]      = "double complex";
+    SHMEM_DtName[FI_LONG_DOUBLE]         = "long double";
+    SHMEM_DtName[FI_LONG_DOUBLE_COMPLEX] = "long double complex";
 
-  SHMEM_OpName[FI_MIN]                 = "MIN";
-  SHMEM_OpName[FI_MAX]                 = "MAX";
-  SHMEM_OpName[FI_SUM]                 = "SUM";
-  SHMEM_OpName[FI_PROD]                = "PROD";
-  SHMEM_OpName[FI_LOR]                 = "LOR";
-  SHMEM_OpName[FI_LAND]                = "LAND";
-  SHMEM_OpName[FI_BOR]                 = "BOR";
-  SHMEM_OpName[FI_BAND]                = "BAND";
-  SHMEM_OpName[FI_LXOR]                = "LXOR";
-  SHMEM_OpName[FI_BXOR]                = "BXOR";
-  SHMEM_OpName[FI_ATOMIC_READ]         = "ATOMIC_WRITE";
-  SHMEM_OpName[FI_ATOMIC_WRITE]        = "ATOMIC_READ";
-  SHMEM_OpName[FI_CSWAP]               = "CSWAP";
-  SHMEM_OpName[FI_CSWAP_NE]            = "CSWAP_NE";
-  SHMEM_OpName[FI_CSWAP_LE]            = "CSWAP_LE";
-  SHMEM_OpName[FI_CSWAP_LT]            = "CSWAP_LT";
-  SHMEM_OpName[FI_CSWAP_GE]            = "CSWAP_GE";
-  SHMEM_OpName[FI_CSWAP_GT]            = "CSWAP_GT";
-  SHMEM_OpName[FI_MSWAP]               = "MSWAP";
+    SHMEM_OpName[FI_MIN]                 = "MIN";
+    SHMEM_OpName[FI_MAX]                 = "MAX";
+    SHMEM_OpName[FI_SUM]                 = "SUM";
+    SHMEM_OpName[FI_PROD]                = "PROD";
+    SHMEM_OpName[FI_LOR]                 = "LOR";
+    SHMEM_OpName[FI_LAND]                = "LAND";
+    SHMEM_OpName[FI_BOR]                 = "BOR";
+    SHMEM_OpName[FI_BAND]                = "BAND";
+    SHMEM_OpName[FI_LXOR]                = "LXOR";
+    SHMEM_OpName[FI_BXOR]                = "BXOR";
+    SHMEM_OpName[FI_ATOMIC_READ]         = "ATOMIC_WRITE";
+    SHMEM_OpName[FI_ATOMIC_WRITE]        = "ATOMIC_READ";
+    SHMEM_OpName[FI_CSWAP]               = "CSWAP";
+    SHMEM_OpName[FI_CSWAP_NE]            = "CSWAP_NE";
+    SHMEM_OpName[FI_CSWAP_LE]            = "CSWAP_LE";
+    SHMEM_OpName[FI_CSWAP_LT]            = "CSWAP_LT";
+    SHMEM_OpName[FI_CSWAP_GE]            = "CSWAP_GE";
+    SHMEM_OpName[FI_CSWAP_GT]            = "CSWAP_GT";
+    SHMEM_OpName[FI_MSWAP]               = "MSWAP";
 }
 
 /* Cover OpenSHMEM atomics API */
@@ -149,23 +149,23 @@ static inline void init_ofi_tables(void)
 #define SIZEOF_AMO_DT 5
 static int DT_AMO_STANDARD[]=
 {
-  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
-  SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
+    SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
+    SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
 };
 #define SIZEOF_AMO_OPS 1
 static int AMO_STANDARD_OPS[]=
 {
-  SHM_INTERNAL_SUM
+    SHM_INTERNAL_SUM
 };
 #define SIZEOF_AMO_FOPS 1
 static int FETCH_AMO_STANDARD_OPS[]=
 {
-  SHM_INTERNAL_SUM
+    SHM_INTERNAL_SUM
 };
 #define SIZEOF_AMO_COPS 1
 static int COMPARE_AMO_STANDARD_OPS[]=
 {
-  FI_CSWAP
+    FI_CSWAP
 };
 
 /* Note: Fortran-specific types should be last so they can be disabled here */
@@ -176,19 +176,19 @@ static int COMPARE_AMO_STANDARD_OPS[]=
 #endif
 static int DT_AMO_EXTENDED[]=
 {
-  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
-  SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64,
-  SHM_INTERNAL_FORTRAN_INTEGER
+    SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
+    SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64,
+    SHM_INTERNAL_FORTRAN_INTEGER
 };
 #define SIZEOF_AMO_EX_OPS 1
 static int AMO_EXTENDED_OPS[]=
 {
-  FI_ATOMIC_WRITE
+    FI_ATOMIC_WRITE
 };
 #define SIZEOF_AMO_EX_FOPS 2
 static int FETCH_AMO_EXTENDED_OPS[]=
 {
-  FI_ATOMIC_WRITE, FI_ATOMIC_READ
+    FI_ATOMIC_WRITE, FI_ATOMIC_READ
 };
 
 
@@ -197,55 +197,55 @@ static int FETCH_AMO_EXTENDED_OPS[]=
 #define SIZEOF_RED_DT 6
 static int DT_REDUCE_BITWISE[]=
 {
-  SHM_INTERNAL_SHORT, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
-  SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
+    SHM_INTERNAL_SHORT, SHM_INTERNAL_INT, SHM_INTERNAL_LONG,
+    SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32, SHM_INTERNAL_INT64
 };
 #define SIZEOF_RED_OPS 3
 static int REDUCE_BITWISE_OPS[]=
 {
-  SHM_INTERNAL_BAND, SHM_INTERNAL_BOR, SHM_INTERNAL_BXOR
+    SHM_INTERNAL_BAND, SHM_INTERNAL_BOR, SHM_INTERNAL_BXOR
 };
 
 
 #define SIZEOF_REDC_DT 9
 static int DT_REDUCE_COMPARE[]=
 {
-  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_SHORT,
-  SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
-  SHM_INTERNAL_INT32, SHM_INTERNAL_INT64, SHM_INTERNAL_LONG_DOUBLE
+    SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_SHORT,
+    SHM_INTERNAL_INT, SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG,
+    SHM_INTERNAL_INT32, SHM_INTERNAL_INT64, SHM_INTERNAL_LONG_DOUBLE
 };
 #define SIZEOF_REDC_OPS 2
 static int REDUCE_COMPARE_OPS[]=
 {
-  SHM_INTERNAL_MAX, SHM_INTERNAL_MIN
+    SHM_INTERNAL_MAX, SHM_INTERNAL_MIN
 };
 
 
 #define SIZEOF_REDA_DT 11
 static int DT_REDUCE_ARITH[]=
 {
-  SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_FLOAT_COMPLEX,
-  SHM_INTERNAL_DOUBLE_COMPLEX, SHM_INTERNAL_SHORT, SHM_INTERNAL_INT,
-  SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32,
-  SHM_INTERNAL_INT64, SHM_INTERNAL_LONG_DOUBLE
+    SHM_INTERNAL_FLOAT, SHM_INTERNAL_DOUBLE, SHM_INTERNAL_FLOAT_COMPLEX,
+    SHM_INTERNAL_DOUBLE_COMPLEX, SHM_INTERNAL_SHORT, SHM_INTERNAL_INT,
+    SHM_INTERNAL_LONG, SHM_INTERNAL_LONG_LONG, SHM_INTERNAL_INT32,
+    SHM_INTERNAL_INT64, SHM_INTERNAL_LONG_DOUBLE
 };
 #define SIZEOF_REDA_OPS 2
 static int REDUCE_ARITH_OPS[]=
 {
-  SHM_INTERNAL_SUM, SHM_INTERNAL_PROD
+    SHM_INTERNAL_SUM, SHM_INTERNAL_PROD
 };
 
 /* Internal to SHMEM implementation atomic requirement */
-/*Locking implementation requirement */
+/* Locking implementation requirement */
 #define SIZEOF_INTERNAL_REQ_DT 1
 static int DT_INTERNAL_REQ[]=
 {
-  SHM_INTERNAL_INT
+    SHM_INTERNAL_INT
 };
 #define SIZEOF_INTERNAL_REQ_OPS 1
 static int INTERNAL_REQ_OPS[]=
 {
-  FI_MSWAP
+    FI_MSWAP
 };
 
 typedef enum{
@@ -257,30 +257,30 @@ typedef enum{
 
 shmem_free_list_t *shmem_transport_ofi_bounce_buffers = NULL;
 
-//size of CQ
-const static size_t shmem_transport_ofi_queue_slots = 32768;//default CQ Depth....
+/* default CQ depth */
+const static size_t shmem_transport_ofi_queue_slots = 32768;
 uint64_t shmem_transport_ofi_max_poll = (1ULL<<30);
 
 #define OFI_MAJOR_VERSION 1
 #define OFI_MINOR_VERSION 0
 
 static
-void
-init_bounce_buffer(shmem_free_list_item_t *item)
+void init_bounce_buffer(shmem_free_list_item_t *item)
 {
     shmem_transport_ofi_frag_t *frag =
         (shmem_transport_ofi_frag_t*) item;
     frag->mytype = SHMEM_TRANSPORT_OFI_TYPE_BOUNCE;
 }
 
-static inline int allocate_endpoints(struct fabric_info *info)
+static inline
+int allocate_endpoints(struct fabric_info *info)
 {
 
-  int ret = 0;
+    int ret = 0;
 
-    /* ------------------------------------*/
-    /* 		Allocate Endpoints	   */
-    /* ------------------------------------*/
+    /* ------------------------------------ */
+    /*         Allocate Endpoints           */
+    /* ------------------------------------ */
 
     /* this endpoint is used to get completion events and
      * used to expose memory to incoming reads/writes */
@@ -288,14 +288,14 @@ static inline int allocate_endpoints(struct fabric_info *info)
     info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_epfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("epfd creation failed");
         return ret;
     }
 
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_cntr_epfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("cntr_epfd creation failed");
         return ret;
     }
@@ -304,80 +304,85 @@ static inline int allocate_endpoints(struct fabric_info *info)
 
 }
 
-static inline int bind_resources_to_and_enable_ep(void)
+static inline
+int bind_resources_to_and_enable_ep(void)
 {
-
-    /*   must bind resources created to EP then enable EP for communication (resources can now be used) */
+    /* must bind resources created to EP then enable EP for communication
+     * (resources can now be used) */
 
     int ret = 0;
 
     /* attach the endpoints to the shared context */
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
-		    &shmem_transport_ofi_stx->fid, 0);
-    if(ret!=0){
+                     &shmem_transport_ofi_stx->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind epfd2stx failed");
         return ret;
     }
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_stx->fid, 0);
-    if(ret!=0){
+                     &shmem_transport_ofi_stx->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2stx failed");
         return ret;
     }
 
-    /* attaching to endpoint enables counting "writes" for calls used with this endpoint*/
+    /* attaching to endpoint enables counting "writes" for calls used with this
+     * endpoint */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_put_cntrfd->fid, FI_WRITE);
-    if(ret!=0){
+                     &shmem_transport_ofi_put_cntrfd->fid, FI_WRITE);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
 
     /* attach to endpoint */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_get_cntrfd->fid, FI_READ);
-    if(ret!=0){
+                     &shmem_transport_ofi_get_cntrfd->fid, FI_READ);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2get_cntr failed");
         return ret;
     }
 
     /* attach CQ for obtaining completions for large puts (NB puts) */
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
-		    &shmem_transport_ofi_put_nb_cqfd->fid, FI_SEND);
-    if(ret!=0){
+                     &shmem_transport_ofi_put_nb_cqfd->fid, FI_SEND);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind ep2cq_nb failed");
         return ret;
     }
 
     /* attach CQ for error handling on cntr EP */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_put_nb_cqfd->fid, FI_SELECTIVE_COMPLETION | FI_TRANSMIT);
-    if(ret!=0){
+                     &shmem_transport_ofi_put_nb_cqfd->fid,
+                     FI_SELECTIVE_COMPLETION | FI_TRANSMIT);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntrep2cq_nb failed");
         return ret;
     }
 
-    ret = fi_ep_bind(shmem_transport_ofi_epfd, &shmem_transport_ofi_avfd->fid, 0);
-    if(ret!=0){
+    ret = fi_ep_bind(shmem_transport_ofi_epfd,
+                     &shmem_transport_ofi_avfd->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind ep2av failed");
         return ret;
     }
 
-    ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd, &shmem_transport_ofi_avfd->fid, 0);
-    if(ret!=0){
+    ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
+                     &shmem_transport_ofi_avfd->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_ep2av failed");
         return ret;
     }
 
-    /*enable active endpoint state: can now perform data transfers*/
+    /* enable active endpoint state: can now perform data transfers */
     ret = fi_enable(shmem_transport_ofi_epfd);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("enable_epfd failed");
         return ret;
     }
     ret = fi_enable(shmem_transport_ofi_cntr_epfd);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("enable_cntr_epfd failed");
         return ret;
     }
@@ -385,7 +390,8 @@ static inline int bind_resources_to_and_enable_ep(void)
     return ret;
 }
 
-static inline int allocate_cntr_and_cq(void)
+static inline
+int allocate_cntr_and_cq(void)
 {
 
     int ret = 0;
@@ -399,35 +405,35 @@ static inline int allocate_cntr_and_cq(void)
     cntr_attr.wait_obj = FI_WAIT_UNSPEC;
 #endif
 
-    /* -------------------------------------------------------*/
-    /* Define Completion tracking Resources to Attach to EP   */
-    /* -------------------------------------------------------*/
+    /* ------------------------------------------------------- */
+    /* Define Completion tracking Resources to Attach to EP    */
+    /* ------------------------------------------------------- */
 
-    // Create counter for counting completions of outgoing writes
+    /* Create counter for counting completions of outgoing writes */
 
     ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
-		  &shmem_transport_ofi_put_cntrfd, NULL);
-    if(ret!=0){
+                       &shmem_transport_ofi_put_cntrfd, NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("put cntr_open failed");
         return ret;
     }
 
-    // Create counter for counting completions of outbound reads
+    /* Create counter for counting completions of outbound reads */
 
     ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
-		  &shmem_transport_ofi_get_cntrfd, NULL);
-    if(ret!=0){
+                       &shmem_transport_ofi_get_cntrfd, NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("get cntr_open failed");
         return ret;
     }
 
-    /* Create CQ to be used for NB puts */
-    cq_attr.format    = FI_CQ_FORMAT_CONTEXT;//event type for CQ,only context stored/reported
-    cq_attr.size      =	shmem_transport_ofi_queue_slots;
+    /* Create CQ to be used for NB puts, only context reported */
+    cq_attr.format    = FI_CQ_FORMAT_CONTEXT;
+    cq_attr.size      = shmem_transport_ofi_queue_slots;
 
     ret = fi_cq_open(shmem_transport_ofi_domainfd, &cq_attr,
-		    &shmem_transport_ofi_put_nb_cqfd, NULL);
-    if(ret!=0){
+                     &shmem_transport_ofi_put_nb_cqfd, NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("cq_open failed");
         return ret;
     }
@@ -436,28 +442,31 @@ static inline int allocate_cntr_and_cq(void)
 
 }
 
-static inline int allocate_recv_cntr_mr(void)
+static inline
+int allocate_recv_cntr_mr(void)
 {
 
     int ret = 0;
 
-    /* ------------------------------------*/
-    /* POST enable resources for to EP     */
-    /* ------------------------------------*/
-    /* since this is AFTER enable and RMA you must create memory regions for incoming reads/writes
-     * and outgoing non-blocking Puts, specifying entire VA range */
+    /* ------------------------------------ */
+    /* POST enable resources for to EP      */
+    /* ------------------------------------ */
+
+    /* since this is AFTER enable and RMA you must create memory regions for
+     * incoming reads/writes and outgoing non-blocking Puts, specifying entire
+     * VA range */
 
 #ifndef ENABLE_HARD_POLLING
     {
         struct fi_cntr_attr cntr_attr = {0};
 
-        // Create counter for incoming writes
+        /* Create counter for incoming writes */
         cntr_attr.events   = FI_CNTR_EVENTS_COMP;
         cntr_attr.wait_obj = FI_WAIT_UNSPEC;
 
         ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
                            &shmem_transport_ofi_target_cntrfd, NULL);
-        if(ret!=0){
+        if (ret!=0) {
             RAISE_WARN_STR("target cntr_open failed");
             return ret;
         }
@@ -466,26 +475,26 @@ static inline int allocate_recv_cntr_mr(void)
 
 #if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, 0, UINT64_MAX,
-		    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0ULL, 0,
-		    &shmem_transport_ofi_target_mrfd, NULL);
-    if(ret!=0){
+                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0ULL, 0,
+                    &shmem_transport_ofi_target_mrfd, NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("mr_reg failed");
         return ret;
     }
 
-    // Bind counter with target memory region for incoming messages
+    /* Bind counter with target memory region for incoming messages */
 #ifndef ENABLE_HARD_POLLING
     ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
                      &shmem_transport_ofi_target_cntrfd->fid,
                      FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("mr_bind failed");
         return ret;
     }
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+                     &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
@@ -530,8 +539,8 @@ static inline int allocate_recv_cntr_mr(void)
     }
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+                     &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
@@ -541,7 +550,8 @@ static inline int allocate_recv_cntr_mr(void)
     return ret;
 }
 
-static int publish_mr_info(void)
+static
+int publish_mr_info(void)
 {
 #ifndef ENABLE_MR_SCALABLE
     {
@@ -585,7 +595,8 @@ static int publish_mr_info(void)
     return 0;
 }
 
-static int populate_mr_tables(void)
+static
+int populate_mr_tables(void)
 {
 #ifndef ENABLE_MR_SCALABLE
     {
@@ -662,20 +673,21 @@ static int populate_mr_tables(void)
     return 0;
 }
 
-/*SOFT_SUPPORT will not produce warning or error */
-static inline int atomicvalid_rtncheck(int ret, int atomic_size,
-                                    atomic_support_lv atomic_sup,
-                                    char strOP[], char strDT[])
+/* SOFT_SUPPORT will not produce warning or error */
+static inline
+int atomicvalid_rtncheck(int ret, int atomic_size,
+                         atomic_support_lv atomic_sup,
+                         char strOP[], char strDT[])
 {
-    if((ret != 0 || atomic_size == 0) && atomic_sup != ATOMIC_SOFT_SUPPORT) {
-        if(atomic_sup == ATOMIC_WARNINGS) {
+    if ((ret != 0 || atomic_size == 0) && atomic_sup != ATOMIC_SOFT_SUPPORT) {
+        if (atomic_sup == ATOMIC_WARNINGS) {
             fprintf(stderr, "Warning OFI detected no support for atomic '%s' "
-               "on type '%s'\n", strOP, strDT);
+                    "on type '%s'\n", strOP, strDT);
         }
-        else if(atomic_sup == ATOMIC_NO_SUPPORT) {
+        else if (atomic_sup == ATOMIC_NO_SUPPORT) {
             RAISE_WARN_MSG("Error: atomicvalid ret=%d atomic_size=%d\n",
-                       ret, atomic_size);
-	        return ret;
+                           ret, atomic_size);
+            return ret;
         } else {
             RAISE_ERROR_STR("Error: invalid software atomic support request");
         }
@@ -684,149 +696,152 @@ static inline int atomicvalid_rtncheck(int ret, int atomic_size,
     return 0;
 }
 
-static inline int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
-                                    int OPS[], atomic_support_lv atomic_sup)
+static inline
+int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[], int OPS[],
+                      atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
     size_t atomic_size;
 
     for(i=0; i<DT_MAX; i++) {
-      for(j=0; j<OPS_MAX; j++) {
-        ret = fi_atomicvalid(shmem_transport_ofi_epfd, DT[i],
-                        OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
-                            SHMEM_OpName[OPS[j]],
-                            SHMEM_DtName[DT[i]]))
-           return ret;
-      }
+        for(j=0; j<OPS_MAX; j++) {
+            ret = fi_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                                 OPS[j], &atomic_size);
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+                                     SHMEM_OpName[OPS[j]],
+                                     SHMEM_DtName[DT[i]]))
+                return ret;
+        }
     }
 
     return 0;
 }
 
-static inline int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
-                                    int OPS[], atomic_support_lv atomic_sup)
+static inline
+int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
+                              int OPS[], atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
     size_t atomic_size;
 
     for(i=0; i<DT_MAX; i++) {
-      for(j=0; j<OPS_MAX; j++) {
-        ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, DT[i],
-                        OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
-                            SHMEM_OpName[OPS[j]],
-                            SHMEM_DtName[DT[i]]))
-           return ret;
-      }
+        for(j=0; j<OPS_MAX; j++) {
+            ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                                         OPS[j], &atomic_size);
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+                                     SHMEM_OpName[OPS[j]],
+                                     SHMEM_DtName[DT[i]]))
+                return ret;
+        }
     }
 
     return 0;
 }
 
-static inline int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
-                                    int OPS[], atomic_support_lv atomic_sup)
+static inline
+int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[], int OPS[],
+                            atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
     size_t atomic_size;
 
     for(i=0; i<DT_MAX; i++) {
-      for(j=0; j<OPS_MAX; j++) {
-        ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, DT[i],
-                        OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
-                            SHMEM_OpName[OPS[j]],
-                            SHMEM_DtName[DT[i]]))
-           return ret;
-      }
+        for(j=0; j<OPS_MAX; j++) {
+            ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, DT[i],
+                                       OPS[j], &atomic_size);
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+                                     SHMEM_OpName[OPS[j]],
+                                     SHMEM_DtName[DT[i]]))
+                return ret;
+        }
     }
 
     return 0;
 }
-static inline int atomic_limitations_check(void)
-{
 
-    /* ----------------------------------------*/
-    /* Retrieve messaging limitations from OFI */
-    /*          NOTE:                          */
-    /*   currently only have reduction software*/
-    /*   atomic support, user can optionally   */
-    /*   request for warnings if other atomic  */
-    /*   limitations are detected              */
-    /* ----------------------------------------*/
+static inline
+int atomic_limitations_check(void)
+{
+    /* Retrieve messaging limitations from OFI
+     *
+     * NOTE: Currently only have reduction software atomic support. User can
+     * optionally request for warnings if other atomic limitations are detected
+     */
 
     int ret = 0;
     atomic_support_lv general_atomic_sup = ATOMIC_NO_SUPPORT;
     atomic_support_lv reduction_sup = ATOMIC_SOFT_SUPPORT;
 
-    if(NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
+    if (NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
         general_atomic_sup = ATOMIC_WARNINGS;
 
     init_ofi_tables();
 
     /* Standard OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_OPS, DT_AMO_STANDARD,
-                      AMO_STANDARD_OPS, general_atomic_sup);
-    if(ret)
+                            AMO_STANDARD_OPS, general_atomic_sup);
+    if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_FOPS,
-                    DT_AMO_STANDARD, FETCH_AMO_STANDARD_OPS,
-                    general_atomic_sup);
-    if(ret)
+                                  DT_AMO_STANDARD, FETCH_AMO_STANDARD_OPS,
+                                  general_atomic_sup);
+    if (ret)
         return ret;
 
     ret = compare_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_COPS,
-                    DT_AMO_STANDARD, COMPARE_AMO_STANDARD_OPS,
-                    general_atomic_sup);
-    if(ret)
+                                    DT_AMO_STANDARD, COMPARE_AMO_STANDARD_OPS,
+                                    general_atomic_sup);
+    if (ret)
         return ret;
 
     /* Extended OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_OPS, DT_AMO_EXTENDED,
-                      AMO_EXTENDED_OPS, general_atomic_sup);
-    if(ret)
+                            AMO_EXTENDED_OPS, general_atomic_sup);
+    if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_FOPS,
-                    DT_AMO_EXTENDED, FETCH_AMO_EXTENDED_OPS,
-                    general_atomic_sup);
-    if(ret)
+                                  DT_AMO_EXTENDED, FETCH_AMO_EXTENDED_OPS,
+                                  general_atomic_sup);
+    if (ret)
         return ret;
 
     /* Reduction OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_RED_DT, SIZEOF_RED_OPS, DT_REDUCE_BITWISE,
-                      REDUCE_BITWISE_OPS, reduction_sup);
-    if(ret)
+                            REDUCE_BITWISE_OPS, reduction_sup);
+    if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDC_DT, SIZEOF_REDC_OPS, DT_REDUCE_COMPARE,
-                      REDUCE_COMPARE_OPS, reduction_sup);
-    if(ret)
+                            REDUCE_COMPARE_OPS, reduction_sup);
+    if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDA_DT, SIZEOF_REDA_OPS, DT_REDUCE_ARITH,
-                      REDUCE_ARITH_OPS, reduction_sup);
-    if(ret)
+                            REDUCE_ARITH_OPS, reduction_sup);
+    if (ret)
         return ret;
 
     /* Internal atomic requirement */
     ret = compare_atomicvalid_DTxOP(SIZEOF_INTERNAL_REQ_DT, SIZEOF_INTERNAL_REQ_OPS,
-                    DT_INTERNAL_REQ, INTERNAL_REQ_OPS, general_atomic_sup);
-    if(ret)
+                                    DT_INTERNAL_REQ, INTERNAL_REQ_OPS,
+                                    general_atomic_sup);
+    if (ret)
         return ret;
 
     return 0;
 }
 
-static inline int publish_av_info(struct fabric_info *info)
+static inline
+int publish_av_info(struct fabric_info *info)
 {
     int    ret = 0;
     char   epname[128];
     size_t epnamelen = sizeof(epname);
 
 #ifdef USE_ON_NODE_COMMS
-    if(gethostname(myephostname, (EPHOSTNAMELEN - 1)) != 0)
+    if (gethostname(myephostname, (EPHOSTNAMELEN - 1)) != 0)
         RAISE_ERROR_MSG("gethostname error: %s \n", strerror(errno));
 
     myephostname[EPHOSTNAMELEN-1] = '\0';
@@ -839,7 +854,7 @@ static inline int publish_av_info(struct fabric_info *info)
 #endif
 
     ret = fi_getname((fid_t)shmem_transport_ofi_epfd, epname, &epnamelen);
-    if(ret!=0 || (epnamelen > sizeof(epname))){
+    if (ret!=0 || (epnamelen > sizeof(epname))) {
         RAISE_WARN_STR("fi_getname failed");
         return ret;
     }
@@ -858,7 +873,8 @@ static inline int publish_av_info(struct fabric_info *info)
     return ret;
 }
 
-static inline int populate_av(void)
+static inline
+int populate_av(void)
 {
     int    i, ret = 0;
     char   *alladdrs = NULL;
@@ -879,7 +895,7 @@ static inline int populate_av(void)
 
 #ifdef USE_ON_NODE_COMMS
         shmem_runtime_get(i, "fi_ephostname", ephostname, EPHOSTNAMELEN);
-        if(strncmp(myephostname, ephostname, EPHOSTNAMELEN) == 0) {
+        if (strncmp(myephostname, ephostname, EPHOSTNAMELEN) == 0) {
             SHMEM_SET_RANK_SAME_NODE(i, num_on_node++);
             if (num_on_node > 255) {
                 RAISE_WARN_STR("ERROR: Too many local ranks");
@@ -905,39 +921,41 @@ static inline int populate_av(void)
     return 0;
 }
 
-static inline int allocate_fabric_resources(struct fabric_info *info)
+static inline
+int allocate_fabric_resources(struct fabric_info *info)
 {
     int ret = 0;
     struct fi_av_attr   av_attr = {0};
 
 
-    /* fabric domain: define domain of resources physical and logical*/
+    /* fabric domain: define domain of resources physical and logical */
     ret = fi_fabric(info->p_info->fabric_attr, &shmem_transport_ofi_fabfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("fabric initialization failed");
         return ret;
     }
 
-    /*access domain: define communication resource limits/boundary within fabric domain */
+    /* access domain: define communication resource limits/boundary within
+     * fabric domain */
     ret = fi_domain(shmem_transport_ofi_fabfd, info->p_info,
-		    &shmem_transport_ofi_domainfd,NULL);
-    if(ret!=0){
+                    &shmem_transport_ofi_domainfd,NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("domain initialization failed");
         return ret;
     }
 
-    /*transmit context: allocate one transmit context for this SHMEM PE
+    /* transmit context: allocate one transmit context for this SHMEM PE
      * and share it across different multiple endpoints. Since we have only
      * one thread per PE, a single context is sufficient and allows more
      * more PEs/node (i.e. doesn't exhaust contexts)  */
     ret = fi_stx_context(shmem_transport_ofi_domainfd, NULL, /* TODO: fill tx_attr */
-		    &shmem_transport_ofi_stx, NULL);
-    if(ret!=0) {
+                         &shmem_transport_ofi_stx, NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("stx context initialization failed");
         return ret;
     }
 
-    /*AV table set-up for PE mapping*/
+    /* AV table set-up for PE mapping */
 
 #ifdef USE_AV_MAP
     av_attr.type = FI_AV_MAP;
@@ -949,10 +967,10 @@ static inline int allocate_fabric_resources(struct fabric_info *info)
 #endif
 
     ret = fi_av_open(shmem_transport_ofi_domainfd,
-		    &av_attr,
-		    &shmem_transport_ofi_avfd,
-		    NULL);
-    if(ret!=0){
+                     &av_attr,
+                     &shmem_transport_ofi_avfd,
+                     NULL);
+    if (ret!=0) {
         RAISE_WARN_STR("av open failed");
         return ret;
     }
@@ -960,7 +978,8 @@ static inline int allocate_fabric_resources(struct fabric_info *info)
     return ret;
 }
 
-static inline int query_for_fabric(struct fabric_info *info)
+static inline
+int query_for_fabric(struct fabric_info *info)
 {
     int                 ret = 0;
     struct fi_info      hints = {0};
@@ -974,8 +993,8 @@ static inline int query_for_fabric(struct fabric_info *info)
     fabric_attr.prov_name = info->prov_name;
 
     hints.caps   = FI_RMA |     /* request rma capability
-                                    implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
-                   FI_ATOMICS;  /* request atomics capability */
+                                   implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
+        FI_ATOMICS;  /* request atomics capability */
 #ifndef ENABLE_HARD_POLLING
     hints.caps |= FI_RMA_EVENT; /* want to use remote counters */
 #endif /* ndef ENABLE_HARD_POLLING */
@@ -1002,18 +1021,18 @@ static inline int query_for_fabric(struct fabric_info *info)
 
     hints.domain_attr         = &domain_attr;
     ep_attr.type              = FI_EP_RDM; /* reliable connectionless */
-    hints.fabric_attr	      = &fabric_attr;
+    hints.fabric_attr         = &fabric_attr;
     tx_attr.op_flags          = FI_DELIVERY_COMPLETE;
-    tx_attr.inject_size       = shmem_transport_ofi_max_buffered_send; /*require provider to support this as a min*/
-    hints.tx_attr	      = &tx_attr; /* TODO: fill tx_attr */
-    hints.rx_attr	      = NULL;
+    tx_attr.inject_size       = shmem_transport_ofi_max_buffered_send; /* require provider to support this as a min */
+    hints.tx_attr             = &tx_attr; /* TODO: fill tx_attr */
+    hints.rx_attr             = NULL;
     hints.ep_attr             = &ep_attr;
 
     /* find fabric provider to use that is able to support RMA and ATOMICS */
     ret = fi_getinfo( FI_VERSION(OFI_MAJOR_VERSION, OFI_MINOR_VERSION),
                       NULL, NULL, 0, &hints, &(info->fabrics));
 
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_MSG("OFI transport did not find any valid fabric services (provider=%s)\n",
                        info->prov_name != NULL ? info->prov_name : "<auto>");
         return ret;
@@ -1041,7 +1060,7 @@ static inline int query_for_fabric(struct fabric_info *info)
         info->p_info = info->fabrics;
     }
 
-    if(NULL == info->p_info) {
+    if (NULL == info->p_info) {
         RAISE_WARN_MSG("OFI transport, no valid fabric (prov=%s, fabric=%s, domain=%s)\n",
                        info->prov_name != NULL ? info->prov_name : "<auto>",
                        info->fabric_name != NULL ? info->fabric_name : "<auto>",
@@ -1049,7 +1068,7 @@ static inline int query_for_fabric(struct fabric_info *info)
         return ret;
     }
 
-    if(info->p_info->ep_attr->max_msg_size > 0) {
+    if (info->p_info->ep_attr->max_msg_size > 0) {
         shmem_transport_ofi_max_msg_size = info->p_info->ep_attr->max_msg_size;
     } else {
         RAISE_WARN_STR("OFI provider did not set max_msg_size");
@@ -1089,7 +1108,7 @@ int shmem_transport_init(long eager_size)
     info.domain_name = shmem_util_getenv_str("OFI_DOMAIN");
 
     ret = query_for_fabric(&info);
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     /* The current bounce buffering implementation is only compatible with
@@ -1103,30 +1122,29 @@ int shmem_transport_init(long eager_size)
         shmem_transport_ofi_bounce_buffer_size = eager_size;
     }
 
-    //init LL for NB buffers
     shmem_transport_ofi_bounce_buffers =
-       shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t)
-				+ eager_size, init_bounce_buffer);
+        shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t)
+                             + eager_size, init_bounce_buffer);
 
     ret = allocate_fabric_resources(&info);
 
-    if(ret!=0)
-	return ret;
+    if (ret!=0)
+        return ret;
 
     ret = allocate_endpoints(&info);
-    if(ret!=0)
-	return ret;
+    if (ret!=0)
+        return ret;
 
     ret = allocate_cntr_and_cq();
-    if(ret!=0)
-	return ret;
+    if (ret!=0)
+        return ret;
 
     ret = bind_resources_to_and_enable_ep();
-    if(ret!=0)
-	return ret;
+    if (ret!=0)
+        return ret;
 
     ret = allocate_recv_cntr_mr();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = publish_mr_info();
@@ -1134,11 +1152,11 @@ int shmem_transport_init(long eager_size)
         return ret;
 
     ret = atomic_limitations_check();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = publish_av_info(&info);
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     fi_freeinfo(info.fabrics);
@@ -1155,7 +1173,7 @@ int shmem_transport_startup(void)
         return ret;
 
     ret = populate_av();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     return 0;
@@ -1192,24 +1210,24 @@ int shmem_transport_fini(void)
     shmem_transport_quiet();
 
     if (shmem_transport_ofi_epfd &&
-		    fi_close(&shmem_transport_ofi_epfd->fid)) {
+        fi_close(&shmem_transport_ofi_epfd->fid)) {
         RAISE_ERROR_MSG("Endpoint close failed (%s)\n", fi_strerror(errno));
     }
 
     if (shmem_transport_ofi_cntr_epfd &&
-		    fi_close(&shmem_transport_ofi_cntr_epfd->fid)) {
+        fi_close(&shmem_transport_ofi_cntr_epfd->fid)) {
         RAISE_ERROR_MSG("Endpoint close failed (%s)\n", fi_strerror(errno));
     }
 
     if (shmem_transport_ofi_stx &&
-		    fi_close(&shmem_transport_ofi_stx->fid)) {
+        fi_close(&shmem_transport_ofi_stx->fid)) {
         RAISE_ERROR_MSG("Shared context close failed (%s)\n", fi_strerror(errno));
     }
 
 #if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
     if (shmem_transport_ofi_target_mrfd &&
-		    fi_close(&shmem_transport_ofi_target_mrfd->fid)) {
-	RAISE_ERROR_MSG("Target MR close failed (%s)\n", fi_strerror(errno));
+        fi_close(&shmem_transport_ofi_target_mrfd->fid)) {
+        RAISE_ERROR_MSG("Target MR close failed (%s)\n", fi_strerror(errno));
     }
 #else
     if (shmem_transport_ofi_target_heap_mrfd &&
@@ -1224,39 +1242,39 @@ int shmem_transport_fini(void)
 #endif
 
     if (shmem_transport_ofi_put_nb_cqfd &&
-		    fi_close(&shmem_transport_ofi_put_nb_cqfd->fid)) {
+        fi_close(&shmem_transport_ofi_put_nb_cqfd->fid)) {
         RAISE_ERROR_MSG("Write CQ close failed (%s)\n", fi_strerror(errno));
     }
 
-    if(shmem_transport_ofi_put_cntrfd &&
-		    fi_close(&shmem_transport_ofi_put_cntrfd->fid)){
+    if (shmem_transport_ofi_put_cntrfd &&
+        fi_close(&shmem_transport_ofi_put_cntrfd->fid)) {
         RAISE_ERROR_MSG("INJECT PUT CT close failed (%s)\n", fi_strerror(errno));
     }
 
-    if(shmem_transport_ofi_get_cntrfd &&
-		    fi_close(&shmem_transport_ofi_get_cntrfd->fid)){
+    if (shmem_transport_ofi_get_cntrfd &&
+        fi_close(&shmem_transport_ofi_get_cntrfd->fid)) {
         RAISE_ERROR_MSG("GET CT close failed (%s)\n", fi_strerror(errno));
     }
 
 #ifndef ENABLE_HARD_POLLING
-    if(shmem_transport_ofi_target_cntrfd &&
-		    fi_close(&shmem_transport_ofi_target_cntrfd->fid)){
+    if (shmem_transport_ofi_target_cntrfd &&
+        fi_close(&shmem_transport_ofi_target_cntrfd->fid)) {
         RAISE_ERROR_MSG("Target CT close failed (%s)\n", fi_strerror(errno));
     }
 #endif
 
     if (shmem_transport_ofi_avfd &&
-		    fi_close(&shmem_transport_ofi_avfd->fid)) {
+        fi_close(&shmem_transport_ofi_avfd->fid)) {
         RAISE_ERROR_MSG("AV close failed (%s)\n", fi_strerror(errno));
     }
 
     if (shmem_transport_ofi_domainfd &&
-		    fi_close(&shmem_transport_ofi_domainfd->fid)) {
+        fi_close(&shmem_transport_ofi_domainfd->fid)) {
         RAISE_ERROR_MSG("Domain close failed (%s)\n", fi_strerror(errno));
     }
 
     if (shmem_transport_ofi_fabfd &&
-		    fi_close(&shmem_transport_ofi_fabfd->fid)) {
+        fi_close(&shmem_transport_ofi_fabfd->fid)) {
         RAISE_ERROR_MSG("Fabric close failed (%s)\n", fi_strerror(errno));
     }
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -33,14 +33,14 @@
 #include "shmem_internal.h"
 #include "shmem_atomic.h"
 
-extern struct fid_ep*			shmem_transport_ofi_epfd;
-extern struct fid_ep*			shmem_transport_ofi_cntr_epfd;
-extern struct fid_cq*              	shmem_transport_ofi_put_nb_cqfd;
+extern struct fid_ep*                   shmem_transport_ofi_epfd;
+extern struct fid_ep*                   shmem_transport_ofi_cntr_epfd;
+extern struct fid_cq*                   shmem_transport_ofi_put_nb_cqfd;
 #ifndef ENABLE_HARD_POLLING
-extern struct fid_cntr*            	shmem_transport_ofi_target_cntrfd;
+extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;
 #endif
-extern struct fid_cntr*            	shmem_transport_ofi_put_cntrfd;
-extern struct fid_cntr*            	shmem_transport_ofi_get_cntrfd;
+extern struct fid_cntr*                 shmem_transport_ofi_put_cntrfd;
+extern struct fid_cntr*                 shmem_transport_ofi_get_cntrfd;
 #ifndef ENABLE_MR_SCALABLE
 extern uint64_t*                        shmem_transport_ofi_target_heap_keys;
 extern uint64_t*                        shmem_transport_ofi_target_data_keys;
@@ -49,13 +49,13 @@ extern uint8_t**                       shmem_transport_ofi_target_heap_addrs;
 extern uint8_t**                       shmem_transport_ofi_target_data_addrs;
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 #endif /* ENABLE_MR_SCALABLE */
-extern uint64_t          		shmem_transport_ofi_pending_put_counter;
-extern uint64_t 	       	 	shmem_transport_ofi_pending_get_counter;
-extern uint64_t				shmem_transport_ofi_pending_cq_count;
-extern uint64_t				shmem_transport_ofi_max_poll;
-extern size_t          		 	shmem_transport_ofi_max_buffered_send;
-extern size_t    			shmem_transport_ofi_max_msg_size;
-extern size_t    			shmem_transport_ofi_bounce_buffer_size;
+extern uint64_t                         shmem_transport_ofi_pending_put_counter;
+extern uint64_t                         shmem_transport_ofi_pending_get_counter;
+extern uint64_t                         shmem_transport_ofi_pending_cq_count;
+extern uint64_t                         shmem_transport_ofi_max_poll;
+extern size_t                           shmem_transport_ofi_max_buffered_send;
+extern size_t                           shmem_transport_ofi_max_msg_size;
+extern size_t                           shmem_transport_ofi_bounce_buffer_size;
 
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -90,7 +90,7 @@ void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
         *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
 
     } else if ((void*) addr >= shmem_internal_heap_base &&
-              (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
+               (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
 
         *key = 1;
         *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
@@ -98,7 +98,7 @@ void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
         *key = 0;
         *mr_addr = NULL;
         RAISE_ERROR_MSG("[%03d] ERROR in %s: address (0x%p) outside of symmetric areas\n",
-               shmem_internal_my_pe, __func__, addr);
+                        shmem_internal_my_pe, __func__, addr);
     }
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 
@@ -134,7 +134,7 @@ void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
         *key = -1;
         *mr_addr = NULL;
         RAISE_ERROR_MSG("[%03d] ERROR in %s: address (0x%p) outside of symmetric areas\n",
-               shmem_internal_my_pe, __func__, addr);
+                        shmem_internal_my_pe, __func__, addr);
     }
 }
 #endif
@@ -142,7 +142,7 @@ void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
 typedef enum fi_datatype shm_internal_datatype_t;
 typedef enum fi_op       shm_internal_op_t;
 
-// Datatypes
+/* Datatypes */
 #define SHM_INTERNAL_FLOAT           FI_FLOAT
 #define SHM_INTERNAL_DOUBLE          FI_DOUBLE
 #define SHM_INTERNAL_LONG_DOUBLE     FI_LONG_DOUBLE
@@ -159,7 +159,7 @@ typedef enum fi_op       shm_internal_op_t;
 #define SHM_INTERNAL_LONG_LONG       DTYPE_LONG_LONG
 #define SHM_INTERNAL_FORTRAN_INTEGER DTYPE_FORTRAN_INTEGER
 
- // Operations
+/* Operations */
 #define SHM_INTERNAL_BAND            FI_BAND
 #define SHM_INTERNAL_BOR             FI_BOR
 #define SHM_INTERNAL_BXOR            FI_BXOR
@@ -212,71 +212,74 @@ static inline
 void shmem_transport_ofi_drain_cq(void)
 {
 
-	ssize_t ret = 0;
-	struct fi_cq_entry buf;
+    ssize_t ret = 0;
+    struct fi_cq_entry buf;
 
-	if (!shmem_transport_ofi_pending_cq_count) {
-		return;
-	}
+    if (!shmem_transport_ofi_pending_cq_count) {
+        return;
+    }
 
-	do {
-		ret = fi_cq_read(shmem_transport_ofi_put_nb_cqfd,
-				(void *)&buf, 1);
-		/*error cases*/
-		if (ret < 0 && ret != -FI_EAGAIN ) {
-			if(ret == -FI_EAVAIL) {
-				struct fi_cq_err_entry e = {0};
-             	 		fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd,
-				              (void *)&e, 0);
-				OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
-			} else {
-                                if (ret) {
-                                    RAISE_ERROR_MSG("OFI error #%zd: %s\n", ret, fi_strerror(ret));
-                                }
-			}
-		}
+    do {
+        ret = fi_cq_read(shmem_transport_ofi_put_nb_cqfd,
+                         (void *)&buf, 1);
+        /* Error cases */
+        if (ret < 0 && ret != -FI_EAGAIN ) {
+            if(ret == -FI_EAVAIL) {
+                struct fi_cq_err_entry e = {0};
+                fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd,
+                              (void *)&e, 0);
+                OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
+            } else {
+                if (ret) {
+                    RAISE_ERROR_MSG("OFI error #%zd: %s\n", ret, fi_strerror(ret));
+                }
+            }
+        }
 
-		if(ret == 1) {
-			shmem_transport_ofi_frag_t *frag =
+        if(ret == 1) {
+            shmem_transport_ofi_frag_t *frag =
                 (shmem_transport_ofi_frag_t *) buf.op_context;
 
-			if(SHMEM_TRANSPORT_OFI_TYPE_BOUNCE == frag->mytype) {
-				shmem_free_list_free(
-					shmem_transport_ofi_bounce_buffers,
-                    (shmem_transport_ofi_bounce_buffer_t *) frag);
-                        }
-                        else {
-                            RAISE_ERROR_STR("Unrecognized completion object");
-			}
+            if(SHMEM_TRANSPORT_OFI_TYPE_BOUNCE == frag->mytype) {
+                shmem_free_list_free(
+                                     shmem_transport_ofi_bounce_buffers,
+                                     (shmem_transport_ofi_bounce_buffer_t *) frag);
+            }
+            else {
+                RAISE_ERROR_STR("Unrecognized completion object");
+            }
 
-			shmem_transport_ofi_pending_cq_count--;
+            shmem_transport_ofi_pending_cq_count--;
 
-		}
+        }
 
 
-	} while(ret > 0);
+    } while(ret > 0);
 
 }
 
-static inline shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const void *source, const size_t len)
+static inline
+shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const void *source,
+                                                           const size_t len)
 {
-	shmem_transport_ofi_bounce_buffer_t *buff;
+    shmem_transport_ofi_bounce_buffer_t *buff;
 
-	buff = (shmem_transport_ofi_bounce_buffer_t*)
-	shmem_free_list_alloc(shmem_transport_ofi_bounce_buffers);
+    buff = (shmem_transport_ofi_bounce_buffer_t*)
+        shmem_free_list_alloc(shmem_transport_ofi_bounce_buffers);
 
-	/*if LL empty = error, should've been avoided with EQ drain*/
-	if (NULL == buff)
-            RAISE_ERROR_STR("Error allocating bounce buffer");
+    /* if LL empty = error, should've been avoided with EQ drain */
+    if (NULL == buff)
+        RAISE_ERROR_STR("Error allocating bounce buffer");
 
-        shmem_internal_assert(buff->frag.mytype == SHMEM_TRANSPORT_OFI_TYPE_BOUNCE);
+    shmem_internal_assert(buff->frag.mytype == SHMEM_TRANSPORT_OFI_TYPE_BOUNCE);
 
-	memcpy(buff->data, source, len);
+    memcpy(buff->data, source, len);
 
-	return buff;
+    return buff;
 }
 
-static inline void shmem_transport_put_quiet(void)
+static inline
+void shmem_transport_put_quiet(void)
 {
     /* wait until all outstanding queue operations have completed */
     while (shmem_transport_ofi_pending_cq_count) {
@@ -310,84 +313,85 @@ static inline void shmem_transport_put_quiet(void)
 #endif
 }
 
-static inline int shmem_transport_quiet(void)
+static inline
+int shmem_transport_quiet(void)
 {
 
-	shmem_transport_put_quiet();
+    shmem_transport_put_quiet();
+    shmem_transport_get_wait();
 
-	shmem_transport_get_wait();
-
-	return 0;
+    return 0;
 }
 
 
 static inline
-int
-shmem_transport_fence(void)
+int shmem_transport_fence(void)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
-	/*unordered network model*/
-  return shmem_transport_quiet();
+    /*unordered network model*/
+    return shmem_transport_quiet();
 #else
-  return 0;
+    return 0;
 #endif
 
 }
 
-/*RM requires polling until space is available*/
-static inline int try_again(const int ret, uint64_t *polled) {
+/* RM requires polling until space is available */
+static inline
+int try_again(const int ret, uint64_t *polled) {
 
-	if (ret) {
-		if (ret == -FI_EAGAIN) {
-			shmem_transport_ofi_drain_cq();
-			(*polled)++;
-			if ((*polled) <= shmem_transport_ofi_max_poll) {
-				return 1;
-			}
-		}
-		OFI_RET_CHECK(ret);
-	}
+    if (ret) {
+        if (ret == -FI_EAGAIN) {
+            shmem_transport_ofi_drain_cq();
+            (*polled)++;
+            if ((*polled) <= shmem_transport_ofi_max_poll) {
+                return 1;
+            }
+        }
+        OFI_RET_CHECK(ret);
+    }
 
-	return 0;
+    return 0;
 }
 
 static inline
-void
-shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
+void shmem_transport_put_small(void *target, const void *source, size_t len,
+                               int pe)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(len <= shmem_transport_ofi_max_buffered_send);
+    shmem_internal_assert(len <= shmem_transport_ofi_max_buffered_send);
 
-	do {
+    do {
 
-		ret = fi_inject_write(shmem_transport_ofi_cntr_epfd,
-				source,
-				len,
-				GET_DEST(dst),
-				(uint64_t) addr,
-				key);
+        ret = fi_inject_write(shmem_transport_ofi_cntr_epfd,
+                              source,
+                              len,
+                              GET_DEST(dst),
+                              (uint64_t) addr,
+                              key);
 
-	} while(try_again(ret,&polled));
+    } while(try_again(ret,&polled));
 
-        shmem_internal_assert(ret == 0);
-	/* automatically get local completion but need remote completion for fence/quiet*/
-	shmem_transport_ofi_pending_put_counter++;
+    shmem_internal_assert(ret == 0);
+    /* automatically get local completion but need remote completion for
+     * fence/quiet*/
+    shmem_transport_ofi_pending_put_counter++;
 }
 
 static inline
-void
-shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int pe)
+void shmem_transport_ofi_put_large(void *target, const void *source,
+                                   size_t len, int pe)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
     uint64_t key;
     uint8_t *addr;
 
@@ -397,10 +401,11 @@ shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int 
     uint64_t frag_target = (uint64_t) addr;
     size_t frag_len = len;
 
-     /* operation generates counting events and must be completed by
-      * quiet. */
-     while (frag_source < ((uint8_t *) source) + len) {
-        frag_len = MIN(shmem_transport_ofi_max_msg_size, (size_t) (((uint8_t *) source) + len - frag_source));
+    /* operation generates counting events and must be completed by
+     * quiet. */
+    while (frag_source < ((uint8_t *) source) + len) {
+        frag_len = MIN(shmem_transport_ofi_max_msg_size,
+                       (size_t) (((uint8_t *) source) + len - frag_source));
         polled = 0;
 
         do {
@@ -418,37 +423,36 @@ shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int 
 }
 
 static inline
-void
-shmem_transport_put_nb(void *target, const void *source, size_t len,
-                       int pe, long *completion)
+void shmem_transport_put_nb(void *target, const void *source, size_t len,
+                            int pe, long *completion)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_internal_assert(completion != NULL);
+    shmem_internal_assert(completion != NULL);
 
-	if (len <= shmem_transport_ofi_max_buffered_send) {
+    if (len <= shmem_transport_ofi_max_buffered_send) {
 
         shmem_transport_put_small(target, source, len, pe);
 
-	} else if (len <= shmem_transport_ofi_bounce_buffer_size) {
+    } else if (len <= shmem_transport_ofi_bounce_buffer_size) {
 
         shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-		shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, len);
-		polled = 0;
+        shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, len);
+        polled = 0;
 
-		do {
-			ret = fi_write(shmem_transport_ofi_epfd,
-					buff->data, len, NULL,
-					GET_DEST(dst), (uint64_t) addr,
-					key, buff);
-		} while(try_again(ret,&polled));
+        do {
+            ret = fi_write(shmem_transport_ofi_epfd,
+                           buff->data, len, NULL,
+                           GET_DEST(dst), (uint64_t) addr,
+                           key, buff);
+        } while(try_again(ret,&polled));
 
-		shmem_transport_ofi_pending_cq_count++;
+        shmem_transport_ofi_pending_cq_count++;
 
     } else {
         shmem_transport_ofi_put_large(target, source,len, pe);
@@ -456,10 +460,9 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
     }
 }
 
-/*compatibility with Portals transport*/
+/* compatibility with Portals transport */
 static inline
-void
-shmem_transport_put_wait(long *completion) {
+void shmem_transport_put_wait(long *completion) {
 
     shmem_internal_assert((*completion) >= 0);
 
@@ -470,10 +473,10 @@ shmem_transport_put_wait(long *completion) {
 }
 
 static inline
-void
-shmem_transport_put_nbi(void *target, const void *source, size_t len, int pe)
+void shmem_transport_put_nbi(void *target, const void *source, size_t len,
+                             int pe)
 {
-	if (len <= shmem_transport_ofi_max_buffered_send) {
+    if (len <= shmem_transport_ofi_max_buffered_send) {
 
         shmem_transport_put_small(target, source, len, pe);
 
@@ -485,59 +488,58 @@ shmem_transport_put_nbi(void *target, const void *source, size_t len, int pe)
 
 
 static inline
-void
-shmem_transport_get(void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(void *target, const void *source, size_t len, int pe)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(source, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(source, pe, &addr, &key);
 
-        if (len <= shmem_transport_ofi_max_msg_size) {
+    if (len <= shmem_transport_ofi_max_msg_size) {
+        do {
+            ret = fi_read(shmem_transport_ofi_cntr_epfd,
+                          target,
+                          len,
+                          NULL,
+                          GET_DEST(dst),
+                          (uint64_t) addr,
+                          key,
+                          NULL);
+        } while (try_again(ret,&polled));
+
+        shmem_transport_ofi_pending_get_counter++;
+    }
+    else {
+        uint8_t *frag_target = (uint8_t *) target;
+        uint64_t frag_source = (uint64_t) addr;
+        size_t frag_len = len;
+
+        while (frag_target < ((uint8_t *) target) + len) {
+            frag_len = MIN(shmem_transport_ofi_max_msg_size,
+                           (size_t) (((uint8_t *) target) + len - frag_target));
+            polled = 0;
+
             do {
                 ret = fi_read(shmem_transport_ofi_cntr_epfd,
-                              target,
-                              len,
-                              NULL,
-                              GET_DEST(dst),
-                              (uint64_t) addr,
-                              key,
-                              NULL);
+                              frag_target, frag_len, NULL,
+                              GET_DEST(dst), frag_source,
+                              key, NULL);
             } while (try_again(ret,&polled));
 
             shmem_transport_ofi_pending_get_counter++;
+
+            frag_source += frag_len;
+            frag_target += frag_len;
         }
-        else {
-            uint8_t *frag_target = (uint8_t *) target;
-            uint64_t frag_source = (uint64_t) addr;
-            size_t frag_len = len;
-
-            while (frag_target < ((uint8_t *) target) + len) {
-                frag_len = MIN(shmem_transport_ofi_max_msg_size, (size_t) (((uint8_t *) target) + len - frag_target));
-                polled = 0;
-
-                do {
-                    ret = fi_read(shmem_transport_ofi_cntr_epfd,
-                                  frag_target, frag_len, NULL,
-                                  GET_DEST(dst), frag_source,
-                                  key, NULL);
-                } while (try_again(ret,&polled));
-
-                shmem_transport_ofi_pending_get_counter++;
-
-                frag_source += frag_len;
-                frag_target += frag_len;
-            }
-        }
+    }
 }
 
 
 static inline
-void
-shmem_transport_get_wait(void)
+void shmem_transport_get_wait(void)
 {
     /* wait for get counter to meet outstanding count value */
 #ifdef ENABLE_COMPLETION_POLLING
@@ -568,148 +570,143 @@ shmem_transport_get_wait(void)
 
 
 static inline
-void
-shmem_transport_swap(void *target, const void *source, void *dest,
-                     size_t len, int pe, int datatype)
+void shmem_transport_swap(void *target, const void *source, void *dest,
+                          size_t len, int pe, int datatype)
 {
-	int ret = 0;
-        uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(len <= sizeof(double complex));
-        shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
+    shmem_internal_assert(len <= sizeof(double complex));
+    shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-	do {
-        	ret = fi_fetch_atomic(shmem_transport_ofi_cntr_epfd,
-                	source,
-                	1,
-			NULL,
-			dest,
-			NULL,
-			GET_DEST(dst),
-			(uint64_t) addr,
-			key,
-			datatype,
-			FI_ATOMIC_WRITE,
-			NULL);
-	} while(try_again(ret,&polled));
+    do {
+        ret = fi_fetch_atomic(shmem_transport_ofi_cntr_epfd,
+                              source,
+                              1,
+                              NULL,
+                              dest,
+                              NULL,
+                              GET_DEST(dst),
+                              (uint64_t) addr,
+                              key,
+                              datatype,
+                              FI_ATOMIC_WRITE,
+                              NULL);
+    } while(try_again(ret,&polled));
 
-	shmem_transport_ofi_pending_get_counter++;
+    shmem_transport_ofi_pending_get_counter++;
 }
 
 
 static inline
-void
-shmem_transport_cswap(void *target, const void *source, void *dest,
-                      const void *operand, size_t len, int pe, int datatype)
+void shmem_transport_cswap(void *target, const void *source, void *dest,
+                           const void *operand, size_t len, int pe, int datatype)
 {
-	int ret = 0;
-        uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(len <= sizeof(double complex));
-        shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
+    shmem_internal_assert(len <= sizeof(double complex));
+    shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-	do {
-		ret = fi_compare_atomic(shmem_transport_ofi_cntr_epfd,
-			source,
-			1,
-			NULL,
-			operand,
-			NULL,
-			dest,
-			NULL,
-			GET_DEST(dst),
-			(uint64_t) addr,
-			key,
-			datatype,
-			FI_CSWAP,
-			NULL);
-	} while(try_again(ret,&polled));
+    do {
+        ret = fi_compare_atomic(shmem_transport_ofi_cntr_epfd,
+                                source,
+                                1,
+                                NULL,
+                                operand,
+                                NULL,
+                                dest,
+                                NULL,
+                                GET_DEST(dst),
+                                (uint64_t) addr,
+                                key,
+                                datatype,
+                                FI_CSWAP,
+                                NULL);
+    } while(try_again(ret,&polled));
 
-	shmem_transport_ofi_pending_get_counter++;
+    shmem_transport_ofi_pending_get_counter++;
 }
 
 
 static inline
-void
-shmem_transport_mswap(void *target, const void *source, void *dest,
-                      const void *mask, size_t len, int pe, int datatype)
+void shmem_transport_mswap(void *target, const void *source, void *dest,
+                           const void *mask, size_t len, int pe, int datatype)
 {
-	int ret = 0;
-        uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(len <= sizeof(double complex));
-        shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
+    shmem_internal_assert(len <= sizeof(double complex));
+    shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-	do {
-		ret = fi_compare_atomic(shmem_transport_ofi_cntr_epfd,
-			source,
-			1,
-			NULL,
-			mask,
-			NULL,
-			dest,
-			NULL,
-		        GET_DEST(dst),
-			(uint64_t) addr,
-			key,
-			datatype,
-			FI_MSWAP,
-			NULL);
-	} while(try_again(ret,&polled));
+    do {
+        ret = fi_compare_atomic(shmem_transport_ofi_cntr_epfd,
+                                source,
+                                1,
+                                NULL,
+                                mask,
+                                NULL,
+                                dest,
+                                NULL,
+                                GET_DEST(dst),
+                                (uint64_t) addr,
+                                key,
+                                datatype,
+                                FI_MSWAP,
+                                NULL);
+    } while(try_again(ret,&polled));
 
-	shmem_transport_ofi_pending_get_counter++;
+    shmem_transport_ofi_pending_get_counter++;
 }
 
 
 static inline
-void
-shmem_transport_atomic_small(void *target, const void *source, size_t len,
-                                       int pe, int op, int datatype)
+void shmem_transport_atomic_small(void *target, const void *source, size_t len,
+                                  int pe, int op, int datatype)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
+    shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-	do {
-		ret = fi_inject_atomic(shmem_transport_ofi_cntr_epfd,
-			source,
-			1,
-			GET_DEST(dst),
-			(uint64_t) addr,
-			key,
-			datatype,
-			op);
-	} while(try_again(ret,&polled));
+    do {
+        ret = fi_inject_atomic(shmem_transport_ofi_cntr_epfd,
+                               source,
+                               1,
+                               GET_DEST(dst),
+                               (uint64_t) addr,
+                               key,
+                               datatype,
+                               op);
+    } while(try_again(ret,&polled));
 
-	shmem_transport_ofi_pending_put_counter++;
+    shmem_transport_ofi_pending_put_counter++;
 }
 
 
 static inline
-void
-shmem_transport_atomic_set(void *target, const void *source, size_t len,
-                           int pe, int datatype)
+void shmem_transport_atomic_set(void *target, const void *source, size_t len,
+                                int pe, int datatype)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -737,9 +734,8 @@ shmem_transport_atomic_set(void *target, const void *source, size_t len,
 
 
 static inline
-void
-shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
-                            int pe, int datatype)
+void shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
+                                  int pe, int datatype)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -771,160 +767,158 @@ shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
 
 
 static inline
-void
-shmem_transport_atomic_nb(void *target, const void *source, size_t full_len,
-                                   int pe, int op, int datatype,
-                                   long *completion)
+void shmem_transport_atomic_nb(void *target, const void *source,
+                               size_t full_len, int pe, int op, int datatype,
+                               long *completion)
 {
-	int ret = 0;
-	uint64_t dst = (uint64_t) pe;
-	size_t len = full_len/SHMEM_Dtsize[datatype];
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
-	size_t max_atomic_size = 0;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    size_t len = full_len/SHMEM_Dtsize[datatype];
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
+    size_t max_atomic_size = 0;
 
-        shmem_internal_assert(SHMEM_Dtsize[datatype] * len == full_len);
+    shmem_internal_assert(SHMEM_Dtsize[datatype] * len == full_len);
 
-	ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op,
-				&max_atomic_size);
-	max_atomic_size = max_atomic_size * SHMEM_Dtsize[datatype];
-	if (max_atomic_size > shmem_transport_ofi_max_msg_size
-		|| ret || max_atomic_size == 0) {
-		RAISE_ERROR_MSG("atomic_nb error: datatype %d x op %d not supported\n",
-                    datatype, op);
-	}
+    ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op,
+                         &max_atomic_size);
+    max_atomic_size = max_atomic_size * SHMEM_Dtsize[datatype];
+    if (max_atomic_size > shmem_transport_ofi_max_msg_size
+        || ret || max_atomic_size == 0) {
+        RAISE_ERROR_MSG("atomic_nb error: datatype %d x op %d not supported\n",
+                        datatype, op);
+    }
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-	if ( full_len <= MIN(shmem_transport_ofi_max_buffered_send,
-        max_atomic_size)) {
+    if ( full_len <= MIN(shmem_transport_ofi_max_buffered_send,
+                         max_atomic_size)) {
 
-		polled = 0;
+        polled = 0;
 
-		do {
-			ret = fi_inject_atomic(shmem_transport_ofi_cntr_epfd,
-                		source,
-                      		len, //count
-				GET_DEST(dst),
-				(uint64_t) addr,
-				key,
-                        	datatype,
-                        	op);
-		} while(try_again(ret,&polled));
+        do {
+            ret = fi_inject_atomic(shmem_transport_ofi_cntr_epfd,
+                                   source,
+                                   len,
+                                   GET_DEST(dst),
+                                   (uint64_t) addr,
+                                   key,
+                                   datatype,
+                                   op);
+        } while(try_again(ret,&polled));
 
-		shmem_transport_ofi_pending_put_counter++;
+        shmem_transport_ofi_pending_put_counter++;
 
-        } else if (full_len <=
-			MIN(shmem_transport_ofi_bounce_buffer_size, max_atomic_size)) {
+    } else if (full_len <=
+               MIN(shmem_transport_ofi_bounce_buffer_size, max_atomic_size)) {
 
-			shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, full_len);
+        shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, full_len);
 
-			polled = 0;
+        polled = 0;
 
-		do {
-			ret = fi_atomic(shmem_transport_ofi_epfd,
-				buff->data,
-				len,
-				NULL,
-				GET_DEST(dst),
-				(uint64_t) addr,
-				key,
-				datatype,
-				op,
-				buff);
-		} while(try_again(ret,&polled));
+        do {
+            ret = fi_atomic(shmem_transport_ofi_epfd,
+                            buff->data,
+                            len,
+                            NULL,
+                            GET_DEST(dst),
+                            (uint64_t) addr,
+                            key,
+                            datatype,
+                            op,
+                            buff);
+        } while(try_again(ret,&polled));
 
-			shmem_transport_ofi_pending_cq_count++;
+        shmem_transport_ofi_pending_cq_count++;
 
-        } else {
-		size_t sent = 0;
+    } else {
+        size_t sent = 0;
 
-		while (sent < len) {
+        while (sent < len) {
 
-			size_t chunksize = MIN((len-sent),
-				(max_atomic_size/SHMEM_Dtsize[datatype]));
-			polled = 0;
-		do {
-			ret = fi_atomic(shmem_transport_ofi_cntr_epfd,
-				(void *)((char *)source +
-					(sent*SHMEM_Dtsize[datatype])),
-				chunksize,
-				NULL,
-				GET_DEST(dst),
-				((uint64_t) addr +
-				 	(sent*SHMEM_Dtsize[datatype])),
-				key,
-				datatype,
-				op,
-				NULL);
-		} while(try_again(ret,&polled));
+            size_t chunksize = MIN((len-sent),
+                                   (max_atomic_size/SHMEM_Dtsize[datatype]));
+            polled = 0;
+            do {
+                ret = fi_atomic(shmem_transport_ofi_cntr_epfd,
+                                (void *)((char *)source +
+                                         (sent*SHMEM_Dtsize[datatype])),
+                                chunksize,
+                                NULL,
+                                GET_DEST(dst),
+                                ((uint64_t) addr +
+                                 (sent*SHMEM_Dtsize[datatype])),
+                                key,
+                                datatype,
+                                op,
+                                NULL);
+            } while(try_again(ret,&polled));
 
-			shmem_transport_ofi_pending_put_counter++;
-			sent += chunksize;
-		}
+            shmem_transport_ofi_pending_put_counter++;
+            sent += chunksize;
         }
+    }
 }
 
 
 static inline
-void
-shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
-                             size_t len, int pe, int op, int datatype)
+void shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
+                                  size_t len, int pe, int op, int datatype)
 {
-        int ret = 0;
-        uint64_t dst = (uint64_t) pe;
-	uint64_t polled = 0;
-        uint64_t key;
-        uint8_t *addr;
+    int ret = 0;
+    uint64_t dst = (uint64_t) pe;
+    uint64_t polled = 0;
+    uint64_t key;
+    uint8_t *addr;
 
-        shmem_transport_ofi_get_mr(target, pe, &addr, &key);
+    shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-        shmem_internal_assert(len <= sizeof(double complex));
-        shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
+    shmem_internal_assert(len <= sizeof(double complex));
+    shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-	do {
-        	ret = fi_fetch_atomic(shmem_transport_ofi_cntr_epfd,
-			source,
-			1,
-			NULL,
-			dest,
-			NULL,
-			GET_DEST(dst),
-			(uint64_t) addr,
-			key,
-			datatype,
-			op,
-			NULL);
-	} while(try_again(ret,&polled));
+    do {
+        ret = fi_fetch_atomic(shmem_transport_ofi_cntr_epfd,
+                              source,
+                              1,
+                              NULL,
+                              dest,
+                              NULL,
+                              GET_DEST(dst),
+                              (uint64_t) addr,
+                              key,
+                              datatype,
+                              op,
+                              NULL);
+    } while(try_again(ret,&polled));
 
-	shmem_transport_ofi_pending_get_counter++;
+    shmem_transport_ofi_pending_get_counter++;
 }
 
 
 /* detect atomic limitation on the fly and provide software reduction support
-    if needed */
+   if needed */
 static inline
 int shmem_transport_atomic_supported(shm_internal_op_t op,
                                      shm_internal_datatype_t datatype)
 {
-   size_t size = 0;
-   int ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op, &size);
-   return !(ret != 0 || size == 0);
+    size_t size = 0;
+    int ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op, &size);
+    return !(ret != 0 || size == 0);
 }
 
 
 static inline
-void
-shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target,
-                              const void *source, size_t len, int pe, long *completion)
+void shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target,
+                               const void *source, size_t len, int pe,
+                               long *completion)
 {
     RAISE_ERROR_STR("OFI transport does not currently support CT operations");
 }
 
 static inline
 void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
-                                const void *source, size_t len, int pe)
+                            const void *source, size_t len, int pe)
 {
     RAISE_ERROR_STR("OFI transport does not currently support CT operations");
 }


### PR DESCRIPTION
Here are all of the non-whitespace changes (gif diff -b master..):
```
diff --git a/src/transport_ofi.c b/src/transport_ofi.c
index e566866b..ac88e31a 100644
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -236,7 +236,7 @@ static int REDUCE_ARITH_OPS[]=
 };
 
 /* Internal to SHMEM implementation atomic requirement */
-/*Locking implementation requirement */
+/* Locking implementation requirement */
 #define SIZEOF_INTERNAL_REQ_DT 1
 static int DT_INTERNAL_REQ[]=
 {
@@ -257,30 +257,30 @@ typedef enum{
 
 shmem_free_list_t *shmem_transport_ofi_bounce_buffers = NULL;
 
-//size of CQ
-const static size_t shmem_transport_ofi_queue_slots = 32768;//default CQ Depth....
+/* default CQ depth */
+const static size_t shmem_transport_ofi_queue_slots = 32768;
 uint64_t shmem_transport_ofi_max_poll = (1ULL<<30);
 
 #define OFI_MAJOR_VERSION 1
 #define OFI_MINOR_VERSION 0
 
 static
-void
-init_bounce_buffer(shmem_free_list_item_t *item)
+void init_bounce_buffer(shmem_free_list_item_t *item)
 {
     shmem_transport_ofi_frag_t *frag =
         (shmem_transport_ofi_frag_t*) item;
     frag->mytype = SHMEM_TRANSPORT_OFI_TYPE_BOUNCE;
 }
 
-static inline int allocate_endpoints(struct fabric_info *info)
+static inline
+int allocate_endpoints(struct fabric_info *info)
 {
 
     int ret = 0;
 
-    /* ------------------------------------*/
+    /* ------------------------------------ */
     /*         Allocate Endpoints           */
-    /* ------------------------------------*/
+    /* ------------------------------------ */
 
     /* this endpoint is used to get completion events and
      * used to expose memory to incoming reads/writes */
@@ -288,14 +288,14 @@ static inline int allocate_endpoints(struct fabric_info *info)
     info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_epfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("epfd creation failed");
         return ret;
     }
 
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_cntr_epfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("cntr_epfd creation failed");
         return ret;
     }
@@ -304,32 +304,34 @@ static inline int allocate_endpoints(struct fabric_info *info)
 
 }
 
-static inline int bind_resources_to_and_enable_ep(void)
+static inline
+int bind_resources_to_and_enable_ep(void)
 {
-
-    /*   must bind resources created to EP then enable EP for communication (resources can now be used) */
+    /* must bind resources created to EP then enable EP for communication
+     * (resources can now be used) */
 
     int ret = 0;
 
     /* attach the endpoints to the shared context */
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
                      &shmem_transport_ofi_stx->fid, 0);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind epfd2stx failed");
         return ret;
     }
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
                      &shmem_transport_ofi_stx->fid, 0);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2stx failed");
         return ret;
     }
 
-    /* attaching to endpoint enables counting "writes" for calls used with this endpoint*/
+    /* attaching to endpoint enables counting "writes" for calls used with this
+     * endpoint */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
                      &shmem_transport_ofi_put_cntrfd->fid, FI_WRITE);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
@@ -337,7 +339,7 @@ static inline int bind_resources_to_and_enable_ep(void)
     /* attach to endpoint */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
                      &shmem_transport_ofi_get_cntrfd->fid, FI_READ);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2get_cntr failed");
         return ret;
     }
@@ -345,39 +347,42 @@ static inline int bind_resources_to_and_enable_ep(void)
     /* attach CQ for obtaining completions for large puts (NB puts) */
     ret = fi_ep_bind(shmem_transport_ofi_epfd,
                      &shmem_transport_ofi_put_nb_cqfd->fid, FI_SEND);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind ep2cq_nb failed");
         return ret;
     }
 
     /* attach CQ for error handling on cntr EP */
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
-		    &shmem_transport_ofi_put_nb_cqfd->fid, FI_SELECTIVE_COMPLETION | FI_TRANSMIT);
-    if(ret!=0){
+                     &shmem_transport_ofi_put_nb_cqfd->fid,
+                     FI_SELECTIVE_COMPLETION | FI_TRANSMIT);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntrep2cq_nb failed");
         return ret;
     }
 
-    ret = fi_ep_bind(shmem_transport_ofi_epfd, &shmem_transport_ofi_avfd->fid, 0);
-    if(ret!=0){
+    ret = fi_ep_bind(shmem_transport_ofi_epfd,
+                     &shmem_transport_ofi_avfd->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind ep2av failed");
         return ret;
     }
 
-    ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd, &shmem_transport_ofi_avfd->fid, 0);
-    if(ret!=0){
+    ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
+                     &shmem_transport_ofi_avfd->fid, 0);
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_ep2av failed");
         return ret;
     }
 
-    /*enable active endpoint state: can now perform data transfers*/
+    /* enable active endpoint state: can now perform data transfers */
     ret = fi_enable(shmem_transport_ofi_epfd);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("enable_epfd failed");
         return ret;
     }
     ret = fi_enable(shmem_transport_ofi_cntr_epfd);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("enable_cntr_epfd failed");
         return ret;
     }
@@ -385,7 +390,8 @@ static inline int bind_resources_to_and_enable_ep(void)
     return ret;
 }
 
-static inline int allocate_cntr_and_cq(void)
+static inline
+int allocate_cntr_and_cq(void)
 {
 
     int ret = 0;
@@ -399,35 +405,35 @@ static inline int allocate_cntr_and_cq(void)
     cntr_attr.wait_obj = FI_WAIT_UNSPEC;
 #endif
 
-    /* -------------------------------------------------------*/
+    /* ------------------------------------------------------- */
     /* Define Completion tracking Resources to Attach to EP    */
-    /* -------------------------------------------------------*/
+    /* ------------------------------------------------------- */
 
-    // Create counter for counting completions of outgoing writes
+    /* Create counter for counting completions of outgoing writes */
 
     ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
                        &shmem_transport_ofi_put_cntrfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("put cntr_open failed");
         return ret;
     }
 
-    // Create counter for counting completions of outbound reads
+    /* Create counter for counting completions of outbound reads */
 
     ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
                        &shmem_transport_ofi_get_cntrfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("get cntr_open failed");
         return ret;
     }
 
-    /* Create CQ to be used for NB puts */
-    cq_attr.format    = FI_CQ_FORMAT_CONTEXT;//event type for CQ,only context stored/reported
+    /* Create CQ to be used for NB puts, only context reported */
+    cq_attr.format    = FI_CQ_FORMAT_CONTEXT;
     cq_attr.size      = shmem_transport_ofi_queue_slots;
 
     ret = fi_cq_open(shmem_transport_ofi_domainfd, &cq_attr,
                      &shmem_transport_ofi_put_nb_cqfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("cq_open failed");
         return ret;
     }
@@ -436,28 +442,31 @@ static inline int allocate_cntr_and_cq(void)
 
 }
 
-static inline int allocate_recv_cntr_mr(void)
+static inline
+int allocate_recv_cntr_mr(void)
 {
 
     int ret = 0;
 
-    /* ------------------------------------*/
+    /* ------------------------------------ */
     /* POST enable resources for to EP      */
-    /* ------------------------------------*/
-    /* since this is AFTER enable and RMA you must create memory regions for incoming reads/writes
-     * and outgoing non-blocking Puts, specifying entire VA range */
+    /* ------------------------------------ */
+
+    /* since this is AFTER enable and RMA you must create memory regions for
+     * incoming reads/writes and outgoing non-blocking Puts, specifying entire
+     * VA range */
 
 #ifndef ENABLE_HARD_POLLING
     {
         struct fi_cntr_attr cntr_attr = {0};
 
-        // Create counter for incoming writes
+        /* Create counter for incoming writes */
         cntr_attr.events   = FI_CNTR_EVENTS_COMP;
         cntr_attr.wait_obj = FI_WAIT_UNSPEC;
 
         ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_attr,
                            &shmem_transport_ofi_target_cntrfd, NULL);
-        if(ret!=0){
+        if (ret!=0) {
             RAISE_WARN_STR("target cntr_open failed");
             return ret;
         }
@@ -468,24 +477,24 @@ static inline int allocate_recv_cntr_mr(void)
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, 0, UINT64_MAX,
                     FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0ULL, 0,
                     &shmem_transport_ofi_target_mrfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("mr_reg failed");
         return ret;
     }
 
-    // Bind counter with target memory region for incoming messages
+    /* Bind counter with target memory region for incoming messages */
 #ifndef ENABLE_HARD_POLLING
     ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
                      &shmem_transport_ofi_target_cntrfd->fid,
                      FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("mr_bind failed");
         return ret;
     }
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
                      &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
@@ -531,7 +540,7 @@ static inline int allocate_recv_cntr_mr(void)
 
     ret = fi_ep_bind(shmem_transport_ofi_cntr_epfd,
                      &shmem_transport_ofi_target_cntrfd->fid, FI_REMOTE_WRITE | FI_REMOTE_READ);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("ep_bind cntr_epfd2put_cntr failed");
         return ret;
     }
@@ -541,7 +550,8 @@ static inline int allocate_recv_cntr_mr(void)
     return ret;
 }
 
-static int publish_mr_info(void)
+static
+int publish_mr_info(void)
 {
 #ifndef ENABLE_MR_SCALABLE
     {
@@ -585,7 +595,8 @@ static int publish_mr_info(void)
     return 0;
 }
 
-static int populate_mr_tables(void)
+static
+int populate_mr_tables(void)
 {
 #ifndef ENABLE_MR_SCALABLE
     {
@@ -662,17 +673,18 @@ static int populate_mr_tables(void)
     return 0;
 }
 
-/*SOFT_SUPPORT will not produce warning or error */
-static inline int atomicvalid_rtncheck(int ret, int atomic_size,
+/* SOFT_SUPPORT will not produce warning or error */
+static inline
+int atomicvalid_rtncheck(int ret, int atomic_size,
                          atomic_support_lv atomic_sup,
                          char strOP[], char strDT[])
 {
-    if((ret != 0 || atomic_size == 0) && atomic_sup != ATOMIC_SOFT_SUPPORT) {
-        if(atomic_sup == ATOMIC_WARNINGS) {
+    if ((ret != 0 || atomic_size == 0) && atomic_sup != ATOMIC_SOFT_SUPPORT) {
+        if (atomic_sup == ATOMIC_WARNINGS) {
             fprintf(stderr, "Warning OFI detected no support for atomic '%s' "
                     "on type '%s'\n", strOP, strDT);
         }
-        else if(atomic_sup == ATOMIC_NO_SUPPORT) {
+        else if (atomic_sup == ATOMIC_NO_SUPPORT) {
             RAISE_WARN_MSG("Error: atomicvalid ret=%d atomic_size=%d\n",
                            ret, atomic_size);
             return ret;
@@ -684,8 +696,9 @@ static inline int atomicvalid_rtncheck(int ret, int atomic_size,
     return 0;
 }
 
-static inline int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
-                                    int OPS[], atomic_support_lv atomic_sup)
+static inline
+int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[], int OPS[],
+                      atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
     size_t atomic_size;
@@ -694,7 +707,7 @@ static inline int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
         for(j=0; j<OPS_MAX; j++) {
             ret = fi_atomicvalid(shmem_transport_ofi_epfd, DT[i],
                                  OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
                                      SHMEM_DtName[DT[i]]))
                 return ret;
@@ -704,7 +717,8 @@ static inline int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
     return 0;
 }
 
-static inline int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
+static inline
+int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
                               int OPS[], atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
@@ -714,7 +728,7 @@ static inline int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
         for(j=0; j<OPS_MAX; j++) {
             ret = fi_compare_atomicvalid(shmem_transport_ofi_epfd, DT[i],
                                          OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
                                      SHMEM_DtName[DT[i]]))
                 return ret;
@@ -724,8 +738,9 @@ static inline int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
     return 0;
 }
 
-static inline int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
-                                    int OPS[], atomic_support_lv atomic_sup)
+static inline
+int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[], int OPS[],
+                            atomic_support_lv atomic_sup)
 {
     int i, j, ret = 0;
     size_t atomic_size;
@@ -734,7 +749,7 @@ static inline int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
         for(j=0; j<OPS_MAX; j++) {
             ret = fi_fetch_atomicvalid(shmem_transport_ofi_epfd, DT[i],
                                        OPS[j], &atomic_size);
-         if(atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
+            if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
                                      SHMEM_DtName[DT[i]]))
                 return ret;
@@ -743,23 +758,21 @@ static inline int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int DT[],
 
     return 0;
 }
-static inline int atomic_limitations_check(void)
-{
 
-    /* ----------------------------------------*/
-    /* Retrieve messaging limitations from OFI */
-    /*          NOTE:                          */
-    /*   currently only have reduction software*/
-    /*   atomic support, user can optionally   */
-    /*   request for warnings if other atomic  */
-    /*   limitations are detected              */
-    /* ----------------------------------------*/
+static inline
+int atomic_limitations_check(void)
+{
+    /* Retrieve messaging limitations from OFI
+     *
+     * NOTE: Currently only have reduction software atomic support. User can
+     * optionally request for warnings if other atomic limitations are detected
+     */
 
     int ret = 0;
     atomic_support_lv general_atomic_sup = ATOMIC_NO_SUPPORT;
     atomic_support_lv reduction_sup = ATOMIC_SOFT_SUPPORT;
 
-    if(NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
+    if (NULL != shmem_util_getenv_str("OFI_ATOMIC_CHECKS_WARN"))
         general_atomic_sup = ATOMIC_WARNINGS;
 
     init_ofi_tables();
@@ -767,66 +780,68 @@ static inline int atomic_limitations_check(void)
     /* Standard OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_OPS, DT_AMO_STANDARD,
                             AMO_STANDARD_OPS, general_atomic_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_FOPS,
                                   DT_AMO_STANDARD, FETCH_AMO_STANDARD_OPS,
                                   general_atomic_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     ret = compare_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_COPS,
                                     DT_AMO_STANDARD, COMPARE_AMO_STANDARD_OPS,
                                     general_atomic_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     /* Extended OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_OPS, DT_AMO_EXTENDED,
                             AMO_EXTENDED_OPS, general_atomic_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_FOPS,
                                   DT_AMO_EXTENDED, FETCH_AMO_EXTENDED_OPS,
                                   general_atomic_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     /* Reduction OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_RED_DT, SIZEOF_RED_OPS, DT_REDUCE_BITWISE,
                             REDUCE_BITWISE_OPS, reduction_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDC_DT, SIZEOF_REDC_OPS, DT_REDUCE_COMPARE,
                             REDUCE_COMPARE_OPS, reduction_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDA_DT, SIZEOF_REDA_OPS, DT_REDUCE_ARITH,
                             REDUCE_ARITH_OPS, reduction_sup);
-    if(ret)
+    if (ret)
         return ret;
 
     /* Internal atomic requirement */
     ret = compare_atomicvalid_DTxOP(SIZEOF_INTERNAL_REQ_DT, SIZEOF_INTERNAL_REQ_OPS,
-                    DT_INTERNAL_REQ, INTERNAL_REQ_OPS, general_atomic_sup);
-    if(ret)
+                                    DT_INTERNAL_REQ, INTERNAL_REQ_OPS,
+                                    general_atomic_sup);
+    if (ret)
         return ret;
 
     return 0;
 }
 
-static inline int publish_av_info(struct fabric_info *info)
+static inline
+int publish_av_info(struct fabric_info *info)
 {
     int    ret = 0;
     char   epname[128];
     size_t epnamelen = sizeof(epname);
 
 #ifdef USE_ON_NODE_COMMS
-    if(gethostname(myephostname, (EPHOSTNAMELEN - 1)) != 0)
+    if (gethostname(myephostname, (EPHOSTNAMELEN - 1)) != 0)
         RAISE_ERROR_MSG("gethostname error: %s \n", strerror(errno));
 
     myephostname[EPHOSTNAMELEN-1] = '\0';
@@ -839,7 +854,7 @@ static inline int publish_av_info(struct fabric_info *info)
 #endif
 
     ret = fi_getname((fid_t)shmem_transport_ofi_epfd, epname, &epnamelen);
-    if(ret!=0 || (epnamelen > sizeof(epname))){
+    if (ret!=0 || (epnamelen > sizeof(epname))) {
         RAISE_WARN_STR("fi_getname failed");
         return ret;
     }
@@ -858,7 +873,8 @@ static inline int publish_av_info(struct fabric_info *info)
     return ret;
 }
 
-static inline int populate_av(void)
+static inline
+int populate_av(void)
 {
     int    i, ret = 0;
     char   *alladdrs = NULL;
@@ -879,7 +895,7 @@ static inline int populate_av(void)
 
 #ifdef USE_ON_NODE_COMMS
         shmem_runtime_get(i, "fi_ephostname", ephostname, EPHOSTNAMELEN);
-        if(strncmp(myephostname, ephostname, EPHOSTNAMELEN) == 0) {
+        if (strncmp(myephostname, ephostname, EPHOSTNAMELEN) == 0) {
             SHMEM_SET_RANK_SAME_NODE(i, num_on_node++);
             if (num_on_node > 255) {
                 RAISE_WARN_STR("ERROR: Too many local ranks");
@@ -905,39 +921,41 @@ static inline int populate_av(void)
     return 0;
 }
 
-static inline int allocate_fabric_resources(struct fabric_info *info)
+static inline
+int allocate_fabric_resources(struct fabric_info *info)
 {
     int ret = 0;
     struct fi_av_attr   av_attr = {0};
 
 
-    /* fabric domain: define domain of resources physical and logical*/
+    /* fabric domain: define domain of resources physical and logical */
     ret = fi_fabric(info->p_info->fabric_attr, &shmem_transport_ofi_fabfd, NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("fabric initialization failed");
         return ret;
     }
 
-    /*access domain: define communication resource limits/boundary within fabric domain */
+    /* access domain: define communication resource limits/boundary within
+     * fabric domain */
     ret = fi_domain(shmem_transport_ofi_fabfd, info->p_info,
                     &shmem_transport_ofi_domainfd,NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("domain initialization failed");
         return ret;
     }
 
-    /*transmit context: allocate one transmit context for this SHMEM PE
+    /* transmit context: allocate one transmit context for this SHMEM PE
      * and share it across different multiple endpoints. Since we have only
      * one thread per PE, a single context is sufficient and allows more
      * more PEs/node (i.e. doesn't exhaust contexts)  */
     ret = fi_stx_context(shmem_transport_ofi_domainfd, NULL, /* TODO: fill tx_attr */
                          &shmem_transport_ofi_stx, NULL);
-    if(ret!=0) {
+    if (ret!=0) {
         RAISE_WARN_STR("stx context initialization failed");
         return ret;
     }
 
-    /*AV table set-up for PE mapping*/
+    /* AV table set-up for PE mapping */
 
 #ifdef USE_AV_MAP
     av_attr.type = FI_AV_MAP;
@@ -952,7 +970,7 @@ static inline int allocate_fabric_resources(struct fabric_info *info)
                      &av_attr,
                      &shmem_transport_ofi_avfd,
                      NULL);
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_STR("av open failed");
         return ret;
     }
@@ -960,7 +978,8 @@ static inline int allocate_fabric_resources(struct fabric_info *info)
     return ret;
 }
 
-static inline int query_for_fabric(struct fabric_info *info)
+static inline
+int query_for_fabric(struct fabric_info *info)
 {
     int                 ret = 0;
     struct fi_info      hints = {0};
@@ -1004,7 +1023,7 @@ static inline int query_for_fabric(struct fabric_info *info)
     ep_attr.type              = FI_EP_RDM; /* reliable connectionless */
     hints.fabric_attr         = &fabric_attr;
     tx_attr.op_flags          = FI_DELIVERY_COMPLETE;
-    tx_attr.inject_size       = shmem_transport_ofi_max_buffered_send; /*require provider to support this as a min*/
+    tx_attr.inject_size       = shmem_transport_ofi_max_buffered_send; /* require provider to support this as a min */
     hints.tx_attr             = &tx_attr; /* TODO: fill tx_attr */
     hints.rx_attr             = NULL;
     hints.ep_attr             = &ep_attr;
@@ -1013,7 +1032,7 @@ static inline int query_for_fabric(struct fabric_info *info)
     ret = fi_getinfo( FI_VERSION(OFI_MAJOR_VERSION, OFI_MINOR_VERSION),
                       NULL, NULL, 0, &hints, &(info->fabrics));
 
-    if(ret!=0){
+    if (ret!=0) {
         RAISE_WARN_MSG("OFI transport did not find any valid fabric services (provider=%s)\n",
                        info->prov_name != NULL ? info->prov_name : "<auto>");
         return ret;
@@ -1041,7 +1060,7 @@ static inline int query_for_fabric(struct fabric_info *info)
         info->p_info = info->fabrics;
     }
 
-    if(NULL == info->p_info) {
+    if (NULL == info->p_info) {
         RAISE_WARN_MSG("OFI transport, no valid fabric (prov=%s, fabric=%s, domain=%s)\n",
                        info->prov_name != NULL ? info->prov_name : "<auto>",
                        info->fabric_name != NULL ? info->fabric_name : "<auto>",
@@ -1049,7 +1068,7 @@ static inline int query_for_fabric(struct fabric_info *info)
         return ret;
     }
 
-    if(info->p_info->ep_attr->max_msg_size > 0) {
+    if (info->p_info->ep_attr->max_msg_size > 0) {
         shmem_transport_ofi_max_msg_size = info->p_info->ep_attr->max_msg_size;
     } else {
         RAISE_WARN_STR("OFI provider did not set max_msg_size");
@@ -1089,7 +1108,7 @@ int shmem_transport_init(long eager_size)
     info.domain_name = shmem_util_getenv_str("OFI_DOMAIN");
 
     ret = query_for_fabric(&info);
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     /* The current bounce buffering implementation is only compatible with
@@ -1103,30 +1122,29 @@ int shmem_transport_init(long eager_size)
         shmem_transport_ofi_bounce_buffer_size = eager_size;
     }
 
-    //init LL for NB buffers
     shmem_transport_ofi_bounce_buffers =
         shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t)
                              + eager_size, init_bounce_buffer);
 
     ret = allocate_fabric_resources(&info);
 
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = allocate_endpoints(&info);
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = allocate_cntr_and_cq();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = bind_resources_to_and_enable_ep();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = allocate_recv_cntr_mr();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = publish_mr_info();
@@ -1134,11 +1152,11 @@ int shmem_transport_init(long eager_size)
         return ret;
 
     ret = atomic_limitations_check();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     ret = publish_av_info(&info);
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     fi_freeinfo(info.fabrics);
@@ -1155,7 +1173,7 @@ int shmem_transport_startup(void)
         return ret;
 
     ret = populate_av();
-    if(ret!=0)
+    if (ret!=0)
         return ret;
 
     return 0;
@@ -1228,19 +1246,19 @@ int shmem_transport_fini(void)
         RAISE_ERROR_MSG("Write CQ close failed (%s)\n", fi_strerror(errno));
     }
 
-    if(shmem_transport_ofi_put_cntrfd &&
-		    fi_close(&shmem_transport_ofi_put_cntrfd->fid)){
+    if (shmem_transport_ofi_put_cntrfd &&
+        fi_close(&shmem_transport_ofi_put_cntrfd->fid)) {
         RAISE_ERROR_MSG("INJECT PUT CT close failed (%s)\n", fi_strerror(errno));
     }
 
-    if(shmem_transport_ofi_get_cntrfd &&
-		    fi_close(&shmem_transport_ofi_get_cntrfd->fid)){
+    if (shmem_transport_ofi_get_cntrfd &&
+        fi_close(&shmem_transport_ofi_get_cntrfd->fid)) {
         RAISE_ERROR_MSG("GET CT close failed (%s)\n", fi_strerror(errno));
     }
 
 #ifndef ENABLE_HARD_POLLING
-    if(shmem_transport_ofi_target_cntrfd &&
-		    fi_close(&shmem_transport_ofi_target_cntrfd->fid)){
+    if (shmem_transport_ofi_target_cntrfd &&
+        fi_close(&shmem_transport_ofi_target_cntrfd->fid)) {
         RAISE_ERROR_MSG("Target CT close failed (%s)\n", fi_strerror(errno));
     }
 #endif
diff --git a/src/transport_ofi.h b/src/transport_ofi.h
index 8dc962b1..0996aa9c 100644
--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -142,7 +142,7 @@ void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
 typedef enum fi_datatype shm_internal_datatype_t;
 typedef enum fi_op       shm_internal_op_t;
 
-// Datatypes
+/* Datatypes */
 #define SHM_INTERNAL_FLOAT           FI_FLOAT
 #define SHM_INTERNAL_DOUBLE          FI_DOUBLE
 #define SHM_INTERNAL_LONG_DOUBLE     FI_LONG_DOUBLE
@@ -159,7 +159,7 @@ typedef enum fi_op       shm_internal_op_t;
 #define SHM_INTERNAL_LONG_LONG       DTYPE_LONG_LONG
 #define SHM_INTERNAL_FORTRAN_INTEGER DTYPE_FORTRAN_INTEGER
 
- // Operations
+/* Operations */
 #define SHM_INTERNAL_BAND            FI_BAND
 #define SHM_INTERNAL_BOR             FI_BOR
 #define SHM_INTERNAL_BXOR            FI_BXOR
@@ -222,7 +222,7 @@ void shmem_transport_ofi_drain_cq(void)
     do {
         ret = fi_cq_read(shmem_transport_ofi_put_nb_cqfd,
                          (void *)&buf, 1);
-		/*error cases*/
+        /* Error cases */
         if (ret < 0 && ret != -FI_EAGAIN ) {
             if(ret == -FI_EAVAIL) {
                 struct fi_cq_err_entry e = {0};
@@ -258,14 +258,16 @@ void shmem_transport_ofi_drain_cq(void)
 
 }
 
-static inline shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const void *source, const size_t len)
+static inline
+shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const void *source,
+                                                           const size_t len)
 {
     shmem_transport_ofi_bounce_buffer_t *buff;
 
     buff = (shmem_transport_ofi_bounce_buffer_t*)
         shmem_free_list_alloc(shmem_transport_ofi_bounce_buffers);
 
-	/*if LL empty = error, should've been avoided with EQ drain*/
+    /* if LL empty = error, should've been avoided with EQ drain */
     if (NULL == buff)
         RAISE_ERROR_STR("Error allocating bounce buffer");
 
@@ -276,7 +278,8 @@ static inline shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const v
     return buff;
 }
 
-static inline void shmem_transport_put_quiet(void)
+static inline
+void shmem_transport_put_quiet(void)
 {
     /* wait until all outstanding queue operations have completed */
     while (shmem_transport_ofi_pending_cq_count) {
@@ -310,11 +313,11 @@ static inline void shmem_transport_put_quiet(void)
 #endif
 }
 
-static inline int shmem_transport_quiet(void)
+static inline
+int shmem_transport_quiet(void)
 {
 
     shmem_transport_put_quiet();
-
     shmem_transport_get_wait();
 
     return 0;
@@ -322,8 +325,7 @@ static inline int shmem_transport_quiet(void)
 
 
 static inline
-int
-shmem_transport_fence(void)
+int shmem_transport_fence(void)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
     /*unordered network model*/
@@ -334,8 +336,9 @@ shmem_transport_fence(void)
 
 }
 
-/*RM requires polling until space is available*/
-static inline int try_again(const int ret, uint64_t *polled) {
+/* RM requires polling until space is available */
+static inline
+int try_again(const int ret, uint64_t *polled) {
 
     if (ret) {
         if (ret == -FI_EAGAIN) {
@@ -352,8 +355,8 @@ static inline int try_again(const int ret, uint64_t *polled) {
 }
 
 static inline
-void
-shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
+void shmem_transport_put_small(void *target, const void *source, size_t len,
+                               int pe)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -377,13 +380,14 @@ shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
     } while(try_again(ret,&polled));
 
     shmem_internal_assert(ret == 0);
-	/* automatically get local completion but need remote completion for fence/quiet*/
+    /* automatically get local completion but need remote completion for
+     * fence/quiet*/
     shmem_transport_ofi_pending_put_counter++;
 }
 
 static inline
-void
-shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int pe)
+void shmem_transport_ofi_put_large(void *target, const void *source,
+                                   size_t len, int pe)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -400,7 +404,8 @@ shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int
     /* operation generates counting events and must be completed by
      * quiet. */
     while (frag_source < ((uint8_t *) source) + len) {
-        frag_len = MIN(shmem_transport_ofi_max_msg_size, (size_t) (((uint8_t *) source) + len - frag_source));
+        frag_len = MIN(shmem_transport_ofi_max_msg_size,
+                       (size_t) (((uint8_t *) source) + len - frag_source));
         polled = 0;
 
         do {
@@ -418,8 +423,7 @@ shmem_transport_ofi_put_large(void *target, const void *source, size_t len, int
 }
 
 static inline
-void
-shmem_transport_put_nb(void *target, const void *source, size_t len,
+void shmem_transport_put_nb(void *target, const void *source, size_t len,
                             int pe, long *completion)
 {
     int ret = 0;
@@ -456,10 +460,9 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
     }
 }
 
-/*compatibility with Portals transport*/
+/* compatibility with Portals transport */
 static inline
-void
-shmem_transport_put_wait(long *completion) {
+void shmem_transport_put_wait(long *completion) {
 
     shmem_internal_assert((*completion) >= 0);
 
@@ -470,8 +473,8 @@ shmem_transport_put_wait(long *completion) {
 }
 
 static inline
-void
-shmem_transport_put_nbi(void *target, const void *source, size_t len, int pe)
+void shmem_transport_put_nbi(void *target, const void *source, size_t len,
+                             int pe)
 {
     if (len <= shmem_transport_ofi_max_buffered_send) {
 
@@ -485,8 +488,7 @@ shmem_transport_put_nbi(void *target, const void *source, size_t len, int pe)
 
 
 static inline
-void
-shmem_transport_get(void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(void *target, const void *source, size_t len, int pe)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -516,7 +518,8 @@ shmem_transport_get(void *target, const void *source, size_t len, int pe)
         size_t frag_len = len;
 
         while (frag_target < ((uint8_t *) target) + len) {
-                frag_len = MIN(shmem_transport_ofi_max_msg_size, (size_t) (((uint8_t *) target) + len - frag_target));
+            frag_len = MIN(shmem_transport_ofi_max_msg_size,
+                           (size_t) (((uint8_t *) target) + len - frag_target));
             polled = 0;
 
             do {
@@ -536,8 +539,7 @@ shmem_transport_get(void *target, const void *source, size_t len, int pe)
 
 
 static inline
-void
-shmem_transport_get_wait(void)
+void shmem_transport_get_wait(void)
 {
     /* wait for get counter to meet outstanding count value */
 #ifdef ENABLE_COMPLETION_POLLING
@@ -568,8 +570,7 @@ shmem_transport_get_wait(void)
 
 
 static inline
-void
-shmem_transport_swap(void *target, const void *source, void *dest,
+void shmem_transport_swap(void *target, const void *source, void *dest,
                           size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -603,8 +604,7 @@ shmem_transport_swap(void *target, const void *source, void *dest,
 
 
 static inline
-void
-shmem_transport_cswap(void *target, const void *source, void *dest,
+void shmem_transport_cswap(void *target, const void *source, void *dest,
                            const void *operand, size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -640,8 +640,7 @@ shmem_transport_cswap(void *target, const void *source, void *dest,
 
 
 static inline
-void
-shmem_transport_mswap(void *target, const void *source, void *dest,
+void shmem_transport_mswap(void *target, const void *source, void *dest,
                            const void *mask, size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -677,8 +676,7 @@ shmem_transport_mswap(void *target, const void *source, void *dest,
 
 
 static inline
-void
-shmem_transport_atomic_small(void *target, const void *source, size_t len,
+void shmem_transport_atomic_small(void *target, const void *source, size_t len,
                                   int pe, int op, int datatype)
 {
     int ret = 0;
@@ -707,8 +705,7 @@ shmem_transport_atomic_small(void *target, const void *source, size_t len,
 
 
 static inline
-void
-shmem_transport_atomic_set(void *target, const void *source, size_t len,
+void shmem_transport_atomic_set(void *target, const void *source, size_t len,
                                 int pe, int datatype)
 {
     int ret = 0;
@@ -737,8 +734,7 @@ shmem_transport_atomic_set(void *target, const void *source, size_t len,
 
 
 static inline
-void
-shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
+void shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
                                   int pe, int datatype)
 {
     int ret = 0;
@@ -771,9 +767,8 @@ shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
 
 
 static inline
-void
-shmem_transport_atomic_nb(void *target, const void *source, size_t full_len,
-                                   int pe, int op, int datatype,
+void shmem_transport_atomic_nb(void *target, const void *source,
+                               size_t full_len, int pe, int op, int datatype,
                                long *completion)
 {
     int ret = 0;
@@ -805,7 +800,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t full_len,
         do {
             ret = fi_inject_atomic(shmem_transport_ofi_cntr_epfd,
                                    source,
-                      		len, //count
+                                   len,
                                    GET_DEST(dst),
                                    (uint64_t) addr,
                                    key,
@@ -868,8 +863,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t full_len,
 
 
 static inline
-void
-shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
+void shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
                                   size_t len, int pe, int op, int datatype)
 {
     int ret = 0;
@@ -915,9 +909,9 @@ int shmem_transport_atomic_supported(shm_internal_op_t op,
 
 
 static inline
-void
-shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target,
-                              const void *source, size_t len, int pe, long *completion)
+void shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target,
+                               const void *source, size_t len, int pe,
+                               long *completion)
 {
     RAISE_ERROR_STR("OFI transport does not currently support CT operations");
 }
```