### PR TITLE
uni-dir perf suite addition: target put/get with variable PE sets

### DIFF
--- a/test/performance/shmem_perf_suite/Makefile.am
+++ b/test/performance/shmem_perf_suite/Makefile.am
@@ -30,7 +30,8 @@ noinst_HEADERS = \
 	int_element_latency.h \
 	bw_common.h \
 	uni_dir.h \
-	bi_dir.h
+	bi_dir.h \
+	target_put.h
 
 if ENABLE_LENGTHY_TESTS
 TESTS = $(check_PROGRAMS)

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -174,8 +174,9 @@ red_PE_set static inline validation_set(perf_metrics_t my_info, int *nPEs)
             *nPEs = my_info.sztarget;
             return SECOND_HALF;
         } else {
-            fprintf(stderr, "Warning: you are getting data from a node that " \
+            fprintf(stderr, "Warning: you are getting data from a node that "
                 "wasn't a part of the perf set \n ");
+	    return 0;
         }
     } else {
         assert(my_info.cstyle == COMM_INCAST);
@@ -264,19 +265,19 @@ void static command_line_arg_check(int argc, char *argv[],
 
     if (error) {
         if (metric_info->my_node == 0) {
-            fprintf(stderr, "Usage: \n[-s start_length] [-e end_length] "\
-                    ": lengths should be a power of two \n" \
-                    "[-n trials (must be greater than 2*warmup (default: x => 100))] \n"\
-                    "[-p warm-up (see trials for value restriction)] \n"\
-                    "[-w window size - iterations between completion, cannot use with -t] \n"\
-                    "[-k (kilobytes/second)] [-b (bytes/second)] \n"\
-                    "[-v (validate data stream)] \n"\
-                    "[-t output data for target side (default is initiator,"\
-                    " only use with put_bw),\n cannot be used in conjunction "\
-                    "with validate, special sizes used, \ntrials" \
-                    " + warmup * sizes (8/4KB) <= max length \n" \
-                    "[-r number of nodes at target, use only with -t] \n" \
-                    "[-l number of nodes at initiator, use only with -t, " \
+            fprintf(stderr, "Usage: \n[-s start_length] [-e end_length] "
+                    ": lengths should be a power of two \n"
+                    "[-n trials (must be greater than 2*warmup (default: x => 100))] \n"
+                    "[-p warm-up (see trials for value restriction)] \n"
+                    "[-w window size - iterations between completion, cannot use with -t] \n"
+                    "[-k (kilobytes/second)] [-b (bytes/second)] \n"
+                    "[-v (validate data stream)] \n"
+                    "[-t output data for target side (default is initiator,"
+                    " only use with put_bw),\n cannot be used in conjunction "
+                    "with validate, special sizes used, \ntrials"
+                    " + warmup * sizes (8/4KB) <= max length \n"
+                    "[-r number of nodes at target, use only with -t] \n"
+                    "[-l number of nodes at initiator, use only with -t, "
                     "l/r cannot be used together] \n");
         }
 #ifndef VERSION_1_0
@@ -313,7 +314,7 @@ void static print_atomic_results_header(perf_metrics_t metric_info) {
         printf("using pairwise communication style\n");
     }
 
-    printf("\nOperation           %s           "\
+    printf("\nOperation           %s           "
             "Message Rate%17sLatency\n", metric_info.bw_type, " ");
 
     if (metric_info.unit == MB) {
@@ -331,12 +332,12 @@ void static print_atomic_results_header(perf_metrics_t metric_info) {
 }
 
 void static print_results_header(perf_metrics_t metric_info) {
-    printf("\nResults for %d PEs %lu trials with window size %lu "\
-            "max message size %lu with multiple of %lu increments, "\
+    printf("\nResults for %d PEs %lu trials with window size %lu "
+            "max message size %lu with multiple of %lu increments, "
             "\ntargeting %d remote PEs initiated from %d PEs\n", metric_info.num_pes,
             metric_info.trials, metric_info.window_size, metric_info.max_len,
             metric_info.size_inc, metric_info.sztarget, metric_info.szinitiator);
-    printf("\nLength           %s           "\
+    printf("\nLength           %s           "
             "Message Rate\n", metric_info.bw_type);
 
     printf("in bytes         ");

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -227,9 +227,11 @@ void static command_line_arg_check(int argc, char *argv[],
             break;
         case 'w':
             metric_info->window_size = strtoul(optarg, (char **)NULL, 0);
+            if(metric_info->target_data) error = true;
             break;
         case 't':
             metric_info->target_data = true;
+            metric_info->window_size = 1;
             if(metric_info->validate) error = true;
             break;
         case 'r':
@@ -265,7 +267,7 @@ void static command_line_arg_check(int argc, char *argv[],
                     ": lengths should be a power of two \n" \
                     "[-n trials (must be greater than 2*warmup (default: x => 100))] \n"\
                     "[-p warm-up (see trials for value restriction)] \n"\
-                    "[-w window size - iterations between completion] \n"\
+                    "[-w window size - iterations between completion, cannot use with -t] \n"\
                     "[-k (kilobytes/second)] [-b (bytes/second)] \n"\
                     "[-v (validate data stream)] \n"\
                     "[-t output data for target side (default is initiator,"\

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -139,9 +139,8 @@ int static inline partner_node(perf_metrics_t my_info)
     if(my_info.cstyle == COMM_PAIRWISE) {
         int pairs = my_info.midpt;
 
-        return (my_info.my_node < pairs ?
-            ((my_info.my_node + pairs) % (my_info.sztarget + pairs)) :
-            (my_info.my_node - pairs) % my_info.szinitiator);
+        return (my_info.my_node < pairs ? (my_info.my_node + pairs) :
+            (my_info.my_node - pairs));
     } else {
         assert(my_info.cstyle == COMM_INCAST);
         return INCAST_PE;
@@ -237,12 +236,14 @@ void static command_line_arg_check(int argc, char *argv[],
         case 'r':
             metric_info->sztarget = strtoul(optarg, (char **)NULL, 0);
             if(metric_info->sztarget > metric_info->midpt ||
-                metric_info->szinitiator < metric_info->midpt) error = true;
+                metric_info->szinitiator < metric_info->midpt ||
+                !metric_info->target_data) error = true;
             break;
         case 'l':
             metric_info->szinitiator = strtoul(optarg, (char **)NULL, 0);
             if(metric_info->szinitiator > metric_info->midpt ||
-                metric_info->sztarget < metric_info->midpt) error = true;
+                metric_info->sztarget < metric_info->midpt ||
+                !metric_info->target_data) error = true;
             break;
         default:
             error = true;
@@ -274,8 +275,9 @@ void static command_line_arg_check(int argc, char *argv[],
                     " only use with put_bw),\n cannot be used in conjunction "\
                     "with validate, special sizes used, \ntrials" \
                     " + warmup * sizes (8/4KB) <= max length \n" \
-                    "[-r number of nodes at target] \n" \
-                    "[-l number of nodes at initiator] \n");
+                    "[-r number of nodes at target, use only with -t] \n" \
+                    "[-l number of nodes at initiator, use only with -t, " \
+                    "l/r cannot be used together] \n");
         }
 #ifndef VERSION_1_0
         shmem_finalize();

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -56,6 +56,8 @@ typedef enum {
 } bw_type;
 
 typedef enum {
+    STYLE_PUT,
+    STYLE_GET,
     STYLE_RMA,
     STYLE_ATOMIC
 } bw_style;
@@ -491,7 +493,8 @@ void static inline uni_dir_bw_test_and_output(perf_metrics_t metric_info) {
     shmem_barrier_all();
 
     if(metric_info.validate) {
-        if(streaming_node(metric_info) && metric_info.bwstyle != STYLE_ATOMIC) {
+        if((streaming_node(metric_info) && metric_info.bwstyle == STYLE_GET) ||
+            (!streaming_node(metric_info) && metric_info.bwstyle == STYLE_PUT)) {
             validate_recv(metric_info.dest, metric_info.max_len, partner_pe);
         } else if(metric_info.bwstyle == STYLE_ATOMIC) {
             validate_atomics(metric_info);
@@ -542,8 +545,11 @@ void static inline bi_dir_init(perf_metrics_t *metric_info, int argc,
 }
 
 void static inline uni_dir_init(perf_metrics_t *metric_info, int argc,
-                                char *argv[]) {
+                                char *argv[], bw_style bwstyl) {
     bw_init_data_stream(metric_info, argc, argv);
+
+    /* uni-dir validate needs to know if its a put or get */
+    metric_info->bwstyle = bwstyl;
 
     if(metric_info->num_pes != 1)
         only_even_PEs_check(metric_info->my_node, metric_info->num_pes);
@@ -574,11 +580,11 @@ void static inline bi_dir_bw_main(int argc, char *argv[]) {
 
 } /*main() */
 
-void static inline uni_dir_bw_main(int argc, char *argv[]) {
+void static inline uni_dir_bw_main(int argc, char *argv[], bw_style bwstyl) {
 
     perf_metrics_t metric_info;
 
-    uni_dir_init(&metric_info, argc, argv);
+    uni_dir_init(&metric_info, argc, argv, bwstyl);
 
     uni_dir_bw_test_and_output(metric_info);
 

--- a/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_atomics_perf.c
@@ -150,7 +150,6 @@ static inline void bw_set_metric_info_len(perf_metrics_t *metric_info)
                                         sizeof(long long)};
     metric_info->cstyle = ATOMIC_COMM_STYLE;
     metric_info->type = UNI_DIR;
-    metric_info->bwstyle = STYLE_ATOMIC;
     int snode = streaming_node(*metric_info);
     atomic_op_type op_type = OP_ADD;
 
@@ -189,7 +188,7 @@ void uni_dir_bw(int len, perf_metrics_t *metric_info)
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_ATOMIC);
 
     return 0;
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_get_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_get_perf.c
@@ -48,13 +48,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc,argv);
+    uni_dir_bw_main(argc,argv, STYLE_GET);
 
     return 0;
 }  /* end of main() */
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, streaming_node(*metric_info));
-}

--- a/test/performance/shmem_perf_suite/shmem_bw_nb_get_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_nb_get_perf.c
@@ -45,13 +45,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc,argv);
+    uni_dir_bw_main(argc,argv, STYLE_GET);
 
     return 0;
 }  /* end of main() */
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, streaming_node(*metric_info));
-}

--- a/test/performance/shmem_perf_suite/shmem_bw_nb_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_nb_put_perf.c
@@ -45,13 +45,7 @@
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_PUT);
 
     return 0;
-}
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -37,21 +37,10 @@
 */
 #include <bw_common.h>
 #include <uni_dir.h>
-#include <target_put.h>
 
 int main(int argc, char *argv[])
 {
-    uni_dir_bw_main(argc, argv);
+    uni_dir_bw_main(argc, argv, STYLE_PUT);
 
     return 0;
-}
-
-void uni_dir_bw(int len, perf_metrics_t *metric_info)
-{
-    if(metric_info->target_data) {
-        target_bw_itr(len, metric_info, !streaming_node(*metric_info));
-        return;
-    }
-
-    uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -35,9 +35,9 @@
 **
 **NOTE: this test assumes correctness of reduction algorithm
 */
-
 #include <bw_common.h>
 #include <uni_dir.h>
+#include <target_put.h>
 
 int main(int argc, char *argv[])
 {
@@ -46,74 +46,7 @@ int main(int argc, char *argv[])
     return 0;
 }
 
-void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, int start_pe)
-{
-    double start = 0.0, end = 0.0;
-    int i = 0, j = 0;
-    int dest = partner_node(metric_info);
-    int snode = (metric_info.num_pes != 1)? streaming_node : true;
-    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
-    int result[2] = {dest, dest};
-    int init[2] = {metric_info.my_node, metric_info.my_node};
-    long *end_dst_ptr = (long *)(metric_info.dest + (final_len));
-
-    assert(sizeof(int)*2 == sizeof(long));
-
-    shmem_barrier_all();
-
-    /* reset pointer we will be waiting on */
-    if(!snode)
-        *(end_dst_ptr) = *((long *)init);
-
-    shmem_barrier_all();
-    start = perf_shmemx_wtime();
-
-    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
-    if(!snode) {
-        shmem_long_wait_until(end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
-        end = perf_shmemx_wtime();
-
-        if(start_pe == metric_info.my_node)
-            printf("target: \n");
-
-        calc_and_print_results((end - start), len, metric_info);
-    } else if(snode) {
-        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
-            for(j = 0; j < metric_info.window_size; j++)
-                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
-
-            shmem_quiet();
-        }
-        end = perf_shmemx_wtime();
-    }
-
-    shmem_barrier_all();
-
-    if(start_pe == metric_info.my_node && snode)
-        printf("initator: \n");
-    if(snode)
-        calc_and_print_results((end - start), len, metric_info);
-}
-
-void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
-{
-    int nPEs = 0, stride = 0, start_pe = 0;
-    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
-
-    target_data_uni_bw(len, *metric_info, snode, start_pe);
-
-    metric_info->start_len = TARGET_SZ_MAX;
-    len = TARGET_SZ_MAX;
-
-    target_data_uni_bw(len, *metric_info, snode, start_pe);
-
-    /* stopping upper layer from iterating, we are done */
-    metric_info->max_len = TARGET_SZ_MIN;
-}
-
-
-void
-uni_dir_bw(int len, perf_metrics_t *metric_info)
+void uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
     if(metric_info->target_data) {
         target_bw_itr(len, metric_info, !streaming_node(*metric_info));

--- a/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
+++ b/test/performance/shmem_perf_suite/shmem_bw_put_perf.c
@@ -46,8 +46,79 @@ int main(int argc, char *argv[])
     return 0;
 }
 
+void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, int start_pe)
+{
+    double start = 0.0, end = 0.0;
+    int i = 0, j = 0;
+    int dest = partner_node(metric_info);
+    int snode = (metric_info.num_pes != 1)? streaming_node : true;
+    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
+    int result[2] = {dest, dest};
+    int init[2] = {metric_info.my_node, metric_info.my_node};
+    long *end_dst_ptr = (long *)(metric_info.dest + (final_len));
+
+    assert(sizeof(int)*2 == sizeof(long));
+
+    shmem_barrier_all();
+
+    /* reset pointer we will be waiting on */
+    if(!snode)
+        *(end_dst_ptr) = *((long *)init);
+
+    shmem_barrier_all();
+    start = perf_shmemx_wtime();
+
+    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
+    if(!snode) {
+        shmem_long_wait_until(end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        end = perf_shmemx_wtime();
+
+        if(start_pe == metric_info.my_node)
+            printf("target: \n");
+
+        calc_and_print_results((end - start), len, metric_info);
+    } else if(snode) {
+        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
+            for(j = 0; j < metric_info.window_size; j++)
+                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
+
+            shmem_quiet();
+        }
+        end = perf_shmemx_wtime();
+    }
+
+    shmem_barrier_all();
+
+    if(start_pe == metric_info.my_node && snode)
+        printf("initator: \n");
+    if(snode)
+        calc_and_print_results((end - start), len, metric_info);
+}
+
+void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
+{
+    int nPEs = 0, stride = 0, start_pe = 0;
+    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    metric_info->start_len = TARGET_SZ_MAX;
+    len = TARGET_SZ_MAX;
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    /* stopping upper layer from iterating, we are done */
+    metric_info->max_len = TARGET_SZ_MIN;
+}
+
+
 void
 uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
+    if(metric_info->target_data) {
+        target_bw_itr(len, metric_info, !streaming_node(*metric_info));
+        return;
+    }
+
     uni_bw(len, metric_info, !streaming_node(*metric_info));
 }

--- a/test/performance/shmem_perf_suite/target_put.h
+++ b/test/performance/shmem_perf_suite/target_put.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+void static inline target_data_uni_bw(int len, perf_metrics_t metric_info, int streaming_node, uint32_t start_pe)
+{
+    double start = 0.0, end = 0.0;
+    int i = 0, j = 0;
+    uint32_t dest = partner_node(metric_info);
+    int snode = (metric_info.num_pes != 1)? streaming_node : true;
+    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
+    uint32_t result[2] = {dest, dest};
+    uint64_t *end_dst_ptr = (uint64_t *)(metric_info.dest + (final_len));
+
+    shmem_barrier_all();
+
+    /* reset pointer we will be waiting on */
+    if(!snode)
+        *(end_dst_ptr) = 0;
+
+    shmem_barrier_all();
+    start = perf_shmemx_wtime();
+
+    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
+    if(!snode) {
+        shmem_long_wait_until((long *)end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        end = perf_shmemx_wtime();
+
+        if(start_pe == metric_info.my_node)
+            printf("target: \n");
+
+        calc_and_print_results((end - start), len, metric_info);
+    } else if(snode) {
+        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
+            for(j = 0; j < metric_info.window_size; j++)
+                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
+
+            shmem_quiet();
+        }
+        end = perf_shmemx_wtime();
+    }
+
+    shmem_barrier_all();
+
+    if(start_pe == metric_info.my_node && snode)
+        printf("initator: \n");
+    if(snode)
+        calc_and_print_results((end - start), len, metric_info);
+}
+
+void static inline target_bw_itr(int len, perf_metrics_t *metric_info, int snode)
+{
+    int stride = 0;
+    uint32_t start_pe = 0, nPEs = 0;
+    PE_set_used_adjustments(&nPEs, &stride, &start_pe, *metric_info);
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    metric_info->start_len = TARGET_SZ_MAX;
+    len = TARGET_SZ_MAX;
+
+    target_data_uni_bw(len, *metric_info, snode, start_pe);
+
+    /* stopping upper layer from iterating, we are done */
+    metric_info->max_len = TARGET_SZ_MIN;
+}

--- a/test/performance/shmem_perf_suite/target_put.h
+++ b/test/performance/shmem_perf_suite/target_put.h
@@ -25,43 +25,84 @@
  * SOFTWARE.
  */
 
+int get_size_of_side(perf_metrics_t my_info) {
+    if(my_info.my_node < my_info.midpt)
+        return my_info.szinitiator;
+    else
+        return my_info.sztarget;
+}
+
+int get_num_partners(perf_metrics_t my_info) {
+    int unused_PEs = 0, num_partners = 0, num_xtra_partners = 0;
+    int active_PEs = get_size_of_side(my_info);
+
+    if(active_PEs == my_info.midpt)
+        return 1;
+
+    unused_PEs = my_info.midpt - active_PEs;
+    num_partners = my_info.midpt / active_PEs;
+    num_xtra_partners = unused_PEs % active_PEs;
+
+    if((my_info.my_node % my_info.midpt) < num_xtra_partners)
+        num_partners++;
+
+    return num_partners;
+}
+
+/* target only needs to know num of partners */
+int *get_initiators_partners(perf_metrics_t my_info, int num_partners) {
+    int node_to_shadow = my_info.my_node;
+    int i = 0;
+    int *partner_nodes = NULL;
+
+    assert(my_info.cstyle == COMM_PAIRWISE && !target_node(my_info));
+    if(num_partners < 1)
+        return partner_nodes;
+
+    partner_nodes = (int *) malloc(sizeof(int) * num_partners);
+    assert(partner_nodes);
+
+    for(i = 0; i < num_partners; i++) {
+        partner_nodes[i] = ((node_to_shadow % my_info.sztarget) + my_info.midpt);
+        node_to_shadow += my_info.szinitiator;
+    }
+
+    return partner_nodes;
+}
+
 void static inline target_data_uni_bw(int len, perf_metrics_t metric_info)
 {
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
-    uint32_t dest = partner_node(metric_info);
     int snode = (metric_info.num_pes != 1)? streaming_node(metric_info) : true;
-    size_t final_len = (metric_info.trials + metric_info.warmup - 1) * len;
-    uint32_t result[2] = {dest, dest};
-    uint32_t init[2] = {metric_info.my_node, metric_info.my_node};
-    uint64_t *end_dst_ptr = (uint64_t *)(metric_info.dest + (final_len));
-
-    shmem_barrier_all();
-
-    /* reset pointer we will be waiting on */
-    if(target_node(metric_info))
-        *(end_dst_ptr) = (*(long *)init);
+    int num_partners = get_num_partners(metric_info);
+    static int completion_signal = 0;
+    int *my_PE_partners = (snode ?
+        get_initiators_partners(metric_info, num_partners): NULL);
 
     shmem_barrier_all();
     start = perf_shmemx_wtime();
 
-    /* wait on 8 bytes of final chunk, dst was filled with my_node ints */
     if(target_node(metric_info)) {
-        shmem_long_wait_until((long *)end_dst_ptr, SHMEM_CMP_EQ, *((long *)result));
+        shmem_int_wait_until(&completion_signal, SHMEM_CMP_EQ, num_partners);
         end = perf_shmemx_wtime();
 
         calc_and_print_results((end - start), len, metric_info);
     } else if(snode) {
-        for (i = 0; i < metric_info.trials + metric_info.warmup; i++) {
-            for(j = 0; j < metric_info.window_size; j++)
-                shmem_putmem((metric_info.dest + (len*i)), (metric_info.src + (len*i)), len, dest);
-
-            shmem_quiet();
+        for (i = 0; i < num_partners; i++) {
+            for(j = 0; j < metric_info.trials + metric_info.warmup; j++) {
+                shmem_putmem(metric_info.dest, metric_info.src, len, my_PE_partners[i]);
+                shmem_quiet();
+            }
+            shmem_int_inc(&completion_signal, my_PE_partners[i]);
         }
         end = perf_shmemx_wtime();
+        free(my_PE_partners);
     }
 
     shmem_barrier_all();
+    completion_signal = 0;
+
     if(snode)
         calc_and_print_results((end - start), len, metric_info);
 }

--- a/test/performance/shmem_perf_suite/target_put.h
+++ b/test/performance/shmem_perf_suite/target_put.h
@@ -25,14 +25,14 @@
  * SOFTWARE.
  */
 
-int get_size_of_side(perf_metrics_t my_info) {
+int static inline get_size_of_side(perf_metrics_t my_info) {
     if(my_info.my_node < my_info.midpt)
         return my_info.szinitiator;
     else
         return my_info.sztarget;
 }
 
-int get_num_partners(perf_metrics_t my_info) {
+int static inline get_num_partners(perf_metrics_t my_info) {
     int unused_PEs = 0, num_partners = 0, num_xtra_partners = 0;
     int active_PEs = get_size_of_side(my_info);
 
@@ -50,7 +50,7 @@ int get_num_partners(perf_metrics_t my_info) {
 }
 
 /* target only needs to know num of partners */
-int *get_initiators_partners(perf_metrics_t my_info, int num_partners) {
+int static inline *get_initiators_partners(perf_metrics_t my_info, int num_partners) {
     int node_to_shadow = my_info.my_node;
     int i = 0;
     int *partner_nodes = NULL;

--- a/test/performance/shmem_perf_suite/uni_dir.h
+++ b/test/performance/shmem_perf_suite/uni_dir.h
@@ -33,7 +33,7 @@ void inline uni_dir_bw(int len, perf_metrics_t *metric_info)
     int dest = partner_node(*metric_info);
     int snode = (metric_info->num_pes != 1)? streaming_node(*metric_info) : true;
 
-    if(metric_info->target_data && metric_info->bwstyle == STYLE_PUT) {
+    if(metric_info->target_data) {
         target_bw_itr(len, metric_info);
         return;
     }

--- a/test/performance/shmem_perf_suite/uni_dir.h
+++ b/test/performance/shmem_perf_suite/uni_dir.h
@@ -24,13 +24,19 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#include <target_put.h>
 
-void static inline uni_bw(int len, perf_metrics_t *metric_info, int streaming_node)
+void inline uni_dir_bw(int len, perf_metrics_t *metric_info)
 {
     double start = 0.0, end = 0.0;
     int i = 0, j = 0;
     int dest = partner_node(*metric_info);
-    int snode = (metric_info->num_pes != 1)? streaming_node : true;
+    int snode = (metric_info->num_pes != 1)? streaming_node(*metric_info) : true;
+
+    if(metric_info->target_data && metric_info->bwstyle == STYLE_PUT) {
+        target_bw_itr(len, metric_info);
+        return;
+    }
 
     shmem_barrier_all();
 


### PR DESCRIPTION
This test suite adds the following input variables: -t, -l, -r

-t:  enables timing of the target side of a transfer (will output initiator timing as well, side-by-side)
-l: PEs stream across two nodes for this suite, the "left side" is the initiator side, you can reduce the PEs streaming on this side, X <= PPN 
-r: same ideas as above: "right side" is the target side of the transfer stream, you can reduce the PEs streaming on this side, X <= PPN 

feature notes: 
-only for sizes 8bytes and 4KB
-you cannot use -l/r together, if you want less on both sides, you should launch less
-window size is set at 1 and cannot be altered for -t 

Review notes:
target_put.h is best read on its own at head commit (was overhauled since initial commit)

@jdinan please review