### PR TITLE
Remove less-than-zero arg checks for unsigned args

### DIFF
--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -152,7 +152,6 @@ shmem_broadcast32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(PE_root);
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
@@ -171,7 +170,6 @@ shmem_broadcast64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(PE_root);
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
@@ -188,7 +186,6 @@ shmem_collect32(void *target, const void *source, size_t nlong,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
@@ -204,7 +201,6 @@ shmem_collect64(void *target, const void *source, size_t nlong,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
@@ -220,7 +216,6 @@ shmem_fcollect32(void *target, const void *source, size_t nlong,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
@@ -236,7 +231,6 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nlong);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
@@ -252,7 +246,6 @@ shmem_alltoall32(void *dest, const void *source, size_t nelems, int PE_start,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
@@ -268,7 +261,6 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
@@ -287,7 +279,6 @@ shmem_alltoalls32(void *dest, const void *source, ptrdiff_t dst, ptrdiff_t sst,
     SHMEM_ERR_CHECK_POSITIVE(sst);
     SHMEM_ERR_CHECK_POSITIVE(dst);
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, logPE_stride, PE_size);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, 4 * ((nelems-1) * dst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(source, 4 * ((nelems-1) * sst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
@@ -309,7 +300,6 @@ shmem_alltoalls64(void *dest, const void *source, ptrdiff_t dst, ptrdiff_t sst,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, 8 * ((nelems-1) * dst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(source, 8 * ((nelems-1) * sst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
 
     shmem_internal_alltoalls(dest, source, dst, sst, 8, nelems, PE_start,
                              logPE_stride, PE_size, pSync);

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -158,7 +158,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_G')
     long completion = 0;                                         \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                        \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
     shmem_internal_put_nb(target, source, sizeof(TYPE) * nelems, \
@@ -175,7 +174,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT')
     long completion = 0;                                       \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                      \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
     shmem_internal_put_nb(target, source, (SIZE) * nelems, pe, \
@@ -192,7 +190,6 @@ SHMEM_DEF_PUT_N(`mem', `1')
   {                                                              \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                        \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
     shmem_internal_put_nbi(target, source, sizeof(TYPE)*nelems,  \
@@ -207,7 +204,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT_NBI')
   {                                                            \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                      \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
     shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
@@ -222,7 +218,6 @@ SHMEM_DEF_PUT_N_NBI(`mem', `1')
   {                                                           \
     SHMEM_ERR_CHECK_INITIALIZED();                            \
     SHMEM_ERR_CHECK_PE(pe);                                   \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                     \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
     shmem_internal_get(target, source, sizeof(TYPE) * nelems, \
@@ -238,7 +233,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET')
   {                                                        \
     SHMEM_ERR_CHECK_INITIALIZED();                         \
     SHMEM_ERR_CHECK_PE(pe);                                \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                  \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                  \
     shmem_internal_get(target, source, (SIZE)*nelems, pe); \
@@ -254,7 +248,6 @@ SHMEM_DEF_GET_N(`mem', `1')
   {                                                              \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                        \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                        \
     shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
@@ -268,7 +261,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET_NBI')
   {                                                            \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                      \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(target, nelems);                      \
     shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
@@ -286,7 +278,6 @@ SHMEM_DEF_GET_N_NBI(`mem', `1')
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_POSITIVE(tst);                            \
     SHMEM_ERR_CHECK_POSITIVE(sst);                            \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                     \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                     \
     for ( ; nelems > 0 ; --nelems) {                          \
@@ -308,7 +299,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IPUT')
     SHMEM_ERR_CHECK_PE(pe);                                  \
     SHMEM_ERR_CHECK_POSITIVE(tst);                           \
     SHMEM_ERR_CHECK_POSITIVE(sst);                           \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                    \
     for ( ; nelems > 0 ; --nelems) {                         \
@@ -329,7 +319,6 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IPUT_N')
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_POSITIVE(tst);                            \
     SHMEM_ERR_CHECK_POSITIVE(sst);                            \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                     \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
     for ( ; nelems > 0 ; --nelems) {                          \
@@ -351,7 +340,6 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IGET')
     SHMEM_ERR_CHECK_PE(pe);                               \
     SHMEM_ERR_CHECK_POSITIVE(tst);                        \
     SHMEM_ERR_CHECK_POSITIVE(sst);                        \
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);                 \
     SHMEM_ERR_CHECK_SYMMETRIC(source, SIZE * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                 \
     for ( ; nelems > 0 ; --nelems) {                      \
@@ -369,7 +357,6 @@ shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(pe);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_NULL(target, nelems);
 
@@ -384,7 +371,6 @@ void shmemx_putmem_ct(shmemx_ct_t ct, void *target, const void *source,
 
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_PE(pe);
-    SHMEM_ERR_CHECK_NON_NEGATIVE(nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(target, nelems);
     SHMEM_ERR_CHECK_NULL(source, nelems);
 


### PR DESCRIPTION
Don't check args for less-than-zero errors when the type of the args is unsigned (e.g. ```size_t```).

Fixes coverity issues 169688-169781.