### PR TITLE
Fix asymmetric allocation bug in GUPS

### DIFF
--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -261,10 +261,10 @@ UpdateTable(uint64_t *Table,
             uint64_t MinLocalTableSize,
             uint64_t Top,
             int Remainder,
-            int64_t niterate,
+            uint64_t niterate,
             int use_lock)
 {
-  int64_t iterate;
+  uint64_t iterate;
   int index;
   uint64_t ran, remote_val, global_offset;
   int remote_pe;
@@ -307,7 +307,7 @@ SHMEMRandomAccess(void)
   int NumProcs, MyProc;
   int Remainder;            /* Number of processors with (LocalTableSize + 1) entries */
   uint64_t Top;               /* Number of table entries in top of Table */
-  int64_t LocalTableSize;    /* Local table width */
+  uint64_t LocalTableSize;    /* Local table width */
   uint64_t MinLocalTableSize; /* Integer ratio TableSize/NumProcs */
   uint64_t logTableSize, TableSize;
 

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -319,7 +319,7 @@ SHMEMRandomAccess(void)
   uint64_t NumUpdates_Default; /* Number of updates to table (suggested: 4x number of table entries) */
   uint64_t NumUpdates;  /* actual number of updates to table - may be smaller than
                        * NumUpdates_Default due to execution time bounds */
-  int64_t ProcNumUpdates; /* number of updates per processor */
+  uint64_t ProcNumUpdates; /* number of updates per processor */
 
   static long pSync_bcast[SHMEM_BCAST_SYNC_SIZE];
   static long long int llpWrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -389,13 +389,13 @@ SHMEMRandomAccess(void)
 
 
   sAbort = 0;
-  HPCC_PELock = (long *) shmem_malloc(sizeof(long) * NumProcs);
-  if (! HPCC_PELock) sAbort = 1;
-
   /* Ensure the allocation size is symmetric */
   HPCC_Table = shmem_malloc((Remainder > 0 ? (MinLocalTableSize + 1) : LocalTableSize)
                             * sizeof(uint64_t));
   if (! HPCC_Table) sAbort = 1;
+
+  HPCC_PELock = (long *) shmem_malloc(sizeof(long) * NumProcs);
+  if (! HPCC_PELock) sAbort = 1;
 
   for (i = 0; i < NumProcs; i++)
       HPCC_PELock[i] = 0;

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -389,11 +389,13 @@ SHMEMRandomAccess(void)
 
 
   sAbort = 0;
-  HPCC_Table = shmem_malloc(LocalTableSize * sizeof(uint64_t));
-  if (! HPCC_Table) sAbort = 1;
-
   HPCC_PELock = (long *) shmem_malloc(sizeof(long) * NumProcs);
   if (! HPCC_PELock) sAbort = 1;
+
+  /* Table sizes are not always symmetric.  The table allocation must be the
+   * last call to shmem_malloc. */
+  HPCC_Table = shmem_malloc(LocalTableSize * sizeof(uint64_t));
+  if (! HPCC_Table) sAbort = 1;
 
   for (i = 0; i < NumProcs; i++)
       HPCC_PELock[i] = 0;

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -392,9 +392,9 @@ SHMEMRandomAccess(void)
   HPCC_PELock = (long *) shmem_malloc(sizeof(long) * NumProcs);
   if (! HPCC_PELock) sAbort = 1;
 
-  /* Table sizes are not always symmetric.  The table allocation must be the
-   * last call to shmem_malloc. */
-  HPCC_Table = shmem_malloc(LocalTableSize * sizeof(uint64_t));
+  /* Ensure the allocation size is symmetric */
+  HPCC_Table = shmem_malloc((Remainder > 0 ? (MinLocalTableSize + 1) : LocalTableSize)
+                            * sizeof(uint64_t));
   if (! HPCC_Table) sAbort = 1;
 
   for (i = 0; i < NumProcs; i++)

--- a/test/unit/bcast.c
+++ b/test/unit/bcast.c
@@ -68,6 +68,12 @@ main(int argc, char* argv[])
         return 0;
     }
 
+    if (sizeof(long) != 8) {
+        printf("Test assumes 64-bit long (%zd)\n", sizeof(long));
+        shmem_global_exit(1);
+        return 0;
+    }
+
     if ((pgm=strrchr(argv[0],'/'))) {
         pgm++;
     } else {


### PR DESCRIPTION
OpenSHMEM requires that any asymmetric allocation must be the last call to ```shmem_malloc```.  Since the Table allocation in GUPS can be asymmetric (as reported in #384), ensure it's the last symmetric allocation call.

Closes #384