### PR TITLE
Updated wrappers to catch -h and --help

### DIFF
--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -220,8 +220,8 @@ if ($want_link == 1) {
     push(@exec_argv, split(' ', $libs));
 }
 if ($want_help == 1) {
-    print("== OSHRUN HELP ======================================\n");
-    print("OSHRUN_LAUNCHER= $comp\n\n");
+    print("== Sandia OpenSHMEM Help ======================================\n");
+    print("SOS LAUNCHER= $comp\n\n");
     print("== LAUNCHER HELP ====================================\n");
 }
 

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -182,6 +182,7 @@ while (scalar(@args) > 0) {
             $want_link = 0;
             $real_flag = 1;
         } elsif ($arg eq "-h" || $arg eq "--help") {
+            $arg = "--help";
             $want_help = 1;
             $real_flag = 1;
         } elsif ($arg eq "-S") {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -181,8 +181,7 @@ while (scalar(@args) > 0) {
             $want_compile = 0;
             $want_link = 0;
             $real_flag = 1;
-        } elsif ($arg eq "-h" || $arg eq "--help") {
-            $arg = "--help";
+        } elsif ($arg eq "--help") {
             $want_help = 1;
             $real_flag = 1;
         } elsif ($arg eq "-S") {
@@ -225,7 +224,7 @@ if ($want_help == 1) {
     print("usage: ",$wrapper," [",$wrapper,"_options] [compiler_arguments]\n\n");
     print("COMPILER = $comp\n\n");
     print($wrapper," options:\n");
-    print("\t--help | -h       Display this information\n");
+    print("\t--help            Display this information\n");
     print("\t-showme | -show   Print the command that would be run without executing it\n");
     print("\t-E | -M           Disable compilation and linking\n");
     print("\t-S                Disable linking\n");

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -182,7 +182,6 @@ while (scalar(@args) > 0) {
             $want_link = 0;
             $real_flag = 1;
         } elsif ($arg eq "-h" || $arg eq "--help") {
-            $arg = "--help";
             $want_help = 1;
             $real_flag = 1;
         } elsif ($arg eq "-S") {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -105,6 +105,7 @@ use File::Spec::Functions;
 
 my $includedir = "@WRAPPER_COMPILER_INCLUDEDIR@";
 my $libdir = "@WRAPPER_COMPILER_LIBDIR@";
+my $wrapperdir = $0;
 
 my $lang = "@LANG@";
 my $CC = "@WRAPPER_COMPILER_CC@";
@@ -118,6 +119,7 @@ my $include_flag = "-I";
 my $libdir_flag = "-L";
 
 my $comp = "";
+my $wrapper = (split(/\//, $wrapperdir))[-1];
 my $preproc_flags = $include_flag . $includedir;
 my $comp_flags = "";
 my $comp_flags_prefix = "";
@@ -180,11 +182,11 @@ while (scalar(@args) > 0) {
             $want_compile = 0;
             $want_link = 0;
             $real_flag = 1;
-        } elsif ($arg eq "-h" || $arg eq "--help"){
+        } elsif ($arg eq "-h" || $arg eq "--help") {
             $arg = "--help";
             $want_help = 1;
             $real_flag = 1;
-        }elsif ($arg eq "-S") {
+        } elsif ($arg eq "-S") {
             $want_link = 0;
             $real_flag = 1;
         } elsif ($arg =~ /^-.*/) {
@@ -221,8 +223,11 @@ if ($want_link == 1) {
 }
 if ($want_help == 1) {
     print("== Sandia OpenSHMEM Help ============================\n");
-    print("SOS LAUNCHER= $comp\n\n");
-    print("== LAUNCHER HELP ====================================\n");
+    print("SOS WRAPPER= $wrapper\n");
+    print("usage: ",$wrapper," [options]... [file]...\n\n");
+    print("COMPILER= $comp\n\n");
+    print("Options provided by ",$comp," can also be used by ",$wrapper,".\n\n");
+    print("== COMPILER HELP ====================================\n");
 }
 
 if ($dry_run == 1) {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -220,7 +220,7 @@ if ($want_link == 1) {
     push(@exec_argv, split(' ', $libs));
 }
 if ($want_help == 1) {
-    print("== Sandia OpenSHMEM Help ======================================\n");
+    print("== Sandia OpenSHMEM Help ============================\n");
     print("SOS LAUNCHER= $comp\n\n");
     print("== LAUNCHER HELP ====================================\n");
 }

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -105,7 +105,6 @@ use File::Spec::Functions;
 
 my $includedir = "@WRAPPER_COMPILER_INCLUDEDIR@";
 my $libdir = "@WRAPPER_COMPILER_LIBDIR@";
-my $wrapperdir = $0;
 
 my $lang = "@LANG@";
 my $CC = "@WRAPPER_COMPILER_CC@";
@@ -119,7 +118,7 @@ my $include_flag = "-I";
 my $libdir_flag = "-L";
 
 my $comp = "";
-my $wrapper = (split(/\//, $wrapperdir))[-1];
+my $wrapper = basename($0);
 my $preproc_flags = $include_flag . $includedir;
 my $comp_flags = "";
 my $comp_flags_prefix = "";
@@ -222,12 +221,16 @@ if ($want_link == 1) {
     push(@exec_argv, split(' ', $libs));
 }
 if ($want_help == 1) {
-    print("== Sandia OpenSHMEM Help ============================\n");
-    print("SOS WRAPPER= $wrapper\n");
-    print("usage: ",$wrapper," [options]... [file]...\n\n");
+    print("== ",uc $wrapper," HELP ============================\n");
+    print("usage: ",$wrapper," [options]... file...\n\n");
     print("COMPILER= $comp\n\n");
+    print($wrapper," options:\n");
+    print("\t--help | -h     Display this information\n");
+    print("\t-showme         Print the command that would be ran without executing it\n");
+    print("\t-E | -M         Disable compilation and linking\n");
+    print("\t-S              Disable linking\n\n");
     print("Options provided by ",$comp," can also be used by ",$wrapper,".\n\n");
-    print("== COMPILER HELP ====================================\n");
+    print("== ",uc $comp," HELP ============================\n");
 }
 
 if ($dry_run == 1) {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -100,7 +100,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-use File::Basename;
+use File::Basename qw(basename);
 use File::Spec::Functions;
 
 my $includedir = "@WRAPPER_COMPILER_INCLUDEDIR@";
@@ -171,7 +171,7 @@ my @appargs = ();
 while (scalar(@args) > 0) {
     my $arg = shift(@args);
 
-    if ($arg eq "-showme") {
+    if ($arg eq "-showme" || $arg eq "-show") {
         $dry_run = 1;
     } else {
         if ($arg eq "-c") {
@@ -221,16 +221,17 @@ if ($want_link == 1) {
     push(@exec_argv, split(' ', $libs));
 }
 if ($want_help == 1) {
-    print("== ",uc $wrapper," HELP ============================\n");
-    print("usage: ",$wrapper," [options]... file...\n\n");
-    print("COMPILER= $comp\n\n");
+    print("== ",uc $wrapper," HELP ===================================\n");
+    print("usage: ",$wrapper," [",$wrapper,"_options] [compiler_arguments]\n\n");
+    print("COMPILER = $comp\n\n");
     print($wrapper," options:\n");
-    print("\t--help | -h     Display this information\n");
-    print("\t-showme         Print the command that would be ran without executing it\n");
-    print("\t-E | -M         Disable compilation and linking\n");
-    print("\t-S              Disable linking\n\n");
+    print("\t--help | -h       Display this information\n");
+    print("\t-showme | -show   Print the command that would be run without executing it\n");
+    print("\t-E | -M           Disable compilation and linking\n");
+    print("\t-S                Disable linking\n");
+    print("\t-c                Compile and assemble. Disable linking\n\n");
     print("Options provided by ",$comp," can also be used by ",$wrapper,".\n\n");
-    print("== ",uc $comp," HELP ============================\n");
+    print("== ",uc $comp," HELP =====================================\n");
 }
 
 if ($dry_run == 1) {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -161,6 +161,7 @@ my @args = @ARGV;
 my $want_preproc = 1;
 my $want_compile = 1;
 my $want_link = 1;
+my $want_help = 0;
 my $dry_run = 0;
 my $disable_flags = 1;
 my $real_flag = 0;
@@ -179,7 +180,11 @@ while (scalar(@args) > 0) {
             $want_compile = 0;
             $want_link = 0;
             $real_flag = 1;
-        } elsif ($arg eq "-S") {
+        } elsif ($arg eq "-h" || $arg eq "--help"){
+            $arg = "--help";
+            $want_help = 1;
+            $real_flag = 1;
+        }elsif ($arg eq "-S") {
             $want_link = 0;
             $real_flag = 1;
         } elsif ($arg =~ /^-.*/) {
@@ -213,6 +218,12 @@ if ($want_compile == 1) {
 if ($want_link == 1) {
     push(@exec_argv, split(' ', $linker_flags));
     push(@exec_argv, split(' ', $libs));
+}
+if ($want_help == 1) {
+    print("== OSHRUN HELP ======================================\n");
+    print("OSHRUN_LAUNCHER= $comp\n\n");
+    print("== LAUNCHER HELP ====================================\n");
+    
 }
 
 if ($dry_run == 1) {

--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -223,7 +223,6 @@ if ($want_help == 1) {
     print("== OSHRUN HELP ======================================\n");
     print("OSHRUN_LAUNCHER= $comp\n\n");
     print("== LAUNCHER HELP ====================================\n");
-    
 }
 
 if ($dry_run == 1) {

--- a/src/shmem_launcher_script.in
+++ b/src/shmem_launcher_script.in
@@ -37,10 +37,14 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 fi
 
 if [ $want_help = 1 ]; then
-    printf "== OSHRUN HELP ============================\n";
-    printf "usage: ${SOS_LAUNCHER} [options] [exec] [exec args]\n\n";
-    printf "OSHRUN_LAUNCHER= ${SOS_LAUNCHER}\n\n";
-    printf "Selected Launcher= ${LAUNCHER}\n\n";
+    printf "== OSHRUN HELP ====================================\n";
+    printf "usage: ${SOS_LAUNCHER} [oshrun_options] [launcher_arguments]\n\n";
+    if [ -z "${OSHRUN_LAUNCHER}" ]; then
+        printf "OSHRUN_LAUNCHER = (none)\n\n";
+    else
+        printf "OSHRUN_LAUNCHER = ${OSHRUN_LAUNCHER}\n\n";
+    fi
+    printf "Selected launcher: ${LAUNCHER}\n\n";
     printf "${SOS_LAUNCHER} options:\n";
     printf "\t--help | -h     Display this information\n\n";
     printf "Options provided by ${LAUNCHER} can also be used by ${SOS_LAUNCHER}.\n\n";

--- a/src/shmem_launcher_script.in
+++ b/src/shmem_launcher_script.in
@@ -13,8 +13,7 @@
 
 SEARCH_LAUNCHERS="yod mpirun mpiexec srun"
 LAUNCHER=""
-SOS_LAUNCHER_PATH="$0";
-SOS_LAUNCHER=${SOS_LAUNCHER_PATH##*/};
+SOS_LAUNCHER=`basename $0`
 
 # Users can set the OSHRUN_LAUNCHER environment variable to specify the command
 # that will be used by oshrun
@@ -38,12 +37,14 @@ if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
 fi
 
 if [ $want_help = 1 ]; then
-    printf "== Sandia OpenSHMEM Help ============================\n";
-    printf "SOS LAUNCHER= ${SOS_LAUNCHER}\n";
+    printf "== OSHRUN HELP ============================\n";
     printf "usage: ${SOS_LAUNCHER} [options] [exec] [exec args]\n\n";
-    printf "LAUNCHER= ${LAUNCHER}\n\n";
+    printf "OSHRUN_LAUNCHER= ${SOS_LAUNCHER}\n\n";
+    printf "Selected Launcher= ${LAUNCHER}\n\n";
+    printf "${SOS_LAUNCHER} options:\n";
+    printf "\t--help | -h     Display this information\n\n";
     printf "Options provided by ${LAUNCHER} can also be used by ${SOS_LAUNCHER}.\n\n";
-    printf "== LAUNCHER HELP ====================================\n";
+    printf "== ${LAUNCHER} HELP ====================================\n" | tr [a-z] [A-Z];
 fi
 
 if [ -z "${LAUNCHER}" ]; then

--- a/src/shmem_launcher_script.in
+++ b/src/shmem_launcher_script.in
@@ -13,6 +13,8 @@
 
 SEARCH_LAUNCHERS="yod mpirun mpiexec srun"
 LAUNCHER=""
+SOS_LAUNCHER_PATH="$0";
+SOS_LAUNCHER=${SOS_LAUNCHER_PATH##*/};
 
 # Users can set the OSHRUN_LAUNCHER environment variable to specify the command
 # that will be used by oshrun
@@ -27,6 +29,21 @@ else
             break;
         fi
     done
+fi
+
+want_help=0;
+
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    want_help=1
+fi
+
+if [ $want_help = 1 ]; then
+    printf "== Sandia OpenSHMEM Help ============================\n";
+    printf "SOS LAUNCHER= ${SOS_LAUNCHER}\n";
+    printf "usage: ${SOS_LAUNCHER} [options] [exec] [exec args]\n\n";
+    printf "LAUNCHER= ${LAUNCHER}\n\n";
+    printf "Options provided by ${LAUNCHER} can also be used by ${SOS_LAUNCHER}.\n\n";
+    printf "== LAUNCHER HELP ====================================\n";
 fi
 
 if [ -z "${LAUNCHER}" ]; then


### PR DESCRIPTION
$ oshcc -h
== OSHRUN HELP ======================================
OSHRUN_LAUNCHER= gcc

== LAUNCHER HELP ====================================
Usage: gcc [options] file...
Options:
  -pass-exit-codes         Exit with highest error code from a phase
  --help                   Display this information
  --target-help            Display target specific command line options
  --help={common|optimizers|params|target|warnings|[^]{joined|separate|undocumented}}[,...]
                           Display specific types of command line options
  (Use '-v --help' to display command line options of sub-processes)
  --version                Display compiler version information
  -dumpspecs               Display all of the built in spec strings
  -dumpversion             Display the version of the compiler
  -dumpmachine             Display the compiler's target processor
  -print-search-dirs       Display the directories in the compiler's search path
  -print-libgcc-file-name  Display the name of the compiler's companion library
  -print-file-name=<lib>   Display the full path to library <lib>
  -print-prog-name=<prog>  Display the full path to compiler component <prog>
  -print-multiarch         Display the target's normalized GNU triplet, used as
                           a component in the library path
  -print-multi-directory   Display the root directory for versions of libgcc
  -print-multi-lib         Display the mapping between command line options and
                           multiple library search directories
  -print-multi-os-directory Display the relative path to OS libraries
  -print-sysroot           Display the target libraries directory
  -print-sysroot-headers-suffix Display the sysroot suffix used to find headers
  -Wa,<options>            Pass comma-separated <options> on to the assembler
  -Wp,<options>            Pass comma-separated <options> on to the preprocessor
  -Wl,<options>            Pass comma-separated <options> on to the linker
  -Xassembler <arg>        Pass <arg> on to the assembler
  -Xpreprocessor <arg>     Pass <arg> on to the preprocessor
  -Xlinker <arg>           Pass <arg> on to the linker
  -save-temps              Do not delete intermediate files
  -save-temps=<arg>        Do not delete intermediate files
  -no-canonical-prefixes   Do not canonicalize paths when building relative
                           prefixes to other gcc components
  -pipe                    Use pipes rather than intermediate files
  -time                    Time the execution of each subprocess
  -specs=<file>            Override built-in specs with the contents of <file>
  -std=<standard>          Assume that the input sources are for <standard>
  --sysroot=<directory>    Use <directory> as the root directory for headers
                           and libraries
  -B <directory>           Add <directory> to the compiler's search paths
  -v                       Display the programs invoked by the compiler
  -###                     Like -v but options quoted and commands not executed
  -E                       Preprocess only; do not compile, assemble or link
  -S                       Compile only; do not assemble or link
  -c                       Compile and assemble, but do not link
  -o <file>                Place the output into <file>
  -pie                     Create a position independent executable
  -shared                  Create a shared library
  -x <language>            Specify the language of the following input files
                           Permissible languages include: c c++ assembler none
                           'none' means revert to the default behavior of
                           guessing the language based on the file's extension

Options starting with -g, -f, -m, -O, -W, or --param are automatically
 passed on to the various sub-processes invoked by gcc.  In order to pass
 other options on to these processes the -W<letter> options must be used.

For bug reporting instructions, please see:
<http://gcc.gnu.org/bugs.html>.