### PR TITLE
Include transport_none in sources

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -88,6 +88,13 @@ libsma_la_SOURCES += \
 	transport_ofi.c
 endif
 
+if !USE_PORTALS4
+if !USE_OFI
+libsma_la_SOURCES += \
+	transport_none.h
+endif
+endif
+
 if USE_XPMEM
 libsma_la_SOURCES += \
 	transport_xpmem.h \


### PR DESCRIPTION
Ensure that transport_none.h is included in the distribution tarball.