### PR TITLE
Back out shmem_align changes

### DIFF
--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -346,23 +346,8 @@ shmem_align(size_t alignment, size_t size)
 
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    /* Alignment must be at least sizeof(void*) */
-    if (alignment < sizeof(void*))
+    if (alignment == 0)
         return NULL;
-
-    /* Round alignment up to the nearest power of two if
-     * not already a power of two */
-    if ((alignment & (alignment-1)) != 0) {
-        size_t c, log2_alignment = 0;
-
-        for (c = alignment >> 1; c; c >>= 1)
-            log2_alignment++;
-
-        DEBUG_MSG("Alignment was rounded up from %zu to %zu\n",
-                  alignment, (size_t) 1 << (log2_alignment + 1));
-
-        alignment = 1 << (log2_alignment + 1);
-    }
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     ret = dlmemalign(alignment, size);

--- a/test/unit/shmemalign.c
+++ b/test/unit/shmemalign.c
@@ -154,7 +154,7 @@ main(int argc, char **argv)
     for(l=0; l < loops; l++)
     {
         /* align 2**2 ... 2**23; 24 exceeds symetric heap max */
-        for(j=0,c=8; j < 21; j++,c<<=1)
+        for(j=0,c=2; j < 23; j++,c<<=1)
         {
             target_sz = nWords * sizeof(DataType);
             if (!(target = (DataType *)shmem_align(c,target_sz))) {


### PR DESCRIPTION
The Mellanox and Cray tests have divergent requirements, defaulting to Cray.
- Mellanox expects failure for alignments of 0 and 3
- Cray expects 3 to round up to a valid alignment