### PR TITLE
Pr/complex test fix

### DIFF
--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -108,11 +108,11 @@ endif
 if HAVE_FORTRAN
 check_PROGRAMS += \
      hello_f \
-     complex_reductions_f \
      shmem_info_f
 
 if !HAVE_LONG_FORTRAN_HEADER
 check_PROGRAMS += \
+     complex_reductions_f \
      set_fetch_f
 endif
 endif


### PR DESCRIPTION
Don't run complex Fortran test if the long header enabled.