### PR TITLE
Adds folder with manpages and installation support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,5 +15,6 @@ ACLOCAL_AMFLAGS = -I config
 
 EXTRA_DIST = README NEWS LICENSE sandia-openshmem.spec pmi-simple
 
-SUBDIRS = mpp pmi-simple src test
+SUBDIRS = man mpp pmi-simple src test
+
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,19 @@
-#! /bin/sh
+#! /bin/bash
 
 test -d ./config || mkdir ./config
+
+FILES=./man/*.1
+printf "dist_man1_MANS = " > ./man/Makefile.am
+for f in $FILES
+do
+  printf "%s " $(basename $f) >> ./man/Makefile.am
+done
+
+FILES=./man/*.3
+printf "\ndist_man3_MANS = " >> ./man/Makefile.am
+for f in $FILES
+do
+  printf "%s " $(basename $f) >> ./man/Makefile.am
+done
 
 autoreconf -vif

--- a/autogen.sh
+++ b/autogen.sh
@@ -3,17 +3,19 @@
 test -d ./config || mkdir ./config
 
 FILES=./man/*.1
-printf "dist_man1_MANS = " > ./man/Makefile.am
+echo -n "dist_man1_MANS =" > ./man/Makefile.am
 for f in $FILES
 do
-  printf "%s " $(basename $f) >> ./man/Makefile.am
+  echo -n " $(basename $f)" >> ./man/Makefile.am
 done
 
 FILES=./man/*.3
-printf "\ndist_man3_MANS = " >> ./man/Makefile.am
+echo -e -n "\ndist_man3_MANS =" >> ./man/Makefile.am
 for f in $FILES
 do
-  printf "%s " $(basename $f) >> ./man/Makefile.am
+  echo -n " $(basename $f)" >> ./man/Makefile.am
 done
+
+echo -e "\n" >> ./man/Makefile.am
 
 autoreconf -vif

--- a/configure.ac
+++ b/configure.ac
@@ -574,6 +574,7 @@ AC_SUBST(WRAPPER_COMPILER_EXTRA_LIBS)
 
 AC_CONFIG_FILES([Makefile
   sandia-openshmem.spec
+  man/Makefile
   pmi-simple/Makefile
   mpp/Makefile
   mpp/shmem.fh

--- a/man/_my_pe.3
+++ b/man/_my_pe.3
@@ -1,0 +1,1 @@
+.so shmem_my_pe.3

--- a/man/_num_pes.3
+++ b/man/_num_pes.3
@@ -1,0 +1,1 @@
+.so shmem_n_pes

--- a/man/oshc++.1
+++ b/man/oshc++.1
@@ -1,0 +1,26 @@
+.TH OSHC++ 1 "OpenSHMEM Library Documentation"
+.SH NAME
+oshc++ - Compiles and links OpenSHMEM programs written in C++
+.SH DESCRIPTION
+This command can be used to compile and link OpenSHMEM programs written in C++.
+It provides the options and any special libraries that are needed to compile and link OpenSHMEM programs.
+
+It is important to use this command, particularly when linking programs, as it provides the necessary libraries.
+
+usage: oshc++ [oshc++_options] [compiler_arguments]
+.SH COMMAND LINE ARGUMENTS
+.TP 8
+.B --help
+- Display this information
+.TP
+.B -showme | -show
+- Print the command that would be run without executing it
+.TP
+.B -E | -M
+- Disable compilation and linking
+.TP
+.B -S
+- Disable linking
+.TP
+.B -c
+- Compile and assemble. Disable link

--- a/man/oshcc.1
+++ b/man/oshcc.1
@@ -1,0 +1,27 @@
+.TH OSHCC 1 "OpenSHMEM Library Documentation"
+.SH NAME
+oshcc - Compiles and links OpenSHMEM programs written in C
+.SH DESCRIPTION
+This command can be used to compile and link OpenSHMEM programs written in C.
+It provides the options and any special libraries that are needed to compile and link OpenSHMEM programs.
+
+It is important to use this command, particularly when linking programs, as it provides the necessary libraries.
+
+usage: oshcc [oshcc_options] [compiler_arguments]
+.SH COMMAND LINE ARGUMENTS
+.TP 8
+.B --help
+- Display this information
+.TP
+.B -showme | -show
+- Print the command that would be run without executing it
+.TP
+.B -E | -M
+- Disable compilation and linking
+.TP
+.B -S
+- Disable linking
+.TP
+.B -c
+- Compile and assemble. Disable link
+

--- a/man/oshfort.1
+++ b/man/oshfort.1
@@ -1,0 +1,27 @@
+.TH OSHFORT 1 "OpenSHMEM Library Documentation"
+.SH NAME
+oshfort - Compiles and links OpenSHMEM programs written in Fortran
+.SH DESCRIPTION
+This command can be used to compile and link OpenSHMEM programs written in Fortran.
+It provides the options and any special libraries that are needed to compile and link OpenSHMEM programs.
+
+It is important to use this command, particularly when linking programs, as it provides the necessary libraries.
+
+usage: oshfort [oshfort_options] [compiler_arguments]
+.SH COMMAND LINE ARGUMENTS
+.TP 8
+.B --help
+- Display this information
+.TP
+.B -showme | -show
+- Print the command that would be run without executing it
+.TP
+.B -E | -M
+- Disable compilation and linking
+.TP
+.B -S
+- Disable linking
+.TP
+.B -c
+- Compile and assemble. Disable link
+

--- a/man/oshrun.1
+++ b/man/oshrun.1
@@ -5,7 +5,7 @@ oshrun - Run a OpenSHMEM program
 .B oshrun
 launches the OpenSHMEM programs with a given number of processes.
 
-usage: ushrun [oshrun_options] [launcher_arguments]
+usage: oshrun [oshrun_options] [launcher_arguments]
 .SH COMMAND LINE ARGUMENTS
 .TP 8
 .B --help | -h

--- a/man/oshrun.1
+++ b/man/oshrun.1
@@ -1,0 +1,12 @@
+.TH OSHRUN 1 "OpenSHMEM Library Documentation"
+.SH NAME
+oshrun - Run a OpenSHMEM program
+.SH DESCRIPTION
+.B oshrun
+launches the OpenSHMEM programs with a given number of processes.
+
+usage: ushrun [oshrun_options] [launcher_arguments]
+.SH COMMAND LINE ARGUMENTS
+.TP 8
+.B --help | -h
+- Display this information

--- a/man/shfree.3
+++ b/man/shfree.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shmalloc.3
+++ b/man/shmalloc.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shmem_add.3
+++ b/man/shmem_add.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_add.3

--- a/man/shmem_addr_accessible.3
+++ b/man/shmem_addr_accessible.3
@@ -1,0 +1,123 @@
+.TH SHMEM_ADDR_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_addr_accessible \- 
+Determines whether an address is accessible via OpenSHMEM data transfer
+routines from the specified remote PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B int
+.B shmem_addr_accessible(const
+.B void
+.IB "*addr" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "LOGICAL " "LOG, SHMEM_ADDR_ACCESSIBLE"
+.BR "INTEGER " "pe"
+LOG = SHMEM_ADDR_ACCESSIBLE(addr, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I addr
+- Data object on the local PE.
+
+
+.BR "IN " -
+.I pe
+- Integer id of a remote PE.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_addr\_accessible
+is a query routine that indicates whether a local
+address is accessible via OpenSHMEM routines from the specified remote PE. 
+
+This routine verifies that the data object is symmetric and accessible with
+respect to a remote PE via OpenSHMEM data transfer routines. The
+specified address 
+.I addr
+is a data object on the local PE. 
+
+This routine may be particularly useful for hybrid programming with other
+communication libraries (such as MPI) or parallel languages. For
+example, in SGI Altix series systems, for multiple executable MPI programs that
+use OpenSHMEM routines, it is important to note that static memory, such as a
+Fortran common block or C global variable, is symmetric between
+processes running from the same executable file, but is not symmetric between
+processes running from different executable files. Data allocated from the
+symmetric heap (
+.B shmem\_malloc
+or 
+.B shpalloc
+) is symmetric across the
+same or different executable files.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+C/C++: The return value is 1 if 
+.I addr
+is a symmetric data object
+and accessible via OpenSHMEM routines from the specified remote PE;
+otherwise, it is 0.
+
+Fortran: The return value is .TRUE. if 
+.I addr
+is a symmetric data
+object and accessible via OpenSHMEM routines from the specified remote PE;
+otherwise, it is .FALSE..
+
+./ sectionEnd
+
+		
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_align.3
+++ b/man/shmem_align.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shmem_alltoall.3
+++ b/man/shmem_alltoall.3
@@ -1,0 +1,441 @@
+.TH SHMEM_ALLTOALL 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_alltoall \- 
+shmem\_alltoall is a collective routine where each PE exchanges a fixed amount of data with all other PEs in the
+.IR "Active set" .
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_alltoall32(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_alltoall64(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pSync(SHMEM_ALLTOALL_SYNC_SIZE)"
+.BR "INTEGER " "PE_start, logPE_stride, PE_size, nelems"
+.BR "CALL " "SHMEM_ALLTOALL32(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A symmetric data object large enough to receive
+the combined total of 
+.I nelems
+elements from each PE in the
+.IR "Active set" .
+
+
+
+.BR "IN " -
+.I source
+- A symmetric data object that contains 
+.I nelems
+elements of data for each PE in the 
+.I "Active set"
+, ordered according to
+destination PE.
+
+
+.BR "IN " -
+.I nelems
+- The number of elements to exchange for each PE.
+.I nelems
+must be of type size\_t for  C/C++. If you are using
+Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of
+PEs. 
+.I PE\_start
+must be of type integer. If you are using Fortran,
+it must be a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+- The log (base 2) of the stride between
+consecutive PE numbers in the 
+.IR "Active set" .
+.I logPE\_stride
+must be of
+type integer. If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+- The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must
+be a default integer value.
+
+
+.BR "IN " -
+.I pSync
+- A symmetric work array. In  C/C++, 
+.I pSync
+must be
+of type long and size SHMEM\_ALLTOALL\_SYNC\_SIZE. In Fortran,
+.I pSync
+must be of type integer and size
+SHMEM\_ALLTOALL\_SYNC\_SIZE. If you are using Fortran, it must be a
+default integer value. Every element of this array must be initialized with
+the value SHMEM\_SYNC\_VALUE before any of the PEs in the
+.I "Active set"
+enter the routine.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_alltoall
+routines are collective routines. Each PE
+in the 
+.I "Active set"
+exchanges 
+.I nelems
+data elements of size
+32 bits (for 
+.B shmem\_alltoall32
+) or 64 bits (for 
+.B shmem\_alltoall64
+)
+with all other PEs in the set. The data being sent and received are
+stored in a contiguous symmetric data object. The total size of each PEs
+.I source
+object and 
+.I dest
+object is 
+.I nelems
+times the size of
+an element (32 bits or 64 bits) times 
+.IR "PE\_size" .
+.
+The 
+.I source
+object contains 
+.I PE\_size
+blocks of data (the size of each
+block defined by 
+.I nelems
+) and each block of data is sent to a different PE. 
+Given a PE 
+.I i
+that is the 
+.I kth
+PE in the active set and a PE
+.I j
+that is the 
+.I lth
+PE in the active set,
+PE 
+.I i
+sends the 
+.I lth
+block of its 
+.I source
+object to
+the 
+.I kth
+block of
+the 
+.I dest
+object of PE 
+.IR "j" .
+.
+
+As with all OpenSHMEM collective routines, this routine assumes
+that only PEs in the 
+.I "Active set"
+call the routine. If a PE not
+in the 
+.I "Active set"
+calls an OpenSHMEM collective routine, undefined
+behavior results.
+
+The values of arguments 
+.I nelems
+, 
+.I PE\_start
+, 
+.I logPE\_stride
+,
+and 
+.I PE\_size
+must be equal on all PEs in the 
+.IR "Active set" .
+The same
+.I dest
+and 
+.I source
+data objects, and the same 
+.I pSync
+work
+array must be passed to all PEs in the 
+.IR "Active set" .
+
+
+Before any PE calls a 
+.B shmem\_alltoall
+routine, the following
+conditions must exist (synchronization via a barrier or some other method is
+often needed to ensure this): The 
+.I pSync
+array on all PEs in the
+.I "Active set"
+is not still in use from a prior call to a
+.B shmem\_alltoall/s
+routine. The 
+.I dest
+data object on
+all PEs in the 
+.I "Active set"
+is ready to accept the
+.B shmem\_alltoall
+data.
+
+Upon return from a 
+.B shmem\_alltoall
+routine, the following is true for
+the local PE: Its 
+.I dest
+symmetric data object is completely updated and
+the data has been copied out of the 
+.I source
+data object.
+The values in the 
+.I pSync
+array are restored to the original values.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to certain typing
+constraints, which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_alltoall64
+64 bits aligned.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_alltoall32
+32 bits aligned.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+This routine restores 
+.I pSync
+to its original contents. Multiple calls
+to OpenSHMEM routines that use the same 
+.I pSync
+array do not require
+that 
+.I pSync
+be reinitialized after the first call.
+You must ensure that the 
+.I pSync
+array is not being updated by any
+PE in the 
+.I "Active set"
+while any of the PEs participates in
+processing of an OpenSHMEM 
+.B shmem\_alltoall
+routine. Be careful to
+avoid these situations: If the 
+.I pSync
+array is initialized at run time,
+some type of synchronization is needed to ensure that all PEs in the
+.I "Active set"
+have initialized 
+.I pSync
+before any of them enter an
+OpenSHMEM routine called with the 
+.I pSync
+synchronization array. A
+.I pSync
+array may be reused on a subsequent OpenSHMEM
+.B shmem\_alltoall
+routine only if none of the PEs in the
+.I "Active set"
+are still processing a prior OpenSHMEM 
+.B shmem\_alltoall
+routine call that used the same 
+.I pSync
+array. In general, this can be
+ensured only by doing some type of synchronization.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This example shows a 
+.B shmem\_alltoall64
+on two long elements among all
+PEs.
+
+.nf
+#include <stdio.h>
+#include <inttypes.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
+  for (int i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
+     pSync[i] = SHMEM_SYNC_VALUE;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  const int count = 2;
+  int64_t* dest = (int64_t*) shmem_malloc(count * npes * sizeof(int64_t));
+  int64_t* source = (int64_t*) shmem_malloc(count * npes * sizeof(int64_t));
+
+  /* assign source values */
+  for (int pe = 0; pe < npes; pe++) {
+     for (int i = 0; i < count; i++) {
+        source[(pe * count) + i] = me + pe;
+        dest[(pe * count) + i] = 9999;
+     }
+  }
+  /* wait for all PEs to update source/dest */
+  shmem_barrier_all();
+
+  /* alltoall on all PES */
+  shmem_alltoall64(dest, source, count, 0, 0, npes, pSync);
+
+  /* verify results */
+  for (int pe = 0; pe < npes; pe++) {
+     for (int i = 0; i < count; i++) {
+        if (dest[(pe * count) + i] != pe + me) {
+           printf("[%d] ERROR: dest[%d]=%" PRId64 ", should be %d\\n",
+              me, (pe * count) + i, dest[(pe * count) + i], pe + me);
+          }
+      }
+  }
+
+  shmem_free(dest);
+  shmem_free(source);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+

--- a/man/shmem_alltoalls.3
+++ b/man/shmem_alltoalls.3
@@ -1,0 +1,470 @@
+.TH SHMEM_ALLTOALLS 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_alltoalls \- 
+shmem\_alltoalls is a collective routine where each PE exchanges a fixed amount of strided data with all other
+PEs in the 
+.IR "Active set" .
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_alltoalls32(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_alltoalls64(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pSync(SHMEM_ALLTOALLS_SYNC_SIZE)"
+.BR "INTEGER " "dst, sst, PE_start, logPE_stride, PE_size"
+.BR "INTEGER " "nelems"
+.BR "CALL " "SHMEM_ALLTOALLS32(dest, source, dst, sst, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, PE_size, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A symmetric data object large enough to receive 
+the combined total of 
+.I nelems
+elements from each PE in the
+.IR "Active set" .
+
+
+
+.BR "IN " -
+.I source
+- A symmetric data object that contains 
+.I nelems
+elements of data for each PE in the 
+.I "Active set"
+, ordered according to 
+destination PE.
+
+
+.BR "IN " -
+.I dst
+- The stride between consecutive elements of the 
+.I "dest"
+data object. The stride is scaled by the element size. A
+value of 1 indicates contiguous data. 
+.I dst
+must be of type
+ptrdiff\_t. If you are using Fortran, it must be a default integer
+value.
+
+
+.BR "IN " -
+.I sst
+- The stride between consecutive elements of the
+.I "source"
+data object. The stride is scaled by the element size.
+A value of 1 indicates contiguous data. 
+.I sst
+must be
+of type ptrdiff\_t. If you are using Fortran, it must be a
+default integer value.
+
+
+.BR "IN " -
+.I nelems
+- The number of elements to exchange for each PE.
+.I nelems
+must be of type size\_t for  C/C++. If you are using
+Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of
+PEs. 
+.I PE\_start
+must be of type integer. If you are using Fortran,
+it must be a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+- The log (base 2) of the stride between
+consecutive PE numbers in the 
+.IR "Active set" .
+.I logPE\_stride
+must be of
+type integer. If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+- The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must
+be a default integer value.
+
+
+.BR "IN " -
+.I pSync
+- A symmetric work array. In  C/C++, 
+.I pSync
+must be
+of type long and size SHMEM\_ALLTOALLS\_SYNC\_SIZE. In Fortran,
+.I pSync
+must be of type integer and size
+SHMEM\_ALLTOALLS\_SYNC\_SIZE. If you are using Fortran, it must be a
+default integer value. Every element of this array must be initialized with
+the value SHMEM\_SYNC\_VALUE before any of the PEs in the
+.I "Active set"
+enter the routine.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_alltoalls
+routines are collective routines. Each PE
+in the 
+.I "Active set"
+exchanges 
+.I nelems
+strided data elements of size
+32 bits (for 
+.B shmem\_alltoalls32
+) or 64 bits (for 
+.B shmem\_alltoalls64
+)
+with all other PEs in the set. Both strides, 
+.I dst
+and 
+.I sst
+, must be greater
+than or equal to 1.
+Given a PE 
+.I i
+that is the 
+.I kth
+PE in the active set and a PE
+.I j
+that is the 
+.I lth
+PE in the active set,
+PE 
+.I i
+sends the 
+.I sst
+*
+.I lth
+block of the 
+.I source
+data object to
+the 
+.I dst
+*
+.I kth
+block of the 
+.I dest
+data object on
+PE 
+.IR "j" .
+.
+
+As with all OpenSHMEM collective routines, these routines assume
+that only PEs in the 
+.I "Active set"
+call the routine. If a PE not
+in the 
+.I "Active set"
+calls an OpenSHMEM collective routine, undefined
+behavior results.
+
+The values of arguments 
+.I dst
+, 
+.I sst
+, 
+.I nelems
+, 
+.I PE\_start
+,
+.I logPE\_stride
+, and 
+.I PE\_size
+must be equal on all PEs in the
+.IR "Active set" .
+The same 
+.I dest
+and 
+.I source
+data objects, and the same
+.I pSync
+work array must be passed to all PEs in the 
+.IR "Active set" .
+
+
+Before any PE calls to a 
+.B shmem\_alltoalls
+routine, the following
+conditions must exist (synchronization via a barrier or some other method is
+often needed to ensure this): The 
+.I pSync
+array on all PEs in the
+.I "Active set"
+is not still in use from a prior call to a
+.B shmem\_alltoalls
+routine. The 
+.I dest
+data object on
+all PEs in the 
+.I "Active set"
+is ready to accept the
+.B shmem\_alltoalls
+data.
+
+Upon return from a 
+.B shmem\_alltoalls
+routine, the following is true for
+the local PE: Its 
+.I dest
+symmetric data object is completely updated and
+the data has been copied out of the 
+.I source
+data object.
+The values in the 
+.I pSync
+array are restored to the original values.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to certain typing
+constraints, which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_alltoalls64
+64 bits aligned.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_alltoalls32
+32 bits aligned.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+This routine restores 
+.I pSync
+to its original contents. Multiple calls
+to OpenSHMEM routines that use the same 
+.I pSync
+array do not require
+that 
+.I pSync
+be reinitialized after the first call.
+You must ensure the that the 
+.I pSync
+array is not being updated by any
+PE in the 
+.I "Active set"
+while any of the PEs participates in
+processing of an OpenSHMEM 
+.B shmem\_alltoalls
+routine. Be careful to
+avoid these situations: If the 
+.I pSync
+array is initialized at run time,
+some type of synchronization is needed to ensure that all PEs in the
+.I "Active set"
+have initialized 
+.I pSync
+before any of them enter an
+OpenSHMEM routine called with the 
+.I pSync
+synchronization array. A
+.I pSync
+array may be reused on a subsequent OpenSHMEM
+.B shmem\_alltoalls
+routine only if none of the PEs in the
+.I "Active set"
+are still processing a prior OpenSHMEM 
+.B shmem\_alltoalls
+routine call that used the same 
+.I pSync
+array. In general, this can be
+ensured only by doing some type of synchronization. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This example shows a 
+.B shmem\_alltoalls64
+on two long elements among
+all PEs.
+
+.nf
+#include <stdio.h>
+#include <inttypes.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long pSync[SHMEM_ALLTOALLS_SYNC_SIZE];
+  for (int i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++)
+     pSync[i] = SHMEM_SYNC_VALUE;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  const int count = 2;
+  const ptrdiff_t dst = 2;
+  const ptrdiff_t sst = 3;
+  int64_t* dest = (int64_t*) shmem_malloc(count * dst * npes * sizeof(int64_t));
+  int64_t* source = (int64_t*) shmem_malloc(count * sst * npes * sizeof(int64_t));
+
+  /* assign source values */
+  for (int pe = 0; pe < npes; pe++) {
+     for (int i = 0; i < count; i++) {
+        source[sst * ((pe * count) + i)] = me + pe;
+        dest[dst * ((pe * count) + i)] = 9999;
+     }
+  }
+  /* wait for all PEs to update source/dest */
+  shmem_barrier_all();
+
+  /* alltoalls on all PES */
+  shmem_alltoalls64(dest, source, dst, sst, count, 0, 0, npes, pSync);
+
+  /* verify results */
+  for (int pe = 0; pe < npes; pe++) {
+     for (int i = 0; i < count; i++) {
+        int j = dst * ((pe * count) + i);
+        if (dest[j] != pe + me) {
+           printf("[%d] ERROR: dest[%d]=%" PRId64 ", should be %d\\n",
+              me, j, dest[j], pe + me);
+         }
+      }
+  }
+
+  shmem_free(dest);
+  shmem_free(source);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_atomic_add.3
+++ b/man/shmem_atomic_add.3
@@ -1,0 +1,220 @@
+.TH SHMEM_ATOMIC_ADD 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_add \- 
+Performs an atomic add operation on a remote symmetric data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_add(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types specified by
+Table 2.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_add(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types and has a corresponding
+TYPENAME specified by Table 2.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "value_i4"
+.BR "CALL " "SHMEM_INT4_ADD(dest, value_i4, pe)"
+.BR "INTEGER*8 " "value_i8"
+.BR "CALL " "SHMEM_INT8_ADD(dest, value_i8, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- The remotely accessible integer data object to be
+updated on the remote PE. If you are using  C/C++, the type of
+.I "dest"
+should match that implied in the SYNOPSIS section.
+
+
+.BR "IN " -
+.I value
+- The value to be atomically added to 
+.IR "dest" .
+If you
+are using  C/C++, the type of 
+.I value
+should match that implied in
+the SYNOPSIS section. If you are using Fortran, it must be of type
+integer with an element size of 
+.IR "dest" .
+
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number upon which
+.I "dest"
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_atomic\_add
+routine performs an atomic add operation. It adds
+.I value
+to 
+.I "dest"
+on PE 
+.I pe
+and atomically updates the 
+.I "dest"
+without returning the value.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I dest
+must be of the following type:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_ADD
+4-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_ADD
+8-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_add
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_add" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static int dst = 22;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 1)
+     shmem_atomic_add(&dst, 44, 0);
+  shmem_barrier_all();
+  printf("%d: dst = %d\\n", me, dst);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 2:
+Standard AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_and.3
+++ b/man/shmem_atomic_and.3
@@ -1,0 +1,138 @@
+.TH SHMEM_ATOMIC_AND 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_and \- 
+Atomically perform a non-fetching bitwise AND operation on a
+remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_and(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_and(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise AND operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_and
+atomically performs a non-fetching bitwise AND
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_atomic_compare_swap.3
+++ b/man/shmem_atomic_compare_swap.3
@@ -1,0 +1,251 @@
+.TH SHMEM_ATOMIC_COMPARE_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_compare_swap \- 
+Performs an atomic conditional swap on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_compare_swap(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "cond" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types specified by
+Table 2.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_compare_swap(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "cond" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types and has a corresponding
+TYPENAME specified by Table 2.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "SHMEM_INT4_CSWAP, cond_i4, value_i4, ires_i4"
+ires_i4 = SHMEM_INT4_CSWAP(dest, cond_i4, value_i4, pe)
+.BR "INTEGER*8 " "SHMEM_INT8_CSWAP, cond_i8, value_i8, ires_i8"
+ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- The remotely accessible integer data object to be
+updated on the remote PE. 
+
+
+.BR "IN " -
+.I cond
+- 
+.I cond
+is compared to the remote 
+.I dest
+value. If 
+.I cond
+and the remote 
+.I dest
+are equal, then 
+.I value
+is swapped into the remote 
+.IR "dest" .
+. Otherwise, the remote 
+.I dest
+is
+unchanged. In either case, the old value of the remote 
+.I dest
+is
+returned as the routine return value. 
+.I cond
+must be of the same data
+type as 
+.IR "dest" .
+.
+
+
+.BR "IN " -
+.I value
+- The value to be atomically written to the remote
+PE. 
+.I value
+must be the same data type as 
+.IR "dest" .
+.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number upon which
+.I dest
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The conditional swap routines conditionally update a 
+.I dest
+data object on
+the specified PE and return the prior contents of the data object in one
+atomic operation.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+The 
+.I dest
+and 
+.I value
+data objects must conform to certain typing
+constraints, which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I value
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_CSWAP
+4-byte integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_CSWAP
+8-byte integer.
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS Return Values
+
+The contents that had been in the 
+.I dest
+data object on the remote
+PE prior to the conditional swap. Data type is the same as the
+.I dest
+data type.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_cswap
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_compare\_swap" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following call ensures that the first PE to execute the
+conditional swap will successfully write its PE number to
+.I race\_winner
+on PE 0.
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static int race_winner = -1;
+  shmem_init();
+  int me = shmem_my_pe();
+  int oldval = shmem_atomic_compare_swap(&race_winner, -1, me, 0);
+  if (oldval == -1) printf("PE %d was first\\n", me);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 2:
+Standard AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_fetch.3
+++ b/man/shmem_atomic_fetch.3
@@ -1,0 +1,152 @@
+.TH SHMEM_ATOMIC_FETCH 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch \- 
+Atomically fetches the value of a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch(const
+.B TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types specified by
+Table 3.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch(const
+.B TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types and has a corresponding
+TYPENAME specified by Table 3.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "SHMEM_INT4_FETCH, ires_i4"
+ires_i4 = SHMEM_INT4_FETCH(dest, pe)
+.BR "INTEGER*8 " "SHMEM_INT8_FETCH, ires_i8"
+ires_i8 = SHMEM_INT8_FETCH(dest, pe)
+.BR "REAL*4 " "SHMEM_REAL4_FETCH, res_r4"
+res_r4 = SHMEM_REAL4_FETCH(dest, pe)
+.BR "REAL*8 " "SHMEM_REAL8_FETCH, res_r8"
+res_r8 = SHMEM_REAL8_FETCH(dest, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- The remotely accessible data object to be fetched from
+the remote PE.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number from which
+.I dest
+is to be fetched.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_fetch
+performs an atomic fetch operation.
+It returns the contents of the 
+.I dest
+as an atomic operation.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The contents at the 
+.I dest
+address on the remote PE.
+The data type of the return value is the same as the type of
+the remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_fetch
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_fetch" .
+
+./ sectionEnd
+
+
+
+
+.SS Table 3:
+Extended AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_fetch_add.3
+++ b/man/shmem_atomic_fetch_add.3
@@ -1,0 +1,239 @@
+.TH SHMEM_ATOMIC_FETCH_ADD 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch_add \- 
+Performs an atomic fetch-and-add operation on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch_add(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types specified by
+Table 2.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch_add(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types and has a corresponding
+TYPENAME specified by Table 2.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "SHMEM_INT4_FADD, ires_i4, value_i4"
+ires_i4 = SHMEM_INT4_FADD(dest, value_i4, pe)
+.BR "INTEGER*8 " "SHMEM_INT8_FADD, ires_i8, value_i8"
+ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- The remotely accessible integer data object to be updated on
+the remote PE. The type of 
+.I dest
+should match that implied in the
+SYNOPSIS section.
+
+
+.BR "IN " -
+.I value
+- The value to be atomically added to 
+.IR "dest" .
+. The
+type of 
+.I value
+should match that implied in the SYNOPSIS section.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number on which
+.I dest
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_fetch\_add
+routines perform an atomic fetch-and-add operation. An
+atomic fetch-and-add operation fetches the old 
+.I dest
+and adds 
+.I value
+to 
+.I dest
+without the possibility of another atomic operation on the
+.I dest
+between the time of the fetch and the update. These routines add
+.I value
+to 
+.I dest
+on 
+.I pe
+and return the previous contents of
+.I dest
+as an atomic operation.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I dest
+must be of the following type:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_FADD
+4-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_FADD
+8-byte integer
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS Return Values
+
+The contents that had been at the 
+.I dest
+address on the remote PE
+prior to the atomic addition operation. The data type of the return value is
+the same as the 
+.IR "dest" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_fadd
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_fetch\_add" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_atomic\_fetch\_add
+example is for
+C[11] programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  int old = -1;
+  static int dst = 22;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 1)
+     old = shmem_atomic_fetch_add(&dst, 44, 0);
+  shmem_barrier_all();
+  printf("%d: old = %d, dst = %d\\n", me, old, dst);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 2:
+Standard AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_fetch_and.3
+++ b/man/shmem_atomic_fetch_and.3
@@ -1,0 +1,142 @@
+.TH SHMEM_ATOMIC_FETCH_AND 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch_and \- 
+Atomically perform a fetching bitwise AND operation on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch_and(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch_and(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise AND operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_fetch\_and
+atomically performs a fetching bitwise AND
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The value pointed to by 
+.I dest
+on PE 
+.I pe
+immediately before the
+operation is performed.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_atomic_fetch_inc.3
+++ b/man/shmem_atomic_fetch_inc.3
@@ -1,0 +1,214 @@
+.TH SHMEM_ATOMIC_FETCH_INC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch_inc \- 
+Performs an atomic fetch-and-increment operation on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch_inc(TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types specified by
+Table 2.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch_inc(TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types and has a corresponding
+TYPENAME specified by Table 2.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "SHMEM_INT4_FINC, ires_i4"
+ires_i4 = SHMEM_INT4_FINC(dest, pe)
+.BR "INTEGER*8 " "SHMEM_INT8_FINC, ires_i8"
+ires_i8 = SHMEM_INT8_FINC(dest, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- The remotely accessible integer data object to be updated
+on the remote PE. The type of 
+.I "dest"
+should match that implied in the
+SYNOPSIS section.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number on which
+.I "dest"
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS API Description
+
+These routines perform a fetch-and-increment operation. The 
+.I "dest"
+on
+PE 
+.I pe
+is increased by one and the routine returns the previous
+contents of 
+.I "dest"
+as an atomic operation.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I dest
+must be of the following type:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_FINC
+4-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_FINC
+8-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The contents that had been at the 
+.I "dest"
+address on the remote PE prior to
+the increment. The data type of the return value is the same as the 
+.IR "dest" .
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_finc
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_fetch\_inc" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_atomic\_fetch\_inc
+example is for
+C[11] programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  int old = -1;
+  static int dst = 22;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0)
+     old = shmem_atomic_fetch_inc(&dst, 1);
+  shmem_barrier_all();
+  printf("%d: old = %d, dst = %d\\n", me, old, dst);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 2:
+Standard AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_fetch_or.3
+++ b/man/shmem_atomic_fetch_or.3
@@ -1,0 +1,142 @@
+.TH SHMEM_ATOMIC_FETCH_OR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch_or \- 
+Atomically perform a fetching bitwise OR operation on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch_or(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch_or(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise OR operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_fetch\_or
+atomically performs a fetching bitwise OR
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The value pointed to by 
+.I dest
+on PE 
+.I pe
+immediately before the
+operation is performed.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_atomic_fetch_xor.3
+++ b/man/shmem_atomic_fetch_xor.3
@@ -1,0 +1,143 @@
+.TH SHMEM_ATOMIC_FETCH_XOR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_fetch_xor \- 
+Atomically perform a fetching bitwise exclusive OR (XOR) operation on a
+remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_fetch_xor(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_fetch_xor(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise XOR operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_fetch\_xor
+atomically performs a fetching bitwise XOR
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The value pointed to by 
+.I dest
+on PE 
+.I pe
+immediately before the
+operation is performed.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_atomic_inc.3
+++ b/man/shmem_atomic_inc.3
@@ -1,0 +1,201 @@
+.TH SHMEM_ATOMIC_INC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_inc \- 
+Performs an atomic increment operation on a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_inc(TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types specified by
+Table 2.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_inc(TYPE
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard AMO types and has a corresponding
+TYPENAME specified by Table 2.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "CALL " "SHMEM_INT4_INC(dest, pe)"
+.BR "CALL " "SHMEM_INT8_INC(dest, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- The remotely accessible integer data object to be updated
+on the remote PE. The type of 
+.I "dest"
+should match that implied in the
+SYNOPSIS section.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number on which
+.I "dest"
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+These routines perform an atomic increment operation on the 
+.I dest
+data
+object on PE.
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I dest
+must be of the following type:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_INC
+4-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_INC
+8-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_inc
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_inc" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_atomic\_inc
+example is for
+C[11] programs: 
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static int dst = 74;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0)
+     shmem_atomic_inc(&dst, 1);
+  shmem_barrier_all();
+  printf("%d: dst = %d\\n", me, dst);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 2:
+Standard AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_or.3
+++ b/man/shmem_atomic_or.3
@@ -1,0 +1,138 @@
+.TH SHMEM_ATOMIC_OR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_or \- 
+Atomically perform a non-fetching bitwise OR operation on a
+remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_or(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_or(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise OR operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_or
+atomically performs a non-fetching bitwise OR
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_atomic_set.3
+++ b/man/shmem_atomic_set.3
@@ -1,0 +1,158 @@
+.TH SHMEM_ATOMIC_SET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_set \- 
+Atomically sets the value of a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_set(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types specified by
+Table 3.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_set(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types and has a corresponding
+TYPENAME specified by Table 3.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "pe"
+.BR "INTEGER*4 " "SHMEM_INT4_SET, value_i4"
+.BR "CALL " "SHMEM_INT4_SET(dest, value_i4, pe)"
+.BR "INTEGER*8 " "SHMEM_INT8_SET, value_i8"
+.BR "CALL " "SHMEM_INT8_SET(dest, value_i8, pe)"
+.BR "REAL*4 " "SHMEM_REAL4_SET, value_r4"
+.BR "CALL " "SHMEM_REAL4_SET(dest, value_r4, pe)"
+.BR "REAL*8 " "SHMEM_REAL8_SET, value_r8"
+.BR "CALL " "SHMEM_REAL8_SET(dest, value_r8, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- The remotely accessible data object to be set on
+the remote PE.
+
+
+.BR "IN " -
+.I value
+- The value to be atomically written to the remote PE.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number on which
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_set
+performs an atomic set operation. It writes the
+.I value
+into 
+.I dest
+on 
+.I pe
+as an atomic operation.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_set
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_set" .
+
+./ sectionEnd
+
+
+
+
+.SS Table 3:
+Extended AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_swap.3
+++ b/man/shmem_atomic_swap.3
@@ -1,0 +1,255 @@
+.TH SHMEM_ATOMIC_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_swap \- 
+Performs an atomic swap to a remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_atomic_swap(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types specified by Table 3.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_atomic_swap(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the extended AMO types and has a corresponding TYPENAME specified by Table 3.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "SHMEM_SWAP, value, pe"
+ires = SHMEM_SWAP(dest, value, pe)
+.BR "INTEGER*4 " "SHMEM_INT4_SWAP, value_i4, ires_i4"
+ires_i4 = SHMEM_INT4_SWAP(dest, value_i4, pe)
+.BR "INTEGER*8 " "SHMEM_INT8_SWAP, value_i8, ires_i8"
+ires_i8 = SHMEM_INT8_SWAP(dest, value_i8, pe)
+.BR "REAL*4 " "SHMEM_REAL4_SWAP, value_r4, res_r4"
+res_r4 = SHMEM_REAL4_SWAP(dest, value_r4, pe)
+.BR "REAL*8 " "SHMEM_REAL8_SWAP, value_r8, res_r8"
+res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- The remotely accessible integer data object to be
+updated on the remote PE. If you are using  C/C++, the type of
+.I "dest"
+should match that implied in the SYNOPSIS section.
+
+
+.BR "IN " -
+.I value
+- The value to be atomically written to the remote
+PE. 
+.I value
+is the same type as 
+.IR "dest" .
+
+
+
+.BR "IN " -
+.I pe
+-  An integer that indicates the PE number on which
+.I "dest"
+is to be updated. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_swap
+performs an atomic swap operation.
+It writes 
+.I value
+into 
+.I "dest"
+on PE and returns the previous
+contents of 
+.I "dest"
+as an atomic operation.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I dest
+must be of the following type:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+SHMEM\_SWAP
+Integer of default kind
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT4\_SWAP
+4-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INT8\_SWAP
+8-byte integer
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL4\_SWAP
+4-byte real
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL8\_SWAP
+8-byte real
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The content that had been at the 
+.I "dest"
+address on the remote PE
+prior to the swap is returned.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], 
+.B shmem\_swap
+has been deprecated.
+Its behavior and call signature are identical to the replacement
+interface, 
+.BR "shmem\_atomic\_swap" .
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The example below swaps values between odd numbered PEs and
+their right (modulo) neighbor and outputs the result of swap.
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long dest;
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+  dest = me;
+  shmem_barrier_all();
+  long new_val = me;
+  if (me & 1) {
+     long swapped_val = shmem_atomic_swap(&dest, new_val, (me + 1) % npes);
+     printf("%d: dest = %ld, swapped = %ld\\n", me, dest, swapped_val);
+  }
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 3:
+Extended AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong

--- a/man/shmem_atomic_xor.3
+++ b/man/shmem_atomic_xor.3
@@ -1,0 +1,138 @@
+.TH SHMEM_ATOMIC_XOR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_atomic_xor \- 
+Atomically perform a non-fetching bitwise exclusive OR (XOR) operation on a
+remote data object.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_atomic_xor(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types specified by
+Table 4.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_atomic_xor(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the bitwise AMO types and has a corresponding
+TYPENAME specified by Table 4.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A pointer to the remotely accessible data object to
+be updated.
+
+
+.BR "IN " -
+.I value
+- The operand to the bitwise XOR operation.
+
+
+.BR "IN " -
+.I pe
+- An integer value for the PE on which 
+.I dest
+is to be updated.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_atomic\_xor
+atomically performs a non-fetching bitwise XOR
+on the remotely accessible data object pointed to by 
+.I dest
+at PE
+.I pe
+with the operand 
+.IR "value" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+
+.SS Table 4:
+Bitwise AMO Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64

--- a/man/shmem_barrier.3
+++ b/man/shmem_barrier.3
@@ -1,0 +1,249 @@
+.TH SHMEM_BARRIER 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_barrier \- 
+Performs all operations described in the 
+.B shmem\_barrier\_all
+interface
+but with respect to a subset of PEs defined by the 
+.IR "Active set" .
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_barrier(int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "PE_start, logPE_stride, PE_size"
+.BR "INTEGER " "pSync(SHMEM_BARRIER_SYNC_SIZE)"
+.BR "CALL " "SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of PEs.
+.I PE\_start
+must be of type integer. If you are using Fortran, it must be
+a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+- The log (base 2) of the stride between consecutive
+PE numbers in the 
+.IR "Active set" .
+.I logPE\_stride
+must be of type integer.
+If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+- The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must be a default
+integer value.
+
+
+.BR "IN " -
+.I pSync
+- A symmetric work array. In  C/C++, 
+.I pSync
+must
+be of type long and size SHMEM\_BARRIER\_SYNC\_SIZE. In Fortran,
+.I pSync
+must be of type integer and size SHMEM\_BARRIER\_SYNC\_SIZE.
+If you are using Fortran, it must be a default integer type. Every element
+of this array must be initialized to SHMEM\_SYNC\_VALUE before any of
+the PEs in the 
+.I "Active set"
+enter 
+.B shmem\_barrier
+the first time.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_barrier
+is a collective synchronization routine over an
+.IR "Active set" .
+Control returns from 
+.B shmem\_barrier
+after all PEs in
+the 
+.I "Active set"
+(specified by 
+.I PE\_start
+, 
+.I logPE\_stride
+, and
+.I PE\_size
+) have called 
+.BR "shmem\_barrier" .
+
+
+As with all OpenSHMEM collective routines, each of these routines assumes that
+only PEs in the 
+.I "Active set"
+call the routine. If a PE not in the
+.I "Active set"
+calls an OpenSHMEM collective routine, undefined behavior results.
+
+The values of arguments 
+.I PE\_start
+, 
+.I logPE\_stride
+, and 
+.I PE\_size
+must be equal on all PEs in the 
+.IR "Active set" .
+The same work array must be
+passed in 
+.I pSync
+to all PEs in the 
+.IR "Active set" .
+
+
+
+.B shmem\_barrier
+ensures that all previously issued stores and remote
+memory updates, including AMOs and RMA operations, done by any of the
+PEs in the 
+.I "Active set"
+are complete before returning.
+
+The same 
+.I pSync
+array may be reused on consecutive calls to
+.B shmem\_barrier
+if the same active PE set is used.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+If the 
+.I pSync
+array is initialized at run time, be sure to use some type of
+synchronization, for example, a call to 
+.B shmem\_barrier\_all
+, before
+calling 
+.B shmem\_barrier
+for the first time.
+
+If the 
+.I "Active set"
+does not change, 
+.B shmem\_barrier
+can be called
+repeatedly with the same 
+.I pSync
+array. No additional synchronization
+beyond that implied by 
+.B shmem\_barrier
+itself is necessary in this case.
+
+The 
+.B shmem\_barrier
+routine can be used to
+portably ensure that memory access operations observe remote updates in the order
+enforced by initiator PEs.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following barrier example is for C11 programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static int x = 10101;
+  static long pSync[SHMEM_BARRIER_SYNC_SIZE];
+  for (int i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++)
+     pSync[i] = SHMEM_SYNC_VALUE;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  if (me % 2 == 0) {
+     /* put to next even PE in a circular fashion */
+     shmem_p(&x, 4, (me + 2) % npes);
+     /* synchronize all even pes */
+     shmem_barrier(0, 1, (npes / 2 + npes % 2), pSync);
+  }
+  printf("%d: x = %d\\n", me, x);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_barrier_all.3
+++ b/man/shmem_barrier_all.3
@@ -1,0 +1,140 @@
+.TH SHMEM_BARRIER_ALL 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_barrier_all \- 
+Registers the arrival of a PE at a barrier and suspends PE execution
+until all other PEs arrive at the barrier and all local and remote memory
+updates are completed.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_barrier_all(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_BARRIER_ALL"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_barrier\_all
+routine registers the arrival of a PE at
+a barrier. Barriers are a fast mechanism for synchronizing all PEs at
+once. This routine causes a PE to suspend execution until all PEs
+have called 
+.BR "shmem\_barrier\_all" .
+This routine must be used with
+PEs started by 
+.BR "shmem\_init" .
+
+
+Prior to synchronizing with other PEs, 
+.B shmem\_barrier\_all
+ensures completion of all previously issued memory stores and remote memory
+updates issued via OpenSHMEM AMOs and RMA routine calls such
+as 
+.B shmem\_int\_add
+, 
+.B shmem\_put32
+, 
+.B shmem\_put\_nbi
+, and 
+.BR "shmem\_get\_nbi" .
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+The 
+.B shmem\_barrier\_all
+routine can be used to
+portably ensure that memory access operations observe remote updates in the order
+enforced by initiator PEs.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_barrier\_all
+example is for C11 programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static int x = 1010;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  /* put to next  PE in a circular fashion */
+  shmem_p(&x, 4, (me + 1) % npes);
+
+  /* synchronize all PEs */
+  shmem_barrier_all();
+  printf("%d: x = %d\\n", me, x);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_broadcast.3
+++ b/man/shmem_broadcast.3
@@ -1,0 +1,409 @@
+.TH SHMEM_BROADCAST 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_broadcast \- 
+Broadcasts a block of data from one PE to one or more destination
+PEs.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_broadcast32(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_root" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_broadcast64(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_root" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "nelems, PE_root, PE_start, logPE_stride, PE_size"
+.BR "INTEGER " "pSync(SHMEM_BCAST_SYNC_SIZE)"
+.BR "CALL " "SHMEM_BROADCAST4(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_BROADCAST8(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_BROADCAST32(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size,pSync)"
+.BR "CALL " "SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size,pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A symmetric data object. 
+
+
+.BR "IN " -
+.I source
+- A symmetric data object that can be of any data type
+that is permissible for the 
+.I "dest"
+argument.
+
+
+.BR "IN " -
+.I nelems
+- The number of elements in 
+.IR "source" .
+For
+.B shmem\_broadcast32
+and 
+.B shmem\_broadcast4
+, this is the number of
+32-bit halfwords. nelems must be of type 
+.I size\_t
+in C. If you are
+using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_root
+- Zero-based ordinal of the PE, with respect to
+the 
+.I "Active set"
+,from which the data is copied. Must be greater than or equal to
+0 and less than 
+.IR "PE\_size" .
+. 
+.I PE\_root
+must be of type integer. If you
+are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of
+PEs. 
+.I PE\_start
+must be of type integer. If you are using Fortran,
+it must be a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+-  The log (base 2) of the stride between
+consecutive PE numbers in the 
+.IR "Active set" .
+.I log\_PE\_stride
+must be of
+type integer. If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+-  The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must be a
+default integer value.
+
+
+.BR "IN " -
+.I pSync
+-  A symmetric work array. In  C/C++, 
+.I pSync
+must
+be of type long and size SHMEM\_BCAST\_SYNC\_SIZE. In Fortran,
+.I pSync
+must be of type integer and size SHMEM\_BCAST\_SYNC\_SIZE.
+Every element of this array must be initialized with the value
+SHMEM\_SYNC\_VALUE (in  C/C++) or SHMEM\_SYNC\_VALUE (in
+Fortran) before any of the PEs in the 
+.I "Active set"
+enter
+.BR "shmem\_broadcast" .
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+OpenSHMEM broadcast routines are collective routines. They copy data object
+.I "source"
+on the processor specified by 
+.I PE\_root
+and store the values at
+.I "dest"
+on the other PEs specified by the triplet 
+.I PE\_start
+,
+.I logPE\_stride
+, 
+.IR "PE\_size" .
+. The data is not copied to the 
+.I "dest"
+area
+on the root PE.
+
+As with all OpenSHMEM collective routines, each of these routines assumes that
+only PEs in the 
+.I "Active set"
+call the routine. If a PE not in the
+.I "Active set"
+calls an OpenSHMEM collective routine, undefined behavior results.
+
+The values of arguments 
+.I PE\_root
+, 
+.I PE\_start
+, 
+.I logPE\_stride
+,
+and 
+.I PE\_size
+must be equal on all PEs in the 
+.IR "Active set" .
+The same
+.I "dest"
+and 
+.I "source"
+data objects and the same 
+.I pSync
+work array must be
+passed to all PEs in the 
+.IR "Active set" .
+
+
+Before any PE calls a broadcast routine, you must ensure that the following
+conditions exist (synchronization via a barrier or some other method is often
+needed to ensure this): The 
+.I pSync
+array on all PEs in the
+.I "Active set"
+is not still in use from a prior call to a broadcast routine. The
+.I "dest"
+array on all PEs in the 
+.I "Active set"
+is ready to accept the
+broadcast data.
+
+Upon return from a broadcast routine, the following are true for the local
+PE: If the current PE is not the root PE, the 
+.I "dest"
+data object
+is updated. The 
+.I "source"
+data object may be safely reused. 
+The values in the 
+.I pSync
+array are restored to the original values.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to certain typing
+constraints, which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_broadcast8, shmem\_broadcast64
+Any noncharacter type that has an element size of 64 bits. No Fortran derived types or  C/C++ structures are allowed.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_broadcast4, shmem\_broadcast32
+Any noncharacter type that has an element size of 32 bits. No Fortran derived types or  C/C++ structures are allowed.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+All OpenSHMEM broadcast routines restore 
+.I pSync
+to its original contents.
+Multiple calls to OpenSHMEM routines that use the same 
+.I pSync
+array do not
+require that 
+.I pSync
+be reinitialized after the first call.
+
+You must ensure the that the 
+.I pSync
+array is not being updated by any
+PE in the 
+.I "Active set"
+while any of the PEs participates in processing
+of an OpenSHMEM broadcast routine. Be careful to avoid these situations: If the
+.I pSync
+array is initialized at run time, some type of synchronization is
+needed to ensure that all PEs in the 
+.I "Active set"
+have initialized
+.I pSync
+before any of them enter an OpenSHMEM routine called with the
+.I pSync
+synchronization array. A 
+.I pSync
+array may be reused on a
+subsequent OpenSHMEM broadcast routine only if none of the PEs in the
+.I "Active set"
+are still processing a prior OpenSHMEM broadcast routine call that
+used the same 
+.I pSync
+array. In general, this can be ensured only by doing
+some type of synchronization. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+In the following examples, the call to 
+.B shmem\_broadcast64
+copies 
+.I "source"
+on PE 4 to 
+.I "dest"
+on PEs 5, 6, and 7. 
+
+C/C++ example:
+
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long pSync[SHMEM_BCAST_SYNC_SIZE];
+  for (int i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
+     pSync[i] = SHMEM_SYNC_VALUE;
+  static long source[4], dest[4];
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  if (me == 0)
+     for (int i = 0; i < 4; i++)
+        source[i] = i;
+
+  shmem_broadcast64(dest, source, 4, 0, 0, 0, npes, pSync);
+  printf("%d: %ld, %ld, %ld, %ld\\n", me, dest[0], dest[1], dest[2], dest[3]);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+Fortran example:
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_BCAST_SYNC_SIZE)
+INTEGER DEST, SOURCE, NLONG, PE_ROOT, PE_START,
+&   LOGPE_STRIDE, PE_SIZE, PSYNC
+COMMON /COM/ DEST, SOURCE
+
+DATA PSYNC /SHMEM_BCAST_SYNC_SIZE*SHMEM_SYNC_VALUE/
+
+CALL SHMEM_BROADCAST64(DEST, SOURCE, NLONG, 0, 4, 0, 4, PSYNC)
+
+
+.fi
+
+
+
+
+

--- a/man/shmem_cache.3
+++ b/man/shmem_cache.3
@@ -1,0 +1,159 @@
+.TH SHMEM_CACHE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_cache \- 
+Controls data cache utilities.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_clear_cache_inv(void)
+
+
+.B void
+.B shmem_set_cache_inv(void)
+
+
+.B void
+.B shmem_clear_cache_line_inv(void
+.I *dest
+.B );
+
+
+
+.B void
+.B shmem_set_cache_line_inv(void
+.I *dest
+.B );
+
+
+
+.B void
+.B shmem_udcflush(void)
+
+
+.B void
+.B shmem_udcflush_line(void
+.I *dest
+.B );
+
+
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_CLEAR_CACHE_INV"
+.BR "CALL " "SHMEM_SET_CACHE_INV"
+.BR "CALL " "SHMEM_SET_CACHE_LINE_INV(dest)"
+.BR "CALL " "SHMEM_UDCFLUSH"
+.BR "CALL " "SHMEM_UDCFLUSH_LINE(dest)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- A data object that is local to the PE. 
+.I dest
+can be of any noncharacter type. If you are using Fortran, it can be of any
+kind.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_set\_cache\_inv
+enables automatic cache coherency mode.
+
+
+.B shmem\_set\_cache\_line\_inv
+enables automatic cache coherency mode for
+the cache line associated with the address of 
+.I dest
+only.
+
+
+.B shmem\_clear\_cache\_inv
+disables automatic cache coherency mode
+previously enabled by 
+.B shmem\_set\_cache\ \_inv
+or
+.BR "shmem\_set\_cache\_line\_inv" .
+
+
+
+.B shmem\_udcflush
+makes the entire user data cache coherent.
+
+
+.B shmem\_udcflush\_line
+makes coherent the cache line that corresponds with
+the address specified by 
+.IR "dest" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+These routines have been retained for improved backward compatibility with
+legacy architectures. They are not required to be supported by implementing
+them as 
+.I no-ops
+and where used, they may have no effect on cache line
+states.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+None.
+
+
+
+

--- a/man/shmem_calloc.3
+++ b/man/shmem_calloc.3
@@ -1,0 +1,112 @@
+.TH SHMEM_CALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_calloc \- 
+Allocate a zeroed block of symmetric memory.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B *shmem_calloc(size_t
+.IB "count" ,
+.B size_t
+.I size
+.B );
+
+
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I count
+- The number of elements to allocate.
+
+
+.BR "IN " -
+.I size
+- The size in bytes of each element to allocate.
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_calloc
+routine allocates a region of remotely-accessible
+memory for an array of 
+.I count
+objects of 
+.I size
+bytes each and
+returns a pointer to the lowest byte address of the allocated symmetric
+memory. The space is initialized to all bits zero.
+
+If the allocation succeeds, the pointer returned shall be suitably
+aligned so that it may be assigned to a pointer to any type of object.
+If the allocation does not succeed, or either 
+.I count
+or 
+.I size
+is
+0, the return value is a null pointer.
+
+The values for 
+.I count
+and 
+.I size
+shall each be equal across
+all PEs calling 
+.B shmem\_calloc
+; otherwise, the behavior is
+undefined.
+
+The 
+.B shmem\_calloc
+routine calls 
+.B shmem\_barrier\_all
+on exit.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The 
+.B shmem\_calloc
+routine returns a pointer to the lowest byte
+address of the allocated space; otherwise, it returns a null pointer.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_clear_cache_inv.3
+++ b/man/shmem_clear_cache_inv.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_clear_cache_line_inv.3
+++ b/man/shmem_clear_cache_line_inv.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_clear_lock.3
+++ b/man/shmem_clear_lock.3
@@ -1,0 +1,1 @@
+.so shmem_lock.3

--- a/man/shmem_collect.3
+++ b/man/shmem_collect.3
@@ -1,0 +1,446 @@
+.TH SHMEM_COLLECT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_collect \- 
+Concatenates blocks of data from multiple PEs to an array in every
+PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_collect32(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_collect64(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_fcollect32(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_fcollect64(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "nelems"
+.BR "INTEGER " "PE_start, logPE_stride, PE_size"
+.BR "INTEGER " "pSync(SHMEM_COLLECT_SYNC_SIZE)"
+.BR "CALL " "SHMEM_COLLECT4(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_COLLECT8(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_COLLECT32(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_COLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_FCOLLECT4(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_FCOLLECT8(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_FCOLLECT32(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+.BR "CALL " "SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- A symmetric array. The 
+.I "dest"
+argument must be large enough
+to accept the concatenation of the 
+.I "source"
+arrays on all PEs. The data
+types are as follows: For 
+.B shmem\_collect8
+, 
+.B shmem\_collect64
+,
+.B shmem\_fcollect8
+, and 
+.B shmem\_fcollect64
+, any data type with an
+element size of 64 bits. Fortran derived types, Fortran character type,
+and  C/C++ structures are not permitted. For 
+.B shmem\_collect4
+,
+.B shmem\_collect32
+, 
+.B shmem\_fcollect4
+, and 
+.B shmem\_fcollect32
+,
+any data type with an element size of 32 bits. Fortran derived
+types, Fortran character type, and  C/C++ structures are not permitted.
+
+
+.BR "IN " -
+.I source
+- A symmetric data object that can be of any type permissible
+for the 
+.I "dest"
+argument.
+
+
+.BR "IN " -
+.I nelems
+- The number of elements in the 
+.I "source"
+array. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are using Fortran, it must be
+a default integer value.
+
+
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of
+PEs. 
+.I PE\_start
+must be of type integer. If you are using Fortran,
+it must be a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+- The log (base 2) of the stride between
+consecutive PE numbers in the 
+.IR "Active set" .
+.I logPE\_stride
+must be of
+type integer. If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+- The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must be a default
+integer value.
+
+
+.BR "IN " -
+.I pSync
+- A symmetric work array. In  C/C++, 
+.I pSync
+must be of
+type long and size SHMEM\_COLLECT\_SYNC\_SIZE. In Fortran,
+.I pSync
+must be of type integer and size SHMEM\_COLLECT\_SYNC\_SIZE.
+If you are using Fortran, it must be a default integer value. Every element of
+this array must be initialized with the value SHMEM\_SYNC\_VALUE in
+C/C++ or SHMEM\_SYNC\_VALUE in Fortran before any of the PEs
+in the 
+.I "Active set"
+enter 
+.B shmem\_collect
+or 
+.BR "shmem\_fcollect" .
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+OpenSHMEM 
+.B collect
+and 
+.B fcollect
+routines concatenate 
+.I nelems
+64-bit or 32-bit data items from the 
+.I "source"
+array into the
+.I "dest"
+array, over the set of PEs defined by 
+.I PE\_start
+,
+.I log2PE\_stride
+, and 
+.I PE\_size
+, in processor number order. The
+resultant 
+.I "dest"
+array contains the contribution from PE 
+.I PE\_start
+first, then the contribution from PE 
+.I PE\_start
++ 
+.I PE\_stride
+second, and so on. The collected result is written to the 
+.I "dest"
+array for all
+PEs in the 
+.IR "Active set" .
+
+
+The 
+.B fcollect
+routines require that 
+.I nelems
+be the same value in all
+participating PEs, while the 
+.B collect
+routines allow 
+.I nelems
+to
+vary from PE to PE.
+
+As with all OpenSHMEM collective routines, each of these routines assumes that
+only PEs in the 
+.I "Active set"
+call the routine. If a PE not in the
+.I "Active set"
+and calls this collective routine, the behavior is undefined.
+
+The values of arguments 
+.I PE\_start
+, 
+.I logPE\_stride
+, and 
+.I PE\_size
+must be equal on all PEs in the 
+.IR "Active set" .
+The same 
+.I "dest"
+and 
+.I "source"
+arrays and the same 
+.I pSync
+work array must be passed to all PEs in the
+.IR "Active set" .
+
+
+Upon return from a collective routine, the following are true for the local
+PE: The 
+.I "dest"
+array is updated and the 
+.I "source"
+array may be safely reused. 
+The values in the 
+.I pSync
+array are
+restored to the original values.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+All OpenSHMEM collective routines reset the values in 
+.I pSync
+before they
+return, so a particular 
+.I pSync
+buffer need only be initialized the first
+time it is used.
+
+You must ensure that the 
+.I pSync
+array is not being updated on any PE
+in the 
+.I "Active set"
+while any of the PEs participate in processing of an
+OpenSHMEM collective routine. Be careful to avoid these situations: If the
+.I pSync
+array is initialized at run time, some type of synchronization is
+needed to ensure that all PEs in the working set have initialized
+.I pSync
+before any of them enter an OpenSHMEM routine called with the
+.I pSync
+synchronization array. A 
+.I pSync
+array can be reused on a
+subsequent OpenSHMEM collective routine only if none of the PEs in the
+.I "Active set"
+are still processing a prior OpenSHMEM collective routine call
+that used the same 
+.I pSync
+array. In general, this may be ensured only by
+doing some type of synchronization. 
+
+The collective routines operate on active PE sets that have a
+non-power-of-two 
+.I PE\_size
+with some performance degradation. They operate
+with no performance degradation when 
+.I nelems
+is a non-power-of-two value.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_collec
+t example is for  C/C++ programs:
+
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long lock = 0;
+  static long pSync[SHMEM_COLLECT_SYNC_SIZE];
+  for (int i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
+     pSync[i] = SHMEM_SYNC_VALUE;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+  int my_nelem = me + 1; /* linearly increasing number of elements with PE */
+  int total_nelem = (npes * (npes + 1)) / 2;
+
+  int* source = (int*) shmem_malloc(npes*sizeof(int)); /* symmetric alloc */
+  int* dest = (int*) shmem_malloc(total_nelem*sizeof(int));
+
+  for (int i = 0; i < my_nelem; i++)
+     source[i] = (me * (me + 1)) / 2 + i;
+  for (int i = 0; i < total_nelem; i++)
+     dest[i] = -9999;
+
+  shmem_barrier_all(); /* Wait for all PEs to update source/dest */
+
+  shmem_collect32(dest, source, my_nelem, 0, 0, npes, pSync);
+
+  shmem_set_lock(&lock); /* Lock prevents interleaving printfs */
+  printf("%d: %d", me, dest[0]);
+  for (int i = 1; i < total_nelem; i++)
+     printf(", %d", dest[i]);
+  printf("\\n");
+  shmem_clear_lock(&lock);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+The following 
+.B SHMEM\_COLLECT
+example is for Fortran programs:
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_COLLECT_SYNC_SIZE)
+DATA PSYNC /SHMEM_COLLECT_SYNC_SIZE*SHMEM_SYNC_VALUE/
+
+CALL SHMEM_COLLECT4(DEST, SOURCE, 64, PE_START, LOGPE_STRIDE,
+&  PE_SIZE, PSYNC)
+.fi
+
+
+
+
+

--- a/man/shmem_cswap.3
+++ b/man/shmem_cswap.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_compare_swap.3

--- a/man/shmem_fadd.3
+++ b/man/shmem_fadd.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_fetch_add.3

--- a/man/shmem_fcollect.3
+++ b/man/shmem_fcollect.3
@@ -1,0 +1,1 @@
+.so shmem_collect.3

--- a/man/shmem_fence.3
+++ b/man/shmem_fence.3
@@ -1,0 +1,163 @@
+.TH SHMEM_FENCE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_fence \- 
+Assures ordering of delivery of PUT, AMOs, and memory store routines
+to symmetric data objects.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_fence(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_FENCE"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+This routine assures ordering of delivery of PUT, AMOs, and memory store
+routines to symmetric data objects. All PUT, AMOs, and memory store
+routines to symmetric data objects issued to a particular remote PE prior
+to the call to 
+.B shmem\_fence
+are guaranteed to be delivered before any
+subsequent PUT, AMOs, and memory store routines to symmetric data
+objects to the same PE. 
+.B shmem\_fence
+guarantees order of delivery,
+not completion.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+.B shmem\_fence
+only provides per-PE ordering guarantees and does not
+guarantee completion of delivery. 
+.B shmem\_fence
+also does not have an effect on the ordering between memory 
+accesses issued by the target PE. 
+.B shmem\_wait
+, 
+.B shmem\_wait\_until
+, 
+.B shmem\_test
+,
+.B shmem\_barrier
+, 
+.B shmem\_barrier\_all
+routines can be called by the target PE to guarantee 
+ordering of its memory accesses.
+There is a subtle difference between
+.B shmem\_fence
+and 
+.B shmem\_quiet
+, in that, 
+.B shmem\_quiet
+guarantees completion of PUT, AMOs, and memory store routines to
+symmetric data objects which makes the updates visible to all other
+PEs. 
+
+The 
+.B shmem\_quiet
+routine should be called if completion of PUT,
+AMOs, and memory store routines to symmetric data objects is desired
+when multiple remote PEs are involved.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_fence
+example is for C11 programs: 
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  int src = 99;
+  long source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  static long dest[10];
+  static int targ;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) {
+     shmem_put(dest, source, 10, 1); /* put1 */
+     shmem_put(dest, source, 10, 2); /* put2 */
+     shmem_fence();
+     shmem_put(&targ, &src, 1, 1); /* put3 */
+     shmem_put(&targ, &src, 1, 2); /* put4 */
+  }
+  shmem_barrier_all();  /* sync sender and receiver */
+  printf("dest[0] on PE %d is %ld\\n", me, dest[0]);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+.I Put1
+will be ordered to be delivered before 
+.I put3
+and 
+.I put2
+will be ordered to be delivered before 
+.IR "put4" .
+.
+
+
+
+

--- a/man/shmem_fetch.3
+++ b/man/shmem_fetch.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_fetch.3

--- a/man/shmem_finalize.3
+++ b/man/shmem_finalize.3
@@ -1,0 +1,152 @@
+.TH SHMEM_FINALIZE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_finalize \- 
+A collective operation that releases resources used by the OpenSHMEM
+library. This only terminates the OpenSHMEM portion of a program, not the
+entire program.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_finalize(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_FINALIZE()"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_finalize
+is a collective operation that ends the OpenSHMEM
+portion of a program previously initialized by 
+.B shmem\_init
+and
+releases resources used by the OpenSHMEM library. This collective
+operation requires all PEs to participate in the call. There is an
+implicit global barrier in 
+.B shmem\_finalize
+so that pending
+communications are completed, and no resources can be released until all
+PEs have entered 
+.BR "shmem\_finalize" .
+.B shmem\_finalize
+must be
+the last OpenSHMEM library call encountered in the OpenSHMEM portion of a
+program. A call to 
+.B shmem\_finalize
+will release any resources
+initialized by a corresponding call to 
+.BR "shmem\_init" .
+All processes
+that represent the PEs will still exist after the
+call to 
+.B shmem\_finalize
+returns, but they will no longer have access
+to any resources that have been released.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+.B shmem\_finalize
+releases all resources used by the OpenSHMEM library
+including the symmetric memory heap and pointers initiated by
+.BR "shmem\_ptr" .
+This collective operation requires all PEs to
+participate in the call, not just a subset of the PEs. The
+non-OpenSHMEM portion of a program may continue after a call to
+.B shmem\_finalize
+by all PEs. There is an implicit
+.B shmem\_finalize
+at the end of main, so that having an explicit call
+to 
+.B shmem\_finalize
+is optional. However, an explicit
+.B shmem\_finalize
+may be required as an entry point for wrappers used
+by profiling or other tools that need to perform their own finalization.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following finalize example is for C11 programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h> 
+
+int main(void)
+{
+  static long x = 10101;
+  long y = -1;
+
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  if (me == 0)
+     y = shmem_g(&x, npes-1);
+
+  printf("%d: y = %ld\\n", me, y); 
+
+  shmem_finalize();  
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_finc.3
+++ b/man/shmem_finc.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_fetch_inc.3

--- a/man/shmem_free.3
+++ b/man/shmem_free.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shmem_g.3
+++ b/man/shmem_g.3
@@ -1,0 +1,201 @@
+.TH SHMEM_G 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_g \- 
+Copies one data item from a remote PE
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B TYPE
+.B shmem_g(const
+.B TYPE
+.IB "*addr" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B TYPE
+.B shmem_<TYPENAME>_g(const
+.B TYPE
+.IB "*addr" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I addr
+- The remotely accessible array element or scalar data object.
+
+
+.BR "IN " -
+.I pe
+- The number of the remote PE on which 
+.I addr
+resides.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+These routines provide a very low latency get capability for single elements
+of most basic types. 
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+Returns a single element of type specified in the synopsis.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_g
+example is for C11 programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  long y = -1;
+  static long x = 10101;
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+  if (me == 0)
+     y = shmem_g(&x, npes-1);
+  printf("%d: y = %ld\\n", me, y);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_get.3
+++ b/man/shmem_get.3
@@ -1,0 +1,416 @@
+.TH SHMEM_GET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_get \- 
+Copies data from a specified PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_get(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_get(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_get<SIZE>(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+
+.B void
+.B shmem_getmem(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "nelems, pe"
+.BR "CALL " "SHMEM_CHARACTER_GET(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_COMPLEX_GET(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_GET(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET4(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET8(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET32(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET64(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET128(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GETMEM(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_GET(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_GET(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_GET(dest, source, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- Local data object to be updated.
+
+
+.BR "IN " -
+.I source
+- Data object on the PE identified by 
+.I pe
+that contains the data to be copied. This data object must be remotely
+accessible.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I "dest"
+and 
+.I "source"
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are
+using Fortran, it must be a constant, variable, or array element of default
+integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must
+be of type integer. If you are using Fortran, it must be a constant,
+variable, or array element of default integer type.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The get routines provide a method for copying a contiguous symmetric data
+object from a different PE to a contiguous data object on the local
+PE. The routines return after the data has been delivered to the
+.I "dest"
+array on the local PE. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to typing constraints,
+which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_getmem
+Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get4, shmem\_get32
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get8
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get64
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get128
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_CHARACTER\_GET
+Elements of type character. 
+.I nelems
+is the number of characters to transfer. The actual character lengths of the 
+.I "source"
+and 
+.I "dest"
+variables are ignored.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_GET
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_GET
+Fortran: Elements of type double precision.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_GET
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_GET
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_GET
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
+If you are using Fortran, data types must be of default size. For example, a real
+variable must be declared as REAL, REAL*4, or
+REAL(KIND=KIND(1.0)).
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+Consider this example for Fortran.
+
+.nf
+PROGRAM REDUCTION
+INCLUDE "shmem.fh"
+
+REAL VALUES, SUM
+COMMON /C/ VALUES
+REAL WORK
+CALL SHMEM_INIT()             ! ALLOW ANY NUMBER OF PES
+VALUES = SHMEM_MY_PE()              ! INITIALIZE IT TO SOMETHING
+CALL SHMEM_BARRIER_ALL
+SUM = 0.0
+DO I = 0, SHMEM_N_PES()-1
+  CALL SHMEM_REAL_GET(WORK, VALUES, (SHMEM_N_PES()()-1), I)
+  SUM = SUM + WORK
+ENDDO
+PRINT*,'PE ',SHMEM_MY_PE(),' COMPUTED SUM=',SUM
+CALL SHMEM_BARRIER_ALL
+END
+.fi
+
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_get_nbi.3
+++ b/man/shmem_get_nbi.3
@@ -1,0 +1,393 @@
+.TH SHMEM_GET_NBI 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_get_nbi \- 
+The nonblocking get routines provide a method for copying data from a
+contiguous remote data object on the specified PE to the local data object. 
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_get_nbi(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_get_nbi(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_get<SIZE>_nbi(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+
+.B void
+.B shmem_getmem_nbi(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "nelems, pe"
+.BR "CALL " "SHMEM_CHARACTER_GET_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_COMPLEX_GET_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_GET_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET4_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET8_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET32_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET64_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GET128_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_GETMEM_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_GET_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_GET_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_GET_NBI(dest, source, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- Local data object to be updated.
+
+
+.BR "IN " -
+.I source
+- Data object on the PE identified by 
+.I pe
+that contains the data to be copied. This data object must be remotely
+accessible.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I "dest"
+and 
+.I "source"
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are
+using Fortran, it must be a constant, variable, or array element of default
+integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must
+be of type integer. If you are using Fortran, it must be a constant,
+variable, or array element of default integer type.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The get routines provide a method for copying a contiguous symmetric data
+object from a different PE to a contiguous data object on the local
+PE. The routines return after posting the operation. The operation is considered 
+complete after a subsequent call to 
+.BR "shmem\_quiet" .
+At the completion of 
+.B shmem\_quiet
+, the 
+data has been delivered to the 
+.I "dest"
+array on the local PE. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to typing constraints,
+which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_getmem\_nbi
+Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get4\_nbi, shmem\_get32\_nbi
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get8\_nbi
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get64\_nbi
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_get128\_nbi
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_CHARACTER\_GET\_NBI
+Elements of type character. 
+.I nelems
+is the number of characters to transfer. The actual character lengths of the 
+.I "source"
+and 
+.I "dest"
+variables are ignored.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_GET\_NBI
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_GET\_NBI
+Fortran: Elements of type double precision.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_GET\_NBI
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_GET\_NBI
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_GET\_NBI
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
+If you are using Fortran, data types must be of default size. For example, a real
+variable must be declared as REAL, REAL*4, or
+REAL(KIND=KIND(1.0)).
+
+./ sectionEnd
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_getmem.3
+++ b/man/shmem_getmem.3
@@ -1,0 +1,1 @@
+.so shmem_get

--- a/man/shmem_getmem_nbi.3
+++ b/man/shmem_getmem_nbi.3
@@ -1,0 +1,1 @@
+.so shmem_get_nbi.3

--- a/man/shmem_global_exit.3
+++ b/man/shmem_global_exit.3
@@ -1,0 +1,165 @@
+.TH SHMEM_GLOBAL_EXIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_global_exit \- 
+A routine that allows any PE to force termination of an entire program.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B _Noreturn
+.B void
+.B shmem_global_exit(int
+.I status
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_global_exit(int
+.I status
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "STATUS"
+.BR "CALL " "SHMEM_GLOBAL_EXIT(status)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I status
+- The exit status from the main program.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_global\_exit
+is a non-collective routine that allows any one
+PE to force termination of an OpenSHMEM program for all PEs,
+passing an exit status to the execution environment. This routine terminates
+the entire program, not just the OpenSHMEM portion. When any PE calls
+.B shmem\_global\_exit
+, it results in the immediate notification to all
+PEs to terminate. 
+.B shmem\_global\_exit
+flushes I/O and releases
+resources in accordance with C/C++/Fortran language requirements for normal
+program termination. If more than one PE calls
+.B shmem\_global\_exit
+, then the exit status returned to the environment
+shall be one of the values passed to 
+.B shmem\_global\_exit
+as the
+status argument. There is no return to the caller of
+.B shmem\_global\_exit
+; control is returned from the OpenSHMEM program
+to the execution environment for all PEs.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS API Notes
+
+.B shmem\_global\_exit
+may be used in situations where one or more
+PEs have determined that the program has completed and/or should
+terminate early. Accordingly, the integer status argument can be used to
+pass any information about the nature of the exit, e.g an encountered error
+or a found solution. Since 
+.B shmem\_global\_exit
+is a non-collective
+routine, there is no implied synchronization, and all PEs must
+terminate regardless of their current execution state. While I/O must be
+flushed for standard language I/O calls from C/C++/Fortran, it is
+implementation dependent as to how I/O done by other means (e.g. third
+party I/O libraries) is handled. Similarly, resources are released
+according to C/C++/Fortran standard language requirements, but this may not
+include all resources allocated for the OpenSHMEM program. However, a
+quality implementation will make a best effort to flush all I/O and clean
+up all resources.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+
+
+.nf
+#include <stdio.h>
+#include <stdlib.h>
+#include <shmem.h> 
+
+int main(void)
+{
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) {
+     FILE *fp = fopen("input.txt", "r"); 
+     if (fp == NULL) {  /* Input file required by program is not available */
+        shmem_global_exit(EXIT_FAILURE);
+     }
+     /* do something with the file */
+     fclose(fp);
+ }
+ shmem_finalize();
+ return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_iget.3
+++ b/man/shmem_iget.3
@@ -1,0 +1,408 @@
+.TH SHMEM_IGET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_iget \- 
+Copies strided data from a specified PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_iget(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_iget(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_iget<SIZE>(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "dst, sst, nelems, pe"
+.BR "CALL " "SHMEM_COMPLEX_IGET(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_IGET(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IGET4(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IGET8(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IGET32(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IGET64(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IGET128(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_IGET(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_IGET(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- Array to be updated on the local PE. 
+
+
+.BR "IN " -
+.I source
+- Array containing the data to be copied on the remote PE.
+
+
+.BR "IN " -
+.I dst
+- The stride between consecutive elements of the 
+.I "dest"
+array. The stride is scaled by the element size of the 
+.I "dest"
+array.
+A value of 1 indicates contiguous data. 
+.I dst
+must be of
+type ptrdiff\_t. If you are calling from Fortran, it must
+be a default integer value.
+
+
+.BR "IN " -
+.I sst
+- The stride between consecutive elements of the
+.I "source"
+array. The stride is scaled by the element size of the 
+.I "source"
+array. A value of 1 indicates contiguous data. 
+.I sst
+must be
+of type ptrdiff\_t. If you are calling from Fortran, it must
+be a default integer value.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I "dest"
+and 
+.I "source"
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are
+using Fortran, it must be a constant, variable, or array element of
+default integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must be
+of type integer. If you are using Fortran, it must be a constant,
+variable, or array element of default integer type.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B iget
+routines provide a method for copying strided data elements from
+a symmetric array from a specified remote PE to strided locations on a
+local array. The routines return when the data has been copied into the local
+.I dest
+array.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I dest
+and 
+.I source
+data objects must conform to typing
+constraints, which are as follows:
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iget4, shmem\_iget32
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iget8
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iget64
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iget128
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_IGET
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_IGET
+Fortran: Elements of type double precision.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_IGET
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_IGET
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_IGET
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+If you are using Fortran, data types must be of default size. For example, a
+real variable must be declared as REAL, REAL*4, or
+REAL(KIND=KIND(1.0)). 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following example uses 
+.B shmem\_logical\_iget
+in a Fortran
+program.
+
+.nf
+PROGRAM STRIDELOGICAL
+INCLUDE "shmem.fh"
+
+LOGICAL SOURCE(10), DEST(5)
+SAVE SOURCE   ! SAVE MAKES IT REMOTELY ACCESSIBLE
+DATA SOURCE /.T.,.F.,.T.,.F.,.T.,.F.,.T.,.F.,.T.,.F./
+DATA DEST / 5*.F. /
+CALL SHMEM_INIT()
+IF (SHMEM_MY_PE() .EQ. 0) THEN
+  CALL SHMEM_LOGICAL_IGET(DEST, SOURCE, 1, 2, 5, 1)
+  PRINT*,'DEST AFTER SHMEM_LOGICAL_IGET:',DEST
+ENDIF
+CALL SHMEM_BARRIER_ALL
+.fi
+
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_inc.3
+++ b/man/shmem_inc.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_inc.3

--- a/man/shmem_info_get_name.3
+++ b/man/shmem_info_get_name.3
@@ -1,0 +1,97 @@
+.TH SHMEM_INFO_GET_NAME 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_info_get_name \- 
+This routine returns the vendor defined character string.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_info_get_name(char
+.I *name
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CHARACTER " "*(*)NAME"
+SHMEM_INFO_GET_NAME(NAME)   
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I name
+- The vendor defined string.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+This routine returns the vendor defined character string of size defined by
+the library constant SHMEM\_MAX\_NAME\_LEN. The program calling
+this function prepares the 
+.I name
+memory buffer of at least size
+SHMEM\_MAX\_NAME\_LEN. The implementation copies the vendor defined
+string of size at most SHMEM\_MAX\_NAME\_LEN to 
+.IR "name" .
+. In
+C/C++, the string is terminated by a null character. In Fortran,
+the string of size less than SHMEM\_MAX\_NAME\_LEN is padded with
+blank characters up to size SHMEM\_MAX\_NAME\_LEN. If the
+.I name
+memory buffer is provided with size less than
+SHMEM\_MAX\_NAME\_LEN, behavior is undefined. For a given library
+implementation, the vendor string returned is consistent with the library
+constant SHMEM\_VENDOR\_STRING.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None. 
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None. 
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_info_get_version.3
+++ b/man/shmem_info_get_version.3
@@ -1,0 +1,91 @@
+.TH SHMEM_INFO_GET_VERSION 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_info_get_version \- 
+Returns the major and minor version of the library implementation.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_info_get_version(int
+.IB "*major" ,
+.B int
+.I *minor
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "MAJOR, MINOR"
+SHMEM_INFO_GET_VERSION(MAJOR, MINOR)   
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I major
+- The major version of the OpenSHMEM standard in use.
+
+
+.BR "OUT " -
+.I minor
+- The minor version of the OpenSHMEM standard in use.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+This routine returns the major and minor version of the OpenSHMEM standard
+in use. For a given library implementation, the major and minor version
+returned by these calls are consistent with the library constants
+SHMEM\_MAJOR\_VERSION and SHMEM\_MINOR\_VERSION.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None. 
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_init.3
+++ b/man/shmem_init.3
@@ -1,0 +1,158 @@
+.TH SHMEM_INIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_init \- 
+A collective operation that allocates and initializes the resources used by
+the OpenSHMEM library.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_init(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INIT()"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_init
+allocates and initializes resources used by the OpenSHMEM
+library. It is a collective operation that all PEs must call before any
+other OpenSHMEM routine may be called. At the end of the OpenSHMEM program
+which it initialized, the call to 
+.B shmem\_init
+must be matched with a
+call to 
+.BR "shmem\_finalize" .
+After the first call to 
+.B shmem\_init
+, a
+subsequent call to 
+.B shmem\_init
+in the same program results in undefined
+behavior.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM Specification 1.2 the use of 
+.B start\_pes
+has been
+deprecated and is replaced with 
+.BR "shmem\_init" .
+While support for
+.B start\_pes
+is still required in OpenSHMEM libraries, users are
+encouraged to use 
+.BR "shmem\_init" .
+Replacing 
+.B start\_pes
+with
+.B shmem\_init
+in OpenSHMEM programs with no further changes is possible;
+there is an implicit 
+.B shmem\_finalize
+at the end of main. However,
+.B shmem\_init
+differs slightly from 
+.B start\_pes
+: multiple calls to
+.B shmem\_init
+within a program results in undefined behavior, while in the
+case of 
+.B start\_pes
+, any subsequent calls to 
+.B start\_pes
+after the
+first one resulted in a no-op.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This is a simple program that calls 
+.B shmem\_init
+: 
+
+.nf
+PROGRAM PUT
+INCLUDE "shmem.fh"
+
+INTEGER TARG, SRC, RECEIVER, BAR
+COMMON /T/ TARG
+PARAMETER (RECEIVER=1)
+CALL SHMEM_INIT()
+
+IF (SHMEM_MY_PE() .EQ. 0) THEN
+   SRC = 33
+   CALL SHMEM_INTEGER_PUT(TARG, SRC, 1, RECEIVER)
+ENDIF
+
+CALL SHMEM_BARRIER_ALL           ! SYNCHRONIZES SENDER AND RECEIVER
+
+IF (SHMEM_MY_PE() .EQ. RECEIVER) THEN
+   PRINT*,'PE ', SHMEM_MY_PE(),' TARG=',TARG,' (expect 33)'
+ENDIF
+
+CALL SHMEM_FINALIZE()
+
+END
+.fi
+
+
+
+
+

--- a/man/shmem_iput.3
+++ b/man/shmem_iput.3
@@ -1,0 +1,431 @@
+.TH SHMEM_IPUT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_iput \- 
+Copies strided data to a specified PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_iput(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_iput(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_iput<SIZE>(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B ptrdiff_t
+.IB "dst" ,
+.B ptrdiff_t
+.IB "sst" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "dst, sst, nelems, pe"
+.BR "CALL " "SHMEM_COMPLEX_IPUT(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_IPUT(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_IPUT(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IPUT4(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IPUT8(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IPUT32(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IPUT64(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_IPUT128(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_IPUT(dest, source, dst, sst, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- Array to be updated on the remote PE. This data
+object must be remotely accessible.
+
+
+.BR "IN " -
+.I source
+- Array containing the data to be copied.
+
+
+.BR "IN " -
+.I dst
+- The stride between consecutive elements of the 
+.I "dest"
+array. The stride is scaled by the element size of the 
+.I "dest"
+array. A
+value of 1 indicates contiguous data. 
+.I dst
+must be of type
+ptrdiff\_t. If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I sst
+- The stride between consecutive elements of the
+.I "source"
+array. The stride is scaled by the element size of the 
+.I "source"
+array. A value of 1 indicates contiguous data. 
+.I sst
+must be
+of type ptrdiff\_t. If you are using Fortran, it must be a
+default integer value.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I "dest"
+and 
+.I "source"
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are
+using Fortran, it must be a constant, variable, or array element of
+default integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must be
+of type integer. If you are using Fortran, it must be a constant,
+variable, or array element of default integer type.
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B iput
+routines provide a method for copying strided data
+elements (specified by 
+.I sst
+) of an array from a 
+.I "source"
+array on the
+local PE to locations specified by stride 
+.I dst
+on a 
+.I "dest"
+array
+on specified remote PE. Both strides, 
+.I dst
+and 
+.I sst
+, must be
+greater than or equal to 1. The routines return when the data has
+been copied out of the 
+.I source
+array on the local PE but not
+necessarily before the data has been delivered to the remote data object.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to typing constraints,
+which are as follows:
+
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iput4, shmem\_iput32
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iput8
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iput64
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_iput128
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_IPUT
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_IPUT
+Elements of type double precision.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_IPUT
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_IPUT
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_IPUT
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+If you are using Fortran, data types must be of default size. For example, a
+real variable must be declared as REAL, REAL*4 or
+REAL(KIND=KIND(1.0)).
+Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+Consider the following 
+.B shmem\_iput
+example for C11 programs.
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  short source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  static short dest[10];
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) /* put 5 elements into dest on PE 1 */
+     shmem_iput(dest, source, 1, 2, 5, 1);
+  shmem_barrier_all(); /* sync sender and receiver */
+  if (me == 1) {
+     printf("dest on PE %d is %hd %hd %hd %hd %hd\\n", me,
+        dest[0], dest[1], dest[2], dest[3], dest[4]);
+  }
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_lock.3
+++ b/man/shmem_lock.3
@@ -1,0 +1,160 @@
+.TH SHMEM_LOCK 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_lock \- 
+Releases, locks, and tests a mutual exclusion memory lock.
+
+./ sectionEnd
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_clear_lock(long
+.I *lock
+.B );
+
+
+
+.B void
+.B shmem_set_lock(long
+.I *lock
+.B );
+
+
+
+.B int
+.B shmem_test_lock(long
+.I *lock
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "lock, SHMEM_TEST_LOCK"
+.BR "CALL " "SHMEM_CLEAR_LOCK(lock)"
+.BR "CALL " "SHMEM_SET_LOCK(lock)"
+I = SHMEM_TEST_LOCK(lock)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I lock
+- A symmetric data object that is a scalar variable or an array
+of length 1. This data object must be set to 0 on all
+PEs prior to the first use. 
+.I lock
+must be of type long.
+If you are using Fortran, it must be of default kind.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_set\_lock
+routine sets a mutual exclusion lock after waiting
+for the lock to be freed by any other PE currently holding the lock.
+Waiting PEs are assured of getting the lock in a first-come, first-served
+manner. The 
+.B shmem\_clear\_lock
+routine releases a lock previously set
+by 
+.B shmem\_set\_lock
+after ensuring that all local and remote stores
+initiated in the critical region are complete. The 
+.B shmem\_test\_lock
+routine sets a mutual exclusion lock only if it is currently cleared. By using
+this routine, a PE can avoid blocking on a set lock. If the lock is
+currently set, the routine returns without waiting. These routines are
+appropriate for protecting a critical region from simultaneous update by
+multiple PEs.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The 
+.B shmem\_test\_lock
+routine returns 0 if the lock was
+originally cleared and this call was able to set the lock. A value of
+1 is returned if the lock had been set and the call returned without
+waiting to set the lock.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
+The lock variable should always be initialized to zero and accessed only by the OpenSHMEM locking
+API. Changing the value of the lock variable by other means without using
+the OpenSHMEM API, can lead to undefined behavior.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following example uses 
+.B shmem\_lock
+in a C[11] program.
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long lock = 0;
+  static int count = 0;
+  shmem_init();
+  int me = shmem_my_pe();
+  shmem_set_lock(&lock);
+  int val = shmem_g(&count, 0); /* get count value on PE 0 */
+  printf("%d: count is %d\\n", me, val);
+  val++; /* incrementing and updating count on PE 0 */
+  shmem_p(&count, val, 0);
+  shmem_quiet();
+  shmem_clear_lock(&lock);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_malloc.3
+++ b/man/shmem_malloc.3
@@ -1,0 +1,257 @@
+.TH SHMEM_MALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_malloc \- 
+Symmetric heap memory management routines.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B *shmem_malloc(size_t
+.I size
+.B );
+
+
+
+.B void
+.B shmem_free(void
+.I *ptr
+.B );
+
+
+
+.B void
+.B *shmem_realloc(void
+.IB "*ptr" ,
+.B size_t
+.I size
+.B );
+
+
+
+.B void
+.B *shmem_align(size_t
+.IB "alignment" ,
+.B size_t
+.I size
+.B );
+
+
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I size
+- The size, in bytes, of a block to be
+allocated from the symmetric heap. This argument is of type 
+.I size\_t
+
+
+
+.BR "IN " -
+.I ptr
+- Points to a block within the symmetric heap.
+
+
+.BR "IN " -
+.I alignment
+- Byte alignment of the block allocated from the
+symmetric heap.
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_malloc
+routine returns a pointer to a block of at least
+.I size
+bytes suitably aligned for any use. This space is allocated from the
+symmetric heap (in contrast to 
+.B malloc
+, which allocates from the private
+heap).
+
+The 
+.B shmem\_align
+routine allocates a block in the symmetric heap that has
+a byte alignment specified by the alignment argument.
+
+The 
+.B shmem\_free
+routine causes the block to which 
+.I ptr
+points to be
+deallocated, that is, made available for further allocation. If 
+.I ptr
+is a
+null pointer, no action occurs. 
+
+The 
+.B shmem\_realloc
+routine changes the size of the block to which
+.I ptr
+points to the size (in bytes) specified by 
+.IR "size" .
+. The contents
+of the block are unchanged up to the lesser of the new and old sizes. If the new
+size is larger, the newly allocated portion of the block is
+uninitialized. If 
+.I ptr
+is a NULL pointer, the
+.B shmem\_realloc
+routine behaves like the 
+.B shmem\_malloc
+routine for
+the specified size. If 
+.I size
+is 0 and 
+.I ptr
+is not a
+NULL pointer, the block to which it points is freed. If the space cannot
+be allocated, the block to which 
+.I ptr
+points is unchanged.
+
+The 
+.B shmem\_malloc
+, 
+.B shmem\_align
+, 
+.B shmem\_free
+, and 
+.B shmem\_realloc
+routines
+are provided so that multiple PEs in a program can allocate symmetric,
+remotely accessible memory blocks. These memory blocks can then be used with
+OpenSHMEM communication routines. Each of these routines include at least one
+call to a procedure that is semantically equivalent to 
+.B shmem\_barrier\_all
+:
+.B shmem\_malloc
+and 
+.B shmem\_align
+call a
+barrier on exit; 
+.B shmem\_free
+calls a barrier on entry; and
+.B shmem\_realloc
+may call barriers on both entry and exit, depending on
+whether an existing allocation is modified and whether new memory is allocated.
+This ensures that all
+PEs participate in the memory allocation, and that the memory on other
+PEs can be used as soon as the local PE returns. The user is
+responsible for calling these routines with identical argument(s) on all
+PEs; if differing 
+.I size
+arguments are used, the behavior of the call
+and any subsequent OpenSHMEM calls becomes undefined.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The 
+.B shmem\_malloc
+routine returns a pointer to the allocated space;
+otherwise, it returns a NULL pointer.
+
+The 
+.B shmem\_free
+routine returns no value.
+
+The 
+.B shmem\_realloc
+routine returns a pointer to the allocated space
+(which may have moved); otherwise, it returns a null pointer.
+
+The 
+.B shmem\_align
+routine returns an aligned pointer to the allocated
+space; otherwise, it returns a NULL pointer.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of Specification 1.2 the use of 
+.B shmalloc
+, 
+.B shmemalign
+,
+.B shfree
+, and 
+.B shrealloc
+has been deprecated. Although OpenSHMEM
+libraries are required to support the calls, program users are encouraged to use
+.B shmem\_malloc
+, 
+.B shmem\_align
+, 
+.B shmem\_free
+, and
+.B shmem\_realloc
+instead. The behavior and signature of the routines
+remains unchanged from the deprecated versions.
+
+The total size of the symmetric heap is determined at job startup. One can
+adjust the size of the heap using the SHMEM\_SYMMETRIC\_SIZE environment
+variable (where available).
+
+The 
+.B shmem\_malloc
+, 
+.B shmem\_free
+, and 
+.B shmem\_realloc
+routines
+differ from the private heap allocation routines in that all PEs in a
+program must call them (a barrier is used to ensure this).
+
+./ sectionEnd
+		
+
+./ sectionStart
+
+.SS API Notes
+
+The symmetric heap allocation routines always return a pointer to corresponding
+symmetric objects across all PEs. The OpenSHMEM specification does not
+require that the virtual addresses are equal across all PEs. Nevertheless,
+the implementation must avoid costly address translation operations in the
+communication path, including order N (where N is the number of PEs)
+memory translation tables. In order to avoid address translations, the
+implementation may re-map the allocated block of memory based on agreed virtual
+address. Additionally, some operating systems provide an option to disable
+virtual address randomization, which enables predictable allocation of virtual
+memory addresses.
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_my_pe.3
+++ b/man/shmem_my_pe.3
@@ -1,0 +1,95 @@
+.TH SHMEM_MY_PE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_my_pe \- 
+Returns the number of the calling PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B int
+.B shmem_my_pe(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "SHMEM_MY_PE, ME"
+ME = SHMEM_MY_PE()
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+This routine returns the PE number of the calling PE. It accepts no
+arguments. The result is an integer between 0 and 
+.I npes
+-
+1, where 
+.I npes
+is the total number of PEs executing the
+current program.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+Integer - Between 0 and 
+.I npes
+- 1
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+Each PE has a unique number or identifier. As of OpenSHMEM Specification
+1.2 the use of 
+.B \_my\_pe
+has been deprecated. Although OpenSHMEM
+libraries are required to support the call, users are encouraged to use
+.B shmem\_my\_pe
+instead. The behavior and signature of the routine
+.B shmem\_my\_pe
+remains unchanged from the deprecated 
+.B \_my\_pe
+version.
+
+./ sectionEnd
+
+
+
+

--- a/man/shmem_n_pes.3
+++ b/man/shmem_n_pes.3
@@ -1,0 +1,118 @@
+.TH SHMEM_N_PES 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_n_pes \- 
+Returns the number of PEs running in a program.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B int
+.B shmem_n_pes(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "INTEGER " "SHMEM_N_PES, N_PES"
+N_PES = SHMEM_N_PES()
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The routine returns the number of PEs running in the program.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+Integer - Number of PEs running in the OpenSHMEM program.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM Specification 1.2 the use of 
+.B \_num\_pes
+has been
+deprecated. Although OpenSHMEM libraries are required to support the call,
+users are encouraged to use 
+.B shmem\_n\_pes
+instead. The behavior and
+signature of the routine 
+.B shmem\_n\_pes
+remains unchanged from the
+deprecated 
+.B \_num\_pes
+version.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_my\_pe
+and 
+.B shmem\_n\_pes
+example is for
+C/C++ programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  shmem_init();
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+  printf("I am #%d of %d PEs executing this program\\n", me, npes);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_p.3
+++ b/man/shmem_p.3
@@ -1,0 +1,221 @@
+.TH SHMEM_P 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_p \- 
+Copies one data item to a remote PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_p(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_p(TYPE
+.IB "*dest" ,
+.B TYPE
+.IB "value" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I addr
+- The remotely accessible array element or scalar data object
+which will receive the data on the remote PE.
+
+
+.BR "IN " -
+.I value
+- The value to be transferred to 
+.I addr
+on the
+remote PE.
+
+
+.BR "IN " -
+.I pe
+- The number of the remote PE.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+These routines provide a very low latency put capability for single elements of
+most basic types.
+
+As with 
+.B shmem\_put
+, these routines start the remote transfer and may
+return before the data is delivered to the remote PE. Use
+.B shmem\_quiet
+to force completion of all remote PUT transfers.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following example uses 
+.B shmem\_p
+in a C[11] program.
+
+.nf
+#include <stdio.h>
+#include <math.h>
+#include <shmem.h>
+
+int main(void)
+{
+  const double e = 2.71828182;
+  const double epsilon = 0.00000001;
+  static double f = 3.1415927;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0)
+     shmem_p(&f, e, 1);
+  shmem_barrier_all();
+  if (me == 1)
+     printf("%s\\n", (fabs(f - e) < epsilon) ? "OK" : "FAIL");
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_pe_accessible.3
+++ b/man/shmem_pe_accessible.3
@@ -1,0 +1,105 @@
+.TH SHMEM_PE_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_pe_accessible \- 
+Determines whether a PE is accessible via OpenSHMEM's data transfer
+routines.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B int
+.B shmem_pe_accessible(int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "LOGICAL " "LOG, SHMEM_PE_ACCESSIBLE"
+.BR "INTEGER " "pe"
+LOG = SHMEM_PE_ACCESSIBLE(pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I pe
+- Specific PE to be checked for accessibility from
+the local PE.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_pe\_accessible
+is a query routine that indicates whether a
+specified PE is accessible via OpenSHMEM from the local PE. The
+.B shmem\_pe\_accessible
+routine returns TRUE only if the remote
+PE is a process running from the same executable file as the local
+PE, indicating that full OpenSHMEM support for symmetric data objects
+(that reside in the static memory and symmetric heap) is available, otherwise it
+returns FALSE. This routine may be particularly useful for hybrid
+programming with other communication libraries (such as a MPI) or parallel
+languages. For example, on SGI Altix series systems, OpenSHMEM is
+supported across multiple partitioned hosts and InfiniBand connected hosts.
+When running multiple executable MPI programs using OpenSHMEM on an Altix, full
+OpenSHMEM support is available between processes running from the same
+executable file. However, OpenSHMEM support between processes of different
+executable files is supported only for data objects on the symmetric heap,
+since static data objects are not symmetric between different executable
+files. 
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+C/C++: The return value is 1 if the specified PE is a valid remote PE
+for OpenSHMEM routines; otherwise, it is 0. 
+
+
+
+Fortran: The return value is .TRUE. if the specified PE is a valid
+remote PE for OpenSHMEM routines; otherwise, it is .FALSE.. 
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+None. 
+./ sectionEnd
+
+
+
+

--- a/man/shmem_ptr.3
+++ b/man/shmem_ptr.3
@@ -1,0 +1,196 @@
+.TH SHMEM_PTR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_ptr \- 
+Returns a pointer to a data object on a specified PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B *shmem_ptr(const
+.B void
+.IB "*dest" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "POINTER " "(PTR, POINTEE)"
+.BR "INTEGER " "pe"
+PTR = SHMEM_PTR(dest, pe)
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- The symmetric data object to be referenced.
+
+
+.BR "IN " -
+.I pe
+- An integer that indicates the PE number on which 
+.I "dest"
+is to
+be accessed. If you are using Fortran, it must be a default
+integer value.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_ptr
+returns an address that may be used to directly reference
+.I "dest"
+on the specified PE. This address can be assigned to a pointer.
+After that, ordinary loads and stores to this remote address may be performed.
+
+When a sequence of loads (gets) and stores (puts) to a data object on a
+remote PE does not match the access pattern provided in an OpenSHMEM data
+transfer routine like 
+.B shmem\_put32
+or 
+.B shmem\_real\_iget
+, the
+.B shmem\_ptr
+routine can provide an efficient means to accomplish the
+communication.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+The return value is a non-NULL address of the 
+.I "dest"
+data object when it is 
+accessible using memory loads and stores in addition to OpenSHMEM operations.
+Otherwise, a NULL address is returned.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+When calling 
+.B shmem\_ptr
+, 
+.I "dest"
+is the address of the referenced
+symmetric data object on the calling PE.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This Fortran program calls 
+.B shmem\_ptr
+and then PE 0 writes to
+the 
+.I BIGD
+array on PE 1: 
+
+.nf
+PROGRAM REMOTEWRITE
+INCLUDE "shmem.fh"
+
+INTEGER BIGD(100)
+SAVE BIGD
+
+INTEGER POINTEE(*)
+POINTER (PTR,POINTEE)
+
+CALL SHMEM_INIT()
+
+
+IF (SHMEM_MY_PE() .EQ. 0) THEN
+  ! initialize PE 1's BIGD array
+  PTR = SHMEM_PTR(BIGD, 1)     ! get address of PE 1's BIGD
+                               !   array
+  DO I=1,100
+       POINTEE(I) = I
+  ENDDO
+ENDIF
+
+CALL SHMEM_BARRIER_ALL
+
+IF (SHMEM_MY_PE() .EQ. 1) THEN
+  PRINT*,'BIGD on PE 1 is: '
+  PRINT*,BIGD
+ENDIF
+END
+
+.fi
+
+
+
+This is the equivalent program written in C[11]:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void) 
+{
+  static int dest[4];
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) { /* initialize PE 1's dest array */
+     int* ptr = shmem_ptr(dest, 1);
+     if (ptr == NULL)
+        printf("can't use pointer to directly access PE 1's dest array\\n");
+     else
+        for (int i = 0; i < 4; i++)
+           *ptr++ = i + 1;
+  }
+  shmem_barrier_all();
+  if (me == 1)
+     printf("PE 1 dest: %d, %d, %d, %d\\n",
+        dest[0], dest[1], dest[2], dest[3]);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+

--- a/man/shmem_put.3
+++ b/man/shmem_put.3
@@ -1,0 +1,422 @@
+.TH SHMEM_PUT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_put \- 
+The put routines provide a method for copying data from a contiguous local
+data object to a data object on a specified PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_put(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_put(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_put<SIZE>(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+
+.B void
+.B shmem_putmem(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_CHARACTER_PUT(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_COMPLEX_PUT(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_PUT(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_PUT(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_PUT(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT4(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT8(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT32(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT64(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT128(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUTMEM(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_PUT(dest, source, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- Data object to be updated on the remote PE. This
+data object must be remotely accessible.
+
+
+.BR "OUT " -
+.I source
+- Data object containing the data to be copied.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I dest
+and 
+.I source
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are using
+Fortran, it must be a constant, variable, or array element of default
+integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must be
+of type integer. If you are using Fortran, it must be a constant, variable,
+or array element of default integer type.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The routines return after the data has been copied out of the 
+.I "source"
+array
+on the local PE. The delivery of data words into the data object on the
+destination PE may occur in any order. Furthermore, two successive put
+routines may deliver data out of order unless a call to 
+.B shmem\_fence
+is
+introduced between the two calls. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to certain typing
+constraints, which are as follows:
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_putmem
+Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put4, shmem\_put32
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put8
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put64
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put128
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_CHARACTER\_PUT
+Elements of type character. 
+.I nelems
+is the number of characters to transfer. The actual character lengths of the 
+.I "source"
+and 
+.I "dest"
+variables are ignored. 
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_PUT
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_PUT
+Elements of type double precision. 
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_PUT
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_PUT
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_PUT
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+./ sectionStart
+
+.SS API Notes
+
+If you are using Fortran, data types must be of default size. For example,
+a real variable must be declared as REAL, REAL*4, or
+REAL(KIND=KIND(1.0)). The Fortran API routine 
+.B SHMEM\_PUT
+has
+been deprecated, and either 
+.B SHMEM\_PUT8
+or 
+.B SHMEM\_PUT64
+should
+be used in its place.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following 
+.B shmem\_put
+example is for C11 programs:
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  long source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  static long dest[10];
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) /* put 10 words into dest on PE 1 */
+     shmem_put(dest, source, 10, 1);
+  shmem_barrier_all(); /* sync sender and receiver */
+  printf("dest[0] on PE %d is %ld\\n", me, dest[0]);
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_put_nbi.3
+++ b/man/shmem_put_nbi.3
@@ -1,0 +1,387 @@
+.TH SHMEM_PUT_NBI 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_put_nbi \- 
+The nonblocking put routines provide a method for copying data
+from a contiguous local data object to a data object on a specified PE. 
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_put_nbi(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types specified by Table 1.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_put_nbi(TYPE
+.IB "*dest" ,
+.B const
+.B TYPE
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
+./ sectionStart
+
+.B void
+.B shmem_put<SIZE>_nbi(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+where SIZE is one of 8, 16, 32, 64, 128.
+./ sectionStart
+
+.B void
+.B shmem_putmem_nbi(void
+.IB "*dest" ,
+.B const
+.B void
+.IB "*source" ,
+.B size_t
+.IB "nelems" ,
+.B int
+.I pe
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_CHARACTER_PUT_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_COMPLEX_PUT_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_DOUBLE_PUT_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_INTEGER_PUT_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_LOGICAL_PUT_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT4_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT8_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT32_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT64_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUT128_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_PUTMEM_NBI(dest, source, nelems, pe)"
+.BR "CALL " "SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I dest
+- Data object to be updated on the remote PE. This
+data object must be remotely accessible.
+
+
+.BR "IN " -
+.I source
+- Data object containing the data to be copied.
+
+
+.BR "IN " -
+.I nelems
+- Number of elements in the 
+.I dest
+and 
+.I source
+arrays. 
+.I nelems
+must be of type 
+.I size\_t
+for C. If you are using
+Fortran, it must be a constant, variable, or array element of default
+integer type.
+
+
+.BR "IN " -
+.I pe
+- PE number of the remote PE. 
+.I pe
+must be
+of type integer. If you are using Fortran, it must be a constant, variable,
+or array element of default integer type.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The routines return after posting the operation. The operation is considered 
+complete after a subsequent call to 
+.BR "shmem\_quiet" .
+At the completion of 
+.B shmem\_quiet
+, the data has been copied into the 
+.I "dest"
+array
+on the destination PE.
+The delivery of data words into the data object on the
+destination PE may occur in any order.
+Furthermore, two successive put
+routines may deliver data out of order unless a call to 
+.B shmem\_fence
+is
+introduced between the two calls. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+The 
+.I "dest"
+and 
+.I "source"
+data objects must conform to certain typing
+constraints, which are as follows:
+.TP 25
+Routine
+Data type of 
+.I dest
+and 
+.I source
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_putmem\_nbi
+Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put4\_nbi, shmem\_put32\_nbi
+Any noncharacter type that has a storage size equal to 32 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put8\_nbi
+C: Any noncharacter type that has a storage size equal to 8 bits.
+./ sectionEnd
+
+
+
+./ sectionStart
+Fortran: Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put64\_nbi
+Any noncharacter type that has a storage size equal to 64 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_put128\_nbi
+Any noncharacter type that has a storage size equal to 128 bits.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_CHARACTER\_PUT\_NBI
+Elements of type character. 
+.I nelems
+is the number of characters to transfer. The actual character lengths of the 
+.I "source"
+and 
+.I "dest"
+variables are ignored. 
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_COMPLEX\_PUT\_NBI
+Elements of type complex of default size.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_DOUBLE\_PUT\_NBI
+Elements of type double precision. 
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_INTEGER\_PUT\_NBI
+Elements of type integer.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_LOGICAL\_PUT\_NBI
+Elements of type logical.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+SHMEM\_REAL\_PUT\_NBI
+Elements of type real.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+./ sectionStart
+
+.SS API Notes
+None.
+./ sectionEnd
+
+
+
+
+.SS Table 1:
+Standard RMA Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+float
+float
+.TP
+double
+double
+.TP
+long double
+longdouble
+.TP
+char
+char
+.TP
+signed char
+schar
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned char
+uchar
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int8\_t
+int8
+.TP
+int16\_t
+int16
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint8\_t
+uint8
+.TP
+uint16\_t
+uint16
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_putmem.3
+++ b/man/shmem_putmem.3
@@ -1,0 +1,1 @@
+.so shmem_put.3

--- a/man/shmem_quiet.3
+++ b/man/shmem_quiet.3
@@ -1,0 +1,169 @@
+.TH SHMEM_QUIET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_quiet \- 
+Waits for completion of all outstanding PUT, AMOs, memory store,
+and non-blocking PUT and GET routines to symmetric data
+objects issued by a PE.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_quiet(void)
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_QUIET"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.B None.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B shmem\_quiet
+routine ensures completion of PUT, AMOs,
+memory store, and non-blocking PUT and GET routines on
+symmetric data objects issued by the calling PE. All PUT, AMOs,
+memory store, and non-blocking PUT and GET routines to
+symmetric data objects are guaranteed to be completed and visible to all
+PEs when 
+.B shmem\_quiet
+returns. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+.B shmem\_quiet
+is most useful as a way of ensuring completion of
+several PUT, AMOs, memory store, and non-blocking PUT
+and GET routines to symmetric data objects initiated by the calling
+PE. For example, you might use 
+.B shmem\_quiet
+to await delivery
+of a block of data before issuing another PUT or non-blocking
+PUT routine, which sets a completion flag on another PE.
+.B shmem\_quiet
+is not usually needed if
+.B shmem\_barrier\_all
+or 
+.B shmem\_barrier
+are called. The barrier
+routines wait for the completion of outstanding writes (PUT, AMO,
+memory stores, and nonblocking PUT and GET routines) to
+symmetric data objects on all PEs.
+
+
+.B shmem\_quiet
+does not have an effect on the ordering between memory 
+accesses issued by the target PE.
+.B shmem\_wait
+, 
+.B shmem\_wait\_until
+, 
+.B shmem\_test
+, 
+.B shmem\_barrier
+,
+.B shmem\_barrier\_all
+routines can be called by the target PE to guarantee 
+ordering of its memory accesses.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following example uses 
+.B shmem\_quiet
+in a C11 program: 
+
+.nf
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void)
+{
+  static long dest[3];
+  static long source[3] = { 1, 2, 3 };
+  static int targ;
+  static int src = 90;
+  long x[3] = { 0 };
+  int y = 0;
+  shmem_init();
+  int me = shmem_my_pe();
+  if (me == 0) {
+     shmem_put(dest, source, 3, 1); /* put1 */
+     shmem_put(&targ, &src, 1, 2);  /* put2 */
+     shmem_quiet();
+     shmem_get(x, dest, 3, 1);   /* gets updated value from dest on PE 1 to local array x */
+     shmem_get(&y, &targ, 1, 2); /* gets updated value from targ on PE 2 to local variable y */
+     printf("x: { %ld, %ld, %ld }\\n", x[0], x[1], x[2]); /* x: { 1, 2, 3 } */
+     printf("y: %d\\n", y); /* y: 90 */
+     shmem_put(&targ, &src, 1, 1); /* put3 */
+     shmem_put(&targ, &src, 1, 2); /* put4 */
+  }
+  shmem_finalize();
+  return 0;
+}
+.fi
+
+.I Put1
+and 
+.I put2
+will be completed and visible before 
+.I put3
+and 
+.IR "put4" .
+.
+
+
+

--- a/man/shmem_realloc.3
+++ b/man/shmem_realloc.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shmem_reductions.3
+++ b/man/shmem_reductions.3
@@ -1,0 +1,1906 @@
+.TH SHMEM_REDUCTIONS 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_reductions \- 
+Performs arithmetic and logical operations across a set of PEs.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+
+.SH AND
+
+Performs a bitwise AND function across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_short_and_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_and_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_and_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_and_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_AND_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_AND_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH MAX
+
+Performs a maximum function reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_short_max_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_max_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_double_max_to_all(double
+.IB "*dest" ,
+.B const
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_float_max_to_all(float
+.IB "*dest" ,
+.B const
+.I float
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_max_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longdouble_max_to_all(long
+.I double
+.IB "*dest" ,
+.B const
+.B long
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_max_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL4_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL8_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL16_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH MIN
+
+Performs a minimum function reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_short_min_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_min_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_double_min_to_all(double
+.IB "*dest" ,
+.B const
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_float_min_to_all(float
+.IB "*dest" ,
+.B const
+.I float
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_min_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longdouble_min_to_all(long
+.I double
+.IB "*dest" ,
+.B const
+.B long
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_min_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL4_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL8_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL16_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH SUM
+
+Performs a sum reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_complexd_sum_to_all(double
+.I complex
+.IB "*dest" ,
+.B const
+.I double
+.I complex
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.I complex
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_complexf_sum_to_all(float
+.I complex
+.IB "*dest" ,
+.B const
+.I float
+.I complex
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.I complex
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_short_sum_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_sum_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_double_sum_to_all(double
+.IB "*dest" ,
+.B const
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_float_sum_to_all(float
+.IB "*dest" ,
+.B const
+.I float
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_sum_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longdouble_sum_to_all(long
+.I double
+.IB "*dest" ,
+.B const
+.B long
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_sum_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_COMP4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_COMP8_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL8_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL16_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH PROD
+
+Performs a product reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_complexd_prod_to_all(double
+.I complex
+.IB "*dest" ,
+.B const
+.I double
+.I complex
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.I complex
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_complexf_prod_to_all(float
+.I complex
+.IB "*dest" ,
+.B const
+.I float
+.I complex
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.I complex
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_short_prod_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_prod_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_double_prod_to_all(double
+.IB "*dest" ,
+.B const
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_float_prod_to_all(float
+.IB "*dest" ,
+.B const
+.I float
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.I float
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_prod_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longdouble_prod_to_all(long
+.I double
+.IB "*dest" ,
+.B const
+.B long
+.I double
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.I double
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_prod_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_COMP4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_COMP8_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL8_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_REAL16_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH OR
+
+Performs a bitwise OR function reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_short_or_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_or_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_or_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_or_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+.SH XOR
+
+Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (PEs).
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_short_xor_to_all(short
+.IB "*dest" ,
+.B const
+.B short
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B short
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_int_xor_to_all(int
+.IB "*dest" ,
+.B const
+.B int
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B int
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_long_xor_to_all(long
+.IB "*dest" ,
+.B const
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+.B void
+.B shmem_longlong_xor_to_all(long
+.B long
+.IB "*dest" ,
+.B const
+.B long
+.B long
+.IB "*source" ,
+.B int
+.IB "nreduce" ,
+.B int
+.IB "PE_start" ,
+.B int
+.IB "logPE_stride" ,
+.B int
+.IB "PE_size" ,
+.B long
+.B long
+.IB "*pWrk" ,
+.B long
+.I *pSync
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+.BR "CALL " "SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I dest
+- A symmetric array, of length 
+.I nreduce
+elements, to
+receive the result of the reduction routines. The data type of 
+.I "dest"
+varies
+with the version of the reduction routine being called. When calling from
+C/C++, refer to the SYNOPSIS section for data type information.
+
+
+.BR "IN " -
+.I source
+-  A symmetric array, of length 
+.I nreduce
+elements, that
+contains one element for each separate reduction routine. The 
+.I "source"
+argument must have the same data type as 
+.IR "dest" .
+
+
+
+.BR "IN " -
+.I nreduce
+- The number of elements in the 
+.I "dest"
+and 
+.I "source"
+arrays. 
+.I nreduce
+must be of type integer. If you are using Fortran, it
+must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_start
+- The lowest PE number of the 
+.I "Active set"
+of
+PEs. 
+.I PE\_start
+must be of type integer. If you are using Fortran,
+it must be a default integer value.
+
+
+.BR "IN " -
+.I logPE\_stride
+- The log (base 2) of the stride between consecutive
+PE numbers in the 
+.IR "Active set" .
+.I logPE\_stride
+must be of type integer.
+If you are using Fortran, it must be a default integer value.
+
+
+.BR "IN " -
+.I PE\_size
+- The number of PEs in the 
+.IR "Active set" .
+.I PE\_size
+must be of type integer. If you are using Fortran, it must be a
+default integer value.
+
+
+.BR "IN " -
+.I pWrk
+- A symmetric work array. The 
+.I pWrk
+argument must have the
+same data type as 
+.IR "dest" .
+In  C/C++, this contains max(
+.I nreduce
+/2 + 1,
+SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE) elements. In Fortran, this
+contains max(
+.I nreduce
+/2 + 1, SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE)
+elements.
+
+
+.BR "IN " -
+.I pSync
+- A symmetric work array. In  C/C++, 
+.I pSync
+must be of
+type long and size SHMEM\_REDUCE\_SYNC\_SIZE. In Fortran, 
+.I pSync
+must be of type integer and size SHMEM\_REDUCE\_SYNC\_SIZE. If you are
+using Fortran, it must be a default integer value. Every element of this array
+must be initialized with the value SHMEM\_SYNC\_VALUE (in  C/C++) or
+SHMEM\_SYNC\_VALUE (in Fortran) before any of the PEs in the
+.I "Active set"
+enter the reduction routine.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+OpenSHMEM reduction routines compute one or more reductions across symmetric
+arrays on multiple PEs. A reduction performs an associative binary routine
+across a set of values. 
+
+The 
+.I nreduce
+argument determines the number of separate reductions to
+perform. The 
+.I "source"
+array on all PEs in the 
+.I "Active set"
+provides one
+element for each reduction. The results of the reductions are placed in the
+.I "dest"
+array on all PEs in the 
+.IR "Active set" .
+The 
+.I "Active set"
+is defined
+by the 
+.I PE\_start
+, 
+.I logPE\_stride
+, 
+.I PE\_size
+triplet.
+
+The 
+.I "source"
+and 
+.I "dest"
+arrays may be the same array, but they may not be
+overlapping arrays.
+
+As with all OpenSHMEM collective routines, each of these routines assumes
+that only PEs in the 
+.I "Active set"
+call the routine. If a PE not in
+the 
+.I "Active set"
+calls an OpenSHMEM collective routine, undefined behavior
+results.
+
+The values of arguments 
+.I nreduce
+, 
+.I PE\_start
+, 
+.I logPE\_stride
+, and
+.I PE\_size
+must be equal on all PEs in the 
+.IR "Active set" .
+The same 
+.I "dest"
+and 
+.I "source"
+arrays, and the same 
+.I pWrk
+and 
+.I pSync
+work arrays, must
+be passed to all PEs in the 
+.IR "Active set" .
+
+
+Before any PE calls a reduction routine, you must ensure that the
+following conditions exist (synchronization via a 
+.I barrier
+or some other
+method is often needed to ensure this): The 
+.I pWrk
+and 
+.I pSync
+arrays
+on all PEs in the 
+.I "Active set"
+are not still in use from a prior call to a
+collective OpenSHMEM routine. The 
+.I "dest"
+array on all PEs in the
+.I "Active set"
+is ready to accept the results of the 
+.IR "reduction" .
+.
+
+Upon return from a reduction routine, the following are true for the local
+PE: The 
+.I "dest"
+array is updated and the 
+.I "source"
+array may be safely reused. 
+The values in the 
+.I pSync
+array are
+restored to the original values.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+When calling from Fortran, the 
+.I "dest"
+date types are as follows:
+
+.TP 25
+Routine
+Data type
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_and\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_and\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_comp8\_max\_to\_all
+Complex, with an element size equal to two 8-byte real values.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_max\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_max\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real4\_max\_to\_all
+Real, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real16\_max\_to\_all
+Real, with an element size of 16 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_min\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_min\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real4\_min\_to\_all
+Real, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real8\_min\_to\_all
+Real, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real16\_min\_to\_all
+Real,with an element size of 16 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_comp4\_sum\_to\_all
+Complex, with an element size equal to two 4-byte real values.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_comp8\_sum\_to\_all
+Complex, with an element size equal to two 8-byte real values.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_sum\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_sum\_to\_all
+Integer, with an element size of 8 bytes..
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real4\_sum\_to\_all
+Real, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real8\_sum\_to\_all
+Real, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real16\_sum\_to\_all
+Real, with an element size of 16 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_comp4\_prod\_to\_all
+Complex, with an element size equal to two 4-byte real values. 
+./ sectionEnd
+		 
+
+./ sectionStart
+.TP 25
+shmem\_comp8\_prod\_to\_all
+Complex, with an element size equal to two 8-byte real values.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_prod\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_prod\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real4\_prod\_to\_all
+Real, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real8\_prod\_to\_all
+Real, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_real16\_prod\_to\_all
+Real, with an element size of 16 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_or\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_or\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_xor\_to\_all
+Integer, with an element size of 8 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_xor\_to\_all
+Integer, with an element size of 4 bytes.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+All OpenSHMEM reduction routines reset the values in 
+.I pSync
+before they
+return, so a particular 
+.I pSync
+buffer need only be initialized the first
+time it is used. You must ensure that the 
+.I pSync
+array is not being updated on any PE
+in the 
+.I "Active set"
+while any of the PEs participate in processing of an
+OpenSHMEM reduction routine. Be careful to avoid the following situations: If
+the 
+.I pSync
+array is initialized at run time, some type of synchronization
+is needed to ensure that all PEs in the working set have initialized
+.I pSync
+before any of them enter an OpenSHMEM routine called with the
+.I pSync
+synchronization array. A 
+.I pSync
+or 
+.I pWrk
+array can be
+reused in a subsequent reduction routine call only if none of the PEs in
+the 
+.I "Active set"
+are still processing a prior reduction routine call that used
+the same 
+.I pSync
+or 
+.I pWrk
+arrays. In general, this can be assured only
+by doing some type of synchronization. 
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This Fortran reduction example statically initializes the 
+.I pSync
+array
+and finds the logical 
+.I AND
+of the integer variable 
+.I FOO
+across all
+even PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+INTEGER*4 PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+INTEGER FOO, FOOAND
+SAVE FOO, FOOAND, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+FOO = SHMEM_MY_PE()
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+   IF ( MOD(SHMEM_N_PES()(),2) .EQ. 0) THEN
+      CALL SHMEM_INT8_AND_TO_ALL(FOOAND, FOO, NR, 0, 1, NPES/2, &
+	 PWRK, PSYNC)
+   ELSE
+      CALL SHMEM_INT8_AND_TO_ALL(FOOAND, FOO, NR, 0, 1, NPES/2+1, &
+	 PWRK, PSYNC)
+  
+   ENDIF
+   PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOAND
+ENDIF
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and finds
+the 
+.I maximum
+value of real variable 
+.I FOO
+across all even PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL FOO, FOOMAX, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+COMMON /COM/ FOO, FOOMAX, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+      CALL SHMEM_REAL8_MAX_TO_ALL(FOOMAX, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+      PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOMAX
+ENDIF
+
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and finds
+the 
+.I minimum
+value of real variable 
+.I FOO
+across all the even
+PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL FOO, FOOMIN, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+COMMON /COM/ FOO, FOOMIN, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+      CALL SHMEM_REAL8_MIN_TO_ALL(FOOMIN, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+      PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOMIN
+ENDIF
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and finds
+the 
+.I sum
+of the real variable 
+.I FOO
+across all even PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL FOO, FOOSUM, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+COMMON /COM/ FOO, FOOSUM, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+      CALL SHMEM_INT4_SUM_TO_ALL(FOOSUM, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+      PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOSUM
+ENDIF
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and finds
+the 
+.I product
+of the real variable 
+.I FOO
+across all the even PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL FOO, FOOPROD, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+COMMON /COM/ FOO, FOOPROD, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+       CALL SHMEM_COMP8_PROD_TO_ALL(FOOPROD, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOPROD
+ENDIF
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and finds
+the logical 
+.I OR
+of the integer variable 
+.I FOO
+across all even
+PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+INTEGER FOO, FOOOR
+COMMON /COM/ FOO, FOOOR, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+       CALL SHMEM_INT8_OR_TO_ALL(FOOOR, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOOR
+ENDIF
+.fi
+
+
+
+This Fortran example statically initializes the 
+.I pSync
+array and
+computes the exclusive 
+.I XOR
+of variable 
+.I FOO
+across all even
+PEs.
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
+DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
+PARAMETER (NR=1)
+REAL FOO, FOOXOR, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
+COMMON /COM/ FOO, FOOXOR, PWRK
+INTRINSIC SHMEM_MY_PE()
+
+IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
+      CALL SHMEM_REAL8_XOR_TO_ALL(FOOXOR, FOO, NR, 0, 1, N$PES/2,
+&	 PWRK, PSYNC)
+      PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOXOR
+ENDIF
+.fi
+
+
+
+
+

--- a/man/shmem_set.3
+++ b/man/shmem_set.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_set.3

--- a/man/shmem_set_cache_inv.3
+++ b/man/shmem_set_cache_inv.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_set_cache_line_inv.3
+++ b/man/shmem_set_cache_line_inv.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_set_lock.3
+++ b/man/shmem_set_lock.3
@@ -1,0 +1,1 @@
+.so shmem_lock.3

--- a/man/shmem_swap.3
+++ b/man/shmem_swap.3
@@ -1,0 +1,1 @@
+.so shmem_atomic_swap.3

--- a/man/shmem_test.3
+++ b/man/shmem_test.3
@@ -1,0 +1,196 @@
+.TH SHMEM_TEST 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_test \- 
+Test whether a variable on the local PE has changed.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B int
+.B shmem_test(TYPE
+.IB "*ivar" ,
+.I shmem_cmp_t
+.IB "cmp" ,
+.B TYPE
+.I value
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the point-to-point synchronization types specified by
+Table 5.
+./ sectionStart
+.SS C/C++:
+
+.B int
+.B shmem_<TYPENAME>_test(TYPE
+.IB "*ivar" ,
+.I shmem_cmp_t
+.IB "cmp" ,
+.B TYPE
+.I value
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the point-to-point synchronization types and has a
+corresponding TYPENAME specified by Table 5.
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I ivar
+- A pointer to a remotely accessible data object.
+
+
+.BR "IN " -
+.I cmp
+- The comparison operator that compares 
+.I ivar
+with
+.IR "value" .
+.
+
+
+.BR "IN " -
+.I value
+- The value against which the object pointed to
+by 
+.I ivar
+will be compared.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_test
+tests the numeric comparison of the symmetric object
+pointed to by 
+.I ivar
+with the value 
+.I value
+according to the
+comparison operator 
+.IR "cmp" .
+.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+.B shmem\_test
+returns 1 if the comparison of the symmetric object
+pointed to by 
+.I ivar
+with the value 
+.I value
+according to the
+comparison operator 
+.I cmp
+evalutes to true; otherwise, it returns 0.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+./ sectionStart
+.SS Examples
+
+
+The following example demonstrates the use of 
+.B shmem\_test
+to
+wait on an array of symmetric objects and return the index of an
+element that satisfies the specified condition.
+
+.nf
+#include <shmem.h>
+
+int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
+{
+ int idx = 0;
+ while (!shmem_test(&ivar[idx], cmp, value))
+   idx = (idx + 1) % count;
+ return idx;
+}
+.fi
+
+
+
+
+.SS Table 5:
+Point-to-Point Synchronization Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_test_lock.3
+++ b/man/shmem_test_lock.3
@@ -1,0 +1,1 @@
+.so shmem_lock.3

--- a/man/shmem_udcflush.3
+++ b/man/shmem_udcflush.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_udcflush_line.3
+++ b/man/shmem_udcflush_line.3
@@ -1,0 +1,1 @@
+.so shmem_cache.3

--- a/man/shmem_wait.3
+++ b/man/shmem_wait.3
@@ -1,0 +1,394 @@
+.TH SHMEM_WAIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shmem_wait \- 
+Wait for a variable on the local PE to change.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS C11:
+
+.B void
+.B shmem_wait_until(TYPE
+.IB "*ivar" ,
+.I shmem_cmp_t
+.IB "cmp" ,
+.B TYPE
+.I cmp_value
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.B void
+.B shmem_wait(TYPE
+.IB "*ivar" ,
+.B TYPE
+.I cmp_value
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the point-to-point synchronization types specified by
+Table 5.
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B shmem_<TYPENAME>_wait_until(TYPE
+.IB "*ivar" ,
+.I shmem_cmp_t
+.IB "cmp" ,
+.B TYPE
+.I cmp_value
+.B );
+
+
+
+./ sectionEnd
+
+
+
+./ sectionStart
+
+.B void
+.B shmem_<TYPENAME>_wait(TYPE
+.IB "*ivar" ,
+.B TYPE
+.I cmp_value
+.B );
+
+
+
+./ sectionEnd
+
+
+where TYPE is one of the point-to-point synchronization types and has a
+corresponding TYPENAME specified by Table 5.
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "SHMEM_INT4_WAIT(ivar, cmp_value)"
+.BR "CALL " "SHMEM_INT4_WAIT_UNTIL(ivar, cmp, cmp_value)"
+.BR "CALL " "SHMEM_INT8_WAIT(ivar, cmp_value)"
+.BR "CALL " "SHMEM_INT8_WAIT_UNTIL(ivar, cmp, cmp_value)"
+.BR "CALL " "SHMEM_WAIT(ivar, cmp_value)"
+.BR "CALL " "SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I ivar
+- A remotely accessible integer variable that is being updated
+by another PE. If you are using  C/C++, the type of 
+.I ivar
+should
+match that implied in the SYNOPSIS section. 
+
+
+.BR "IN " -
+.I cmp
+- The compare operator that compares 
+.I ivar
+with
+.IR "cmp\_value" .
+. If you are using Fortran, it must be of default kind.
+If you are using  C/C++, it must be of type \CTYPE{shmem\_cmp\_t}.
+
+
+.BR "IN " -
+.I cmp\_value
+- 
+.I cmp\_value
+must be of type integer. If you are
+using  C/C++, the type of 
+.I cmp\_value
+should match that implied in the
+SYNOPSIS section. If you are using Fortran, cmp\_value must be an integer of
+the same size and kind as 
+.IR "ivar" .
+.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B shmem\_wait
+and 
+.B shmem\_wait\_until
+wait for 
+.I ivar
+to be
+changed by a remote write or an atomic operation issued by a different PE.
+These routines can be used for point-to-point direct synchronization. A call
+to 
+.I shmem\_wait
+does not return until some other PE writes a value,
+not equal to 
+.I cmp\_value
+, into 
+.I ivar
+on the waiting PE. A call
+to 
+.B shmem\_wait\_until
+does not return until some other PE changes
+.I ivar
+to satisfy the condition implied by 
+.I cmp
+and 
+.IR "cmp\_value" .
+.
+This mechanism is useful when a PE needs to tell another PE that it
+has completed some action. The 
+.B shmem\_wait
+routines return when
+.I ivar
+is no longer equal to 
+.IR "cmp\_value" .
+. The
+.B shmem\_wait\_until
+routines return when the compare condition is true.
+The compare condition is defined by the 
+.I ivar
+argument compared with the
+.I cmp\_value
+using the comparison operator, 
+.IR "cmp" .
+. 
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+If you are using Fortran, 
+.I ivar
+must be a specific sized integer type
+according to the routine being called, as follows:
+
+.TP 25
+Routine
+Data type
+./ sectionEnd
+
+
+
+./ sectionStart
+.TP 25
+shmem\_wait, shmem\_wait\_until
+default INTEGER
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int4\_wait, shmem\_int4\_wait\_until
+INTEGER*4
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+shmem\_int8\_wait, shmem\_int8\_wait\_until
+INTEGER*8
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+As of OpenSHMEM[1.4], the 
+.B shmem\_wait
+routine is deprecated,
+however, 
+.B shmem\_wait
+is equivalent to 
+.B shmem\_wait\_until
+where 
+.I cmp
+is SHMEM\_CMP\_NE.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+Implementations must ensure that 
+.B shmem\_wait
+and
+.B shmem\_wait\_until
+do not return before the update of the memory
+indicated by 
+.I ivar
+is fully complete. Partial updates to the memory
+must not cause 
+.B shmem\_wait
+or 
+.B shmem\_wait\_until
+to return.
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+The following call returns when variable 
+.I ivar
+is not equal to 100:
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER*8 IVAR
+CALL SHMEM_INT8_WAIT(IVAR, INTEGER*8(100))
+.fi
+
+
+
+The following call to 
+.B SHMEM\_INT8\_WAIT\_UNTIL
+is equivalent to the
+call to 
+.B SHMEM\_INT8\_WAIT
+in example 1:
+
+.nf
+INCLUDE "shmem.fh"
+
+INTEGER*8 IVAR
+CALL SHMEM_INT8_WAIT_UNTIL(IVAR, SHMEM_CMP_NE, INTEGER*8(100))
+.fi
+
+
+
+The following  C/C++ call waits until the value in 
+.I ivar
+is set to
+be less than zero by a transfer from a remote PE:
+
+.nf
+#include <stdio.h>#include <shmem.h>
+
+int ivar;
+shmem_int_wait_until(&ivar, SHMEM_CMP_LT, 0);
+.fi
+
+
+
+The following Fortran example is in the context of a subroutine:
+
+.nf
+INCLUDE "shmem.fh"
+
+SUBROUTINE EXAMPLE()
+INTEGER FLAG_VAR
+COMMON/FLAG/FLAG_VAR
+. . .
+FLAG_VAR = FLAG_VALUE    !  initialize the event variable
+. . .
+IF (FLAG_VAR .EQ.  FLAG_VALUE) THEN
+        CALL SHMEM_WAIT(FLAG_VAR, FLAG_VALUE)
+ENDIF
+FLAG_VAR = FLAG_VALUE    !  reset the event variable for next time
+. . .
+END
+.fi
+
+
+
+
+
+.SS Table 5:
+Point-to-Point Synchronization Types and Names
+.TP 25
+.B \TYPE
+.B \TYPENAME
+.TP
+short
+short
+.TP
+int
+int
+.TP
+long
+long
+.TP
+long long
+longlong
+.TP
+unsigned short
+ushort
+.TP
+unsigned int
+uint
+.TP
+unsigned long
+ulong
+.TP
+unsigned long long
+ulonglong
+.TP
+int32\_t
+int32
+.TP
+int64\_t
+int64
+.TP
+uint32\_t
+uint32
+.TP
+uint64\_t
+uint64
+.TP
+size\_t
+size
+.TP
+ptrdiff\_t
+ptrdiff

--- a/man/shmem_wait_until.3
+++ b/man/shmem_wait_until.3
@@ -1,0 +1,1 @@
+.so shmem_wait.3

--- a/man/shmemalign.3
+++ b/man/shmemalign.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/shpalloc.3
+++ b/man/shpalloc.3
@@ -1,0 +1,142 @@
+.TH SHPALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shpalloc \- 
+Allocates a block of memory from the symmetric heap.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "POINTER " "(addr, A(1))"
+.BR "INTEGER " "length, errcode, abort"
+.BR "CALL " "SHPALLOC(addr, length, errcode, abort)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "OUT " -
+.I addr
+- First word address of the allocated block.
+
+
+.BR "IN " -
+.I length
+- Number of words of memory requested. One word is 32 bits.
+
+
+.BR "OUT " -
+.I errcode
+- Error code is 0 if no error was detected;
+otherwise, it is a negative integer code for the type of error.
+
+
+.BR "IN " -
+.I abort
+- Abort code; nonzero requests abort on error;
+0 requests an error code.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+.B SHPALLOC
+allocates a block of memory from the program's symmetric heap
+that is greater than or equal to the size requested. To maintain symmetric heap
+consistency, all PEs in an program must call 
+.B SHPALLOC
+with the same
+value of length; if any PEs are missing, the program will hang.
+
+By using the Fortran POINTER mechanism in the following manner, you
+can use array 
+.I A
+to refer to the block allocated by 
+.B SHPALLOC
+:
+POINTER (
+.I addr
+, 
+.I A
+())
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+Error Code
+Condition
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-1 
+Length is not an integer greater than 0
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-2
+No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+The total size of the symmetric heap is determined at job startup. One may
+adjust the size of the heap using the SHMEM\_SYMMETRIC\_SIZE environment
+variable (if available).
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+The symmetric heap allocation routines always return a pointer to corresponding
+symmetric objects across all PEs. The OpenSHMEM specification does not
+require that the virtual addresses are equal across all PEs. Nevertheless,
+the implementation must avoid costly address translation operations in the
+communication path, including order N (where N is the number of PEs)
+memory translation tables. In order to avoid address translations, the
+implementation may re-map the allocated block of memory based on agreed virtual
+address. Additionally, some operating systems provide an option to disable
+virtual address randomization, which enables predictable allocation of virtual
+memory addresses.
+
+./ sectionEnd
+
+
+
+

--- a/man/shpclmove.3
+++ b/man/shpclmove.3
@@ -1,0 +1,140 @@
+.TH SHPCLMOVE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shpclmove \- 
+Extends a symmetric heap block or copies the contents of the block into a
+larger block.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "POINTER " "(addr, A(1))"
+.BR "INTEGER " "length, status, abort"
+.BR "CALL " "SHPCLMOVE (addr, length, status, abort)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "INOUT " -
+.I addr
+- On entry, first word address of the block to
+change; on exit, the new address of the block if it was moved.
+
+
+.BR "IN " -
+.I length
+- Requested new total length in words. One word is
+32 bits.
+
+
+.BR "OUT " -
+.I status
+- Status is 0 if the block was extended in
+place, 1 if it was moved, and a negative integer for the type of
+error detected.
+
+
+.BR "IN " -
+.I abort
+- Abort code. Nonzero requests abort on error;
+0 requests an error code.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B SHPCLMOVE
+routine either extends a symmetric heap block if the block
+is followed by a large enough free block or copies the contents of the existing
+block to a larger block and returns a status code indicating that the block was
+moved. This routine also can reduce the size of a block if the new length is
+less than the old length. All PEs in a program must call
+.B SHPCLMOVE
+with the same value of 
+.I addr
+to maintain symmetric heap
+consistency; if any PEs are missing, the program hangs.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+Error Code
+Condition
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-1 
+Length is not an integer greater than 0
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-2
+No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-3
+Address is outside the bounds of the symmetric heap.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-4
+Block is already free.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-5
+Address is not at the beginning of a block.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+

--- a/man/shpdealloc.3
+++ b/man/shpdealloc.3
@@ -1,0 +1,129 @@
+.TH SHPDEALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+shpdealloc \- 
+Returns a memory block to the symmetric heap.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "POINTER " "(addr, A(1))"
+.BR "INTEGER " "errcode, abort"
+.BR "CALL " "SHPDEALLC(addr, errcode, abort)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "IN " -
+.I addr
+-  First word address of the block to deallocate.
+
+
+.BR "OUT " -
+.I errcode
+- Error code is 0 if no error was detected;
+otherwise, it is a negative integer code for the type of error.
+
+
+.BR "IN " -
+.I abort
+- Abort code. Nonzero requests abort on error;
+0 requests an error code.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+SHPDEALLC returns a block of memory (allocated using 
+.B SHPALLOC
+) to the
+list of available space in the symmetric heap. To maintain symmetric heap
+consistency, all PEs in a program must call 
+.B SHPDEALLC
+with the same
+value of 
+.I addr
+; if any PEs are missing, the program hangs.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+Error Code
+Condition
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-1 
+Length is not an integer greater than 0
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-2
+No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-3
+Address is outside the bounds of the symmetric heap.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-4
+Block is already free.
+./ sectionEnd
+
+
+./ sectionStart
+.TP 25
+-5
+Address is not at the beginning of a block.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+None.
+
+./ sectionEnd
+
+
+
+

--- a/man/shrealloc.3
+++ b/man/shrealloc.3
@@ -1,0 +1,1 @@
+.so shmem_malloc.3

--- a/man/start_pes.3
+++ b/man/start_pes.3
@@ -1,0 +1,148 @@
+.TH START_PES 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+./ sectionStart
+.SH NAME
+start_pes \-  
+Called at the beginning of an OpenSHMEM program to initialize the execution
+environment. This routine is deprecated and is provided for backwards
+compatibility. Implementations must include it, and the routine should
+function properly and may notify the user about deprecation of its use.
+
+./ sectionEnd
+
+
+./ sectionStart
+.SH   SYNOPSIS
+./ sectionEnd
+
+
+./ sectionStart
+.SS C/C++:
+
+.B void
+.B start_pes(int
+.I npes
+.B );
+
+
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+.SS Fortran:
+
+.nf
+
+.BR "CALL " "START_PES(npes)"
+
+.fi
+
+./ sectionEnd
+
+
+
+
+
+./ sectionStart
+
+.SH DESCRIPTION
+.SS Arguments
+.BR "npes " -
+.I Unused
+-  Should be set to 0.
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Description
+
+The 
+.B start\_pes
+routine initializes the OpenSHMEM execution
+environment. An OpenSHMEM program must call 
+.B start\_pes
+before
+calling any other OpenSHMEM routine.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS Return Values
+
+None.
+
+./ sectionEnd
+
+
+./ sectionStart
+
+.SS API Notes
+
+If any other OpenSHMEM call occurs before 
+.B start\_pes
+, the
+behavior is undefined. Although it is recommended to set 
+.I npes
+to
+0 for 
+.B start\_pes
+, this is not mandated. The value is ignored.
+Calling 
+.B start\_pes
+more than once has no subsequent
+effect.
+
+As of OpenSHMEM Specification 1.2 the use of 
+.B start\_pes
+has
+been deprecated. Although OpenSHMEM libraries are required to support the
+call, program users are encouraged to use 
+.B shmem\_init
+instead.
+
+./ sectionEnd
+
+
+
+
+./ sectionStart
+.SS Examples
+
+
+
+This is a simple program that calls 
+.B start\_pes
+:
+
+.nf
+PROGRAM PUT
+INCLUDE "shmem.fh"
+
+INTEGER TARG, SRC, RECEIVER, BAR
+COMMON /T/ TARG
+PARAMETER (RECEIVER=1)
+CALL START_PES(0)
+
+IF (SHMEM_MY_PE() .EQ. 0) THEN
+   SRC = 33
+   CALL SHMEM_INTEGER_PUT(TARG, SRC, 1, RECEIVER)
+ENDIF
+
+CALL SHMEM_BARRIER_ALL           ! SYNCHRONIZES SENDER AND RECEIVER
+
+IF (SHMEM_MY_PE() .EQ. RECEIVER) THEN
+   PRINT*,'PE ', SHMEM_MY_PE(),' TARG=',TARG,' (expect 33)'
+ENDIF
+END
+.fi
+
+
+
+
+

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -8,32 +8,36 @@ import argparse
 # boldWordsC and boldWordsF are a set of the key words that will be
 # bolded in the man page
 boldWordsC = {"void", "int", "const", "size_t", "short", "ptrdiff_t", 
-        "long", "TYPE", "shmem_global_exit(int"}
+            "long", "TYPE", "shmem_global_exit(int"}
 boldWordsF = {"INTEGER", "CALL", "POINTER", "LOGICAL", "INTEGER*4",
-        "INTEGER*8", "REAL*4", "REAL*8", "CHARACTER"}
+                "INTEGER*8", "REAL*4", "REAL*8", "CHARACTER"}
 
 def writePageHeader(functionName):
-    """Write the page header for the man page. Takes in the form of:
+    """
+    Write the page header for the man page. Takes in the form of:
     .TH [name of program] [section number] [center footer] [left footer] 
-        [center header]"""
+          [center header]
+    """
 
     titleHeader = ".TH " + functionName.upper() + " 3 " \
-            + "" + "" \
-            + "\"Open Source Software Solutions, Inc.\"" + "" \
-            + "\"OpenSHEMEM Library Documentation\"" + "\n"
+                     + "" + "" \
+                     + "\"Open Source Software Solutions, Inc.\"" + "" \
+                     + "\"OpenSHEMEM Library Documentation\"" + "\n"
     return titleHeader
 
 ##########################################################################
-##                       MACRO REPLACEMENTS                             ##
+##                            MACRO REPLACEMENTS                        ##
 ##########################################################################
 
 def funcReplacements(tex):
-    """Convert every FUNC macro with the bolded argument string 
+    """
+    Convert every FUNC macro with the bolded argument string 
     (.B <argument>).
     -- Special consideration to any periods after the macro, since a 
     period at the beginning of a line denotes a comment and the 
     entire line will not appear.
-    (.BR <argument> .)"""
+    (.BR <argument> .)
+    """
 
     keyString = "\FUNC{"
     while (tex.find(keyString) != -1):
@@ -43,8 +47,8 @@ def funcReplacements(tex):
         innerText = tex[startBrace+1:endBrace]
         if(endBrace + 1 < len(tex) and tex[endBrace + 1] == "."):
             tex = tex[:index] + "\n" + \
-                ".BR \"" + innerText + \
-                "\" .\n" + tex[endBrace+2:]
+                    ".BR \"" + innerText + \
+                    "\" .\n" + tex[endBrace+2:]
         else:                                                                
             tex = tex[:index] + "\n" + \
                 ".B " + innerText + \
@@ -52,14 +56,16 @@ def funcReplacements(tex):
     return tex
 
 def varReplacements(tex, keyString):
-    """Convert every VAR/VARTH macro with the bolded argument string 
+    """
+    Convert every VAR/VARTH macro with the bolded argument string 
     (.I <argument>).
     -- Special consideration to any periods after the macro, since a 
     period at the beginning of a line denotes a comment and the 
     entire line will not appear.
     (.IR <argument> .)
     -- Special consideration to any argument of "VARTH", which will 
-    require appending "th" to the argument string."""
+    require appending "th" to the argument string.
+    """
 
     while (tex.find(keyString) != -1):
         index = tex.find(keyString)
@@ -73,10 +79,10 @@ def varReplacements(tex, keyString):
         else:
             if (tex[endBrace + 1] != "."):
                 tex = tex[:index] + "\n.I " + innerText \
-                    + "\n" + tex[endBrace+1:]
+                                + "\n" + tex[endBrace+1:]
             else:
                 tex = tex[:index] + "\n.IR \"" + innerText \
-                    + "\" .\n" + tex[endBrace+1:]
+                                + "\" .\n" + tex[endBrace+1:]
     return tex
 
 def variableReplacements(tex):
@@ -85,7 +91,9 @@ def variableReplacements(tex):
     return tex
 
 def mBoxReplacements(tex):
-    """Replace the Latex command "|mbox{<argument>}|" with just argument """
+    """
+    Replace the Latex command "|mbox{<argument>}|" with just <argument>
+    """
 
     while (tex.find("|\mbox") != -1):
         index = tex.find("|\mbox")
@@ -93,17 +101,19 @@ def mBoxReplacements(tex):
         ebrace = tex.find("}", sbrace)
         ebar = tex.find("|", sbrace)
         tex = tex[:index] + tex[sbrace+1:ebrace] \
-            + tex[ebar+1:]
+                        + tex[ebar+1:]
     return tex
 
 def boldReplacements(tex):
-    """SPECIFIC TO shmem_reductions:
+    """
+    SPECIFIC TO shmem_reductions:
     Replace the Latex command: 
     "\\textbf{<NAME>} \\newline <text> <code> \\newline...\\bigskip" 
     --NAME will the title of a new section header with <text> as the 
     immediate content. 
     -- <code> will be replaced as normal (See function codeReplace(tex))
-    -- \\bigskip will be replaced by the empty string. """
+    -- \\bigskip will be replaced by the empty string. 
+    """
 
     while (tex.find("\\textbf{") != -1):
         beg = tex.find("\\textbf{")
@@ -114,32 +124,36 @@ def boldReplacements(tex):
         clean = tex[fnewline + len("\\newline"):snewline]
         clean = macroReplacements(clean)
         tex = tex[:beg] + "\n.SH " + tex[sbrace+1:ebrace] \
-            + "\n" + clean \
-            + tex[snewline + len("\\newline"):]
+                        + "\n" + clean \
+                        + tex[snewline + len("\\newline"):]
     tex = tex.replace("\\bigskip", "")
     return tex
 
 def italReplacements(tex):
-    """ Replace the Latex command "\\textit{<argument>}" with just 
-    argument """
+    """ 
+    Replace the Latex command "\\textit{<argument>}" with just 
+    argument 
+    """
 
     while (tex.find("\\textit{") != -1):
         beg = tex.find("\\textit{")
         sbrace = tex.find("{", beg)
         ebrace = tex.find("}", sbrace)
         tex = tex[:beg] + tex[sbrace+1:ebrace] \
-            + tex[ebrace+1:]
+                        + tex[ebrace+1:]
     return tex
 
 def oprReplacements(tex):
-    """Convert every OPR macro with the bolded argument string 
+    """
+    Convert every OPR macro with the bolded argument string 
     (.I <argument>).
     -- Special consideration to any periods after the macro, since a 
     period at the beginning of a line denotes a comment and the 
     entire line will not appear.
     (.IR <argument> .)
     -- Special consideration to any argument of "VARTH", which will 
-    require appending "th" to the argument string. """
+    require appending "th" to the argument string. 
+    """
 
     while (tex.find("\\OPR") != -1):
         index = tex.find("\\OPR")
@@ -147,15 +161,17 @@ def oprReplacements(tex):
         endBrace = tex.find("}", index)
         if (endBrace + 1 == len(tex) or tex[endBrace + 1] != "."):
             tex = tex[:index] + "\n.I " + tex[startBrace+1:endBrace] \
-                + "\n" + tex[endBrace+1:]
+                            + "\n" + tex[endBrace+1:]
         else:
             tex = tex[:index] + "\n.IR \"" + tex[startBrace+1:endBrace] \
-                + "\" .\n" + tex[endBrace+1:]
+                            + "\" .\n" + tex[endBrace+1:]
     return tex
 
 def constReplacements(tex):
-    """Replace the Latex command "\CONST{<argument>}" with just 
-    argument. """
+    """
+    Replace the Latex command "\CONST{<argument>}" with just 
+    argument. 
+    """
 
     while (tex.find("\\CONST") != -1):
         index = tex.find("\\CONST")
@@ -164,13 +180,28 @@ def constReplacements(tex):
         tex = tex[:index] + tex[startBrace+1:endBrace] + tex[endBrace+1:]
     return tex
 
+def cTypeReplacements(tex):
+    """
+    Replace the Latex command "\CONST{<argument>}" with just 
+    argument. 
+    """
+
+    while (tex.find("\\CTYPE") != -1):
+        index = tex.find("\\CTYPE")
+        startBrace = tex.find("{", index)
+        endBrace = tex.find("}", startBrace)
+        tex = tex[:index] + tex[startBrace+1:endBrace] + tex[endBrace+1:]
+    return tex
+
 def generalReplacements(tex):
-    """Replace the common Latex macros that take in no arguments and all 
+    """
+    Replace the common Latex macros that take in no arguments and all 
     Latex definitions that contain a backslash (which may have unde-
     fined behavior in the actual manpage). Some text may need to be 
     processed separately if it is followed by a period, which will 
     cause all text in the same line following the period to be not 
-    shown."""
+    shown.
+    """
 
     tex = tex.replace("\openshmem{}", "OpenSHMEM")
     tex = tex.replace("\openshmem", "OpenSHMEM")
@@ -207,7 +238,8 @@ def generalReplacements(tex):
 ##########################################################################
 
 def descrReplacements(tex):
-    """Search tex file for the keyString "\\apidecription{" and its matching
+    """
+    Search tex file for the keyString "\\apidecription{" and its matching
     parenthesis. All text between will be processed such that there are no
     consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
     have all the macros replaced and put back into its corresponding place
@@ -216,19 +248,21 @@ def descrReplacements(tex):
     beginning and end of the processed text, respectively, for differenti-
     ation between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment.
+    """
 
     startOfText = tex.find("\\apidescription{")
     endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
     sectionText = cleanText(tex[startOfText:endOfText])
     tex = tex[:startOfText] + \
-        "./ sectionStart\n" + "\n.SS API Description\n" + \
-        sectionText + "\n./ sectionEnd\n" + tex[endOfText+1:]
+            "./ sectionStart\n" + "\n.SS API Description\n" + \
+            sectionText + "\n./ sectionEnd\n" + tex[endOfText+1:]
     tex = tex.replace("\\apidescription{", "")
     return tex
 
 def retReplacements(tex):
-    """Search tex file for the keyString "\\apireturnavalues{" and its matching
+    """
+    Search tex file for the keyString "\\apireturnavalues{" and its matching
     parenthesis. All text between will be processed such that there are no
     consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
     have all the macros replaced and put back into its corresponding place
@@ -237,19 +271,21 @@ def retReplacements(tex):
     beginning and end of the processed text, respectively, for differenti-
     ation between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment. 
+    """
 
     startOfText = tex.find("\\apireturnvalues{")
     endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
     sectionText = cleanText(tex[startOfText:endOfText])
     tex = tex[:startOfText] + \
-        "./ sectionStart\n" + "\n.SS Return Values\n" + \
-        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+            "./ sectionStart\n" + "\n.SS Return Values\n" + \
+            sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
     tex = tex.replace("\\apireturnvalues{", "")
     return tex
 
 def notesReplacements(tex):
-    """Search tex file for the keyString "\\apinotes{" and its matching
+    """
+    Search tex file for the keyString "\\apinotes{" and its matching
     parenthesis. All text between will be processed such that there are no
     consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
     have all the macros replaced and put back into its corresponding place
@@ -258,19 +294,21 @@ def notesReplacements(tex):
     beginning and end of the processed text, respectively, for differenti-
     ation between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment. 
+    """
 
     startOfText = tex.find("\\apinotes{")
     endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
     sectionText = cleanText(tex[startOfText:endOfText])
     tex = tex[:startOfText] + \
-        "./ sectionStart\n" + "\n.SS API Notes\n" + \
-        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+            "./ sectionStart\n" + "\n.SS API Notes\n" + \
+            sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
     tex = tex.replace("\\apinotes{", "")
     return tex
 
 def impnotesReplacements(tex):
-    """Search tex file for the keyString "\\apiimpnotes{" and its matching
+    """
+    Search tex file for the keyString "\\apiimpnotes{" and its matching
     parenthesis. All text between will be processed such that there are no
     consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
     have all the macros replaced and put back into its corresponding place
@@ -279,19 +317,21 @@ def impnotesReplacements(tex):
     beginning and end of the processed text, respectively, for differenti-
     ation between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment. 
+    """
 
     startOfText = tex.find("\\apiimpnotes{")
     endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
     sectionText = cleanText(tex[startOfText:endOfText])
     tex = tex[:startOfText] + \
-        "./ sectionStart\n" + "\n.SS API Notes\n" + \
-        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+            "./ sectionStart\n" + "\n.SS API Notes\n" + \
+            sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
     tex = tex.replace("\\apiimpnotes{", "")
     return tex
 
 def sumReplacements(tex, functionName):
-    """Search tex file for the keyString "\\apisummary{" and its matching
+    """
+    Search tex file for the keyString "\\apisummary{" and its matching
     parenthesis. All text between will be processed such that there are no
     consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
     have all the macros replaced and put back into its corresponding place
@@ -300,21 +340,23 @@ def sumReplacements(tex, functionName):
     beginning and end of the processed text, respectively, for differenti-
     ation between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """    
+    with a period will be treated as a comment. 
+    """
 
     startOfText = tex.find("\\apisummary{")
     endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
     sectionText = cleanText(tex[startOfText:endOfText])
     tex = tex[:startOfText] + \
-        "./ sectionStart\n" + \
-        ".SH NAME\n" + functionName + " \- " \
-        + sectionText + "\n" + \
-        "./ sectionEnd\n" + tex[endOfText+1:]
+            "./ sectionStart\n" + \
+            ".SH NAME\n" + functionName + " \- " \
+            + sectionText + "\n" + \
+            "./ sectionEnd\n" + tex[endOfText+1:]
     tex = tex.replace("\\apisummary{", "")
     return tex
 
 def exampleCodeReplace(sectionText, in_directory, keyString):
-    """Searches throught the given text and replaces the files of code with
+    """
+    Searches throught the given text and replaces the files of code with
     the actual code in the file. 
     
     All examples in the Latex file follows the following pattern:
@@ -323,7 +365,8 @@ def exampleCodeReplace(sectionText, in_directory, keyString):
     prior to this function call and will be concatenated to the return
     string.
     -- The pattern ".nf\\n ... .fi\\n" will have the text in between ".nf"
-    and "fi" be presented without formatting. """
+    and "fi" be presented without formatting. 
+    """
 
     while(sectionText.find(keyString) != -1):
         startOfText = sectionText.find(keyString)
@@ -345,7 +388,8 @@ def exampleCodeReplace(sectionText, in_directory, keyString):
     return sectionText
 
 def exampleReplacements(tex, in_directory):
-    """Search tex file for the keyString "\\begin{apiexamples}" and its matching
+    """
+    Search tex file for the keyString "\\begin{apiexamples}" and its matching
     "\\end{apiexamples}". All text between will be processed such that there 
     are no consecutive spaces, no tabs, and unnecessary "\\n". The text will 
     then have all the macros replaced and put back into its corresponding 
@@ -358,7 +402,8 @@ def exampleReplacements(tex, in_directory):
     the example section of the manpage is always the last section. 
     Dangling text is identified as the text between a "./ sectionEnd" and
     ./sectionStart. Since there will be no text following this section, the
-    "./ sectionEnd" flag is no necessary. """
+    "./ sectionEnd" flag is no necessary. 
+    """
 
     startOfText = tex.find("\\begin{apiexamples}")
     endOfText = tex.find("\\end{apiexamples}")
@@ -366,18 +411,19 @@ def exampleReplacements(tex, in_directory):
     sectionText = cleanText(text)
 
     sectionText = exampleCodeReplace(sectionText, in_directory, 
-                "\\apicexample")
+                    "\\apicexample")
     sectionText = exampleCodeReplace(sectionText, in_directory,
-                "\\apifexample")
+                    "\\apifexample")
 
     tex = tex[:startOfText] + "\n" \
-        "./ sectionStart" + "\n.SS Examples\n" + \
-        sectionText + \
-        tex[endOfText + len("\\end{apiexamples}"):]
+            "./ sectionStart" + "\n.SS Examples\n" + \
+            sectionText + \
+            tex[endOfText + len("\\end{apiexamples}"):]
     return tex
 
 def argReplacements(tex):
-    """All elements within the section defined between "\\begin{apiarguments}"
+    """
+    All elements within the section defined between "\\begin{apiarguments}"
     and "\end{apiarguments}" will follow the following pattern:
             \\apiargument{<STATUS>}{<name>}{<description>}
     The following code will convert the above text such that STATUS will be
@@ -387,7 +433,8 @@ def argReplacements(tex):
     the form:
             \\apiargument{"None."}{}{}
     in which case, the code will conver the macro above to have "None." as
-    bolded. """
+    bolded. 
+    """
 
     startOfText = tex.find("\\apiargument")
     endOfText = tex.find("\\end{apiarguments}")
@@ -409,24 +456,25 @@ def argReplacements(tex):
             cleanArgList.append(".B None.")
         else:
             cleanArgList.append(".BR \"" + status + \
-                    " \" -" + "\n.I " + name + \
-                    "\n- " + text + \
-                    arg[thirdEndBrace+1:])
+                        " \" -" + "\n.I " + name + \
+                        "\n- " + text + \
+                        arg[thirdEndBrace+1:])
     sectionText = "\n\n".join(cleanArgList)
     tex = tex[:startOfText] + "\n" + \
-        "./ sectionStart\n" + "\n" + \
-        ".SH DESCRIPTION\n.SS Arguments\n" + \
-        sectionText + "\n./ sectionEnd\n" + tex[endOfText:]
+            "./ sectionStart\n" + "\n" + \
+            ".SH DESCRIPTION\n.SS Arguments\n" + \
+            sectionText + "\n./ sectionEnd\n" + tex[endOfText:]
     tex = tex.replace("\\begin{apiarguments}", "")
     tex = tex.replace("\\end{apiarguments}", "")
     return tex
 
 ##########################################################################
-##                        TABLE REPLACEMENTS                            ##
+##                            TABLE REPLACEMENTS                        ##
 ##########################################################################
 
 def descTReplacements(tex):
-    """All elements within the tex file defined to begin with "\\apidesctable{"
+    """
+    All elements within the tex file defined to begin with "\\apidesctable{"
     will follow the following pattern:
             \\apidesctable{{<desc>}{<firstColHead>}{<secondColHead>}
     The following code will convert the above text to display such that 
@@ -440,7 +488,7 @@ def descTReplacements(tex):
     where <number> is the number of spaces between the start of firstCol
     and the start of secondCol. 
     Displays as:
-                    <firstCol>                   <secondCol>
+                    <firstCol>                     <secondCol>
                     <----------<number>---------->
     If the length of <firstCol> surpasses <number>, it will display as:
                     <----------<number>---------->
@@ -459,7 +507,8 @@ def descTReplacements(tex):
     beginning and end of every row processed, respectively, for differenti-
     ating between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment. 
+    """
 
     index = tex.find("\\apidesctable{")
     firstStartBrace = tex.find("{", index)
@@ -479,7 +528,8 @@ def descTReplacements(tex):
     return tex
 
 def tablerowReplacements(tex):
-    """All elements within the tex file defined to begin with "\\apitablerow"
+    """
+    All elements within the tex file defined to begin with "\\apitablerow"
     will follow the following pattern:
             \\apitablerow{<firstCol>}{<secondCol>}
     The following code will convert the above text to display in tabular 
@@ -492,7 +542,7 @@ def tablerowReplacements(tex):
     where <number> is the number of spaces between the start of firstCol
     and the start of secondCol. 
     Displays as:
-                    <firstCol>                   <secondCol>
+                    <firstCol>                     <secondCol>
                     <----------<number>---------->
     If the length of <firstCol> surpasses <number>, it will display as:
                     <----------<number>---------->
@@ -515,7 +565,8 @@ def tablerowReplacements(tex):
     beginning and end of every row processed, respectively, for differenti-
     ating between the text with sections and "dangling text".
     These strings will not appear in the manpage as any line that begins 
-    with a period will be treated as a comment. """
+    with a period will be treated as a comment. 
+    """
 
     while(tex.find("\\apitablerow") != -1):
         startOfText = tex.find("\\apitablerow")
@@ -547,7 +598,8 @@ def tablerowReplacements(tex):
 ##########################################################################
 
 def refTextReplacements(tex):
-    """Searches through the tex file and processes "dangling text", or text that
+    """
+    Searches through the tex file and processes "dangling text", or text that
     does not belong to a designated section. It finds these strings by search-
     ing for text in between any two consecutive "./ sectionStart" and 
     "./ sectionEnd" These text will sometimes have references to tables, iden-
@@ -555,7 +607,8 @@ def refTextReplacements(tex):
     have a unique integer that it can be identified with, consistent with the
     Latex file.
     The function will return the processed string with an indication array of 
-    which tables are to be appended to the end of the man page. """
+    which tables are to be appended to the end of the man page. 
+    """
 
     tables = [0, 0, 0, 0, 0]
     last = 0
@@ -589,10 +642,12 @@ def refTextReplacements(tex):
     return (tex, tables)
 
 def refMEMReplacements(tex):
-    """ Searches through the tex for any reference that specifically points to 
+    """ 
+    Searches through the tex for any reference that specifically points to 
     the memory modelled and replaces that sentence with a hard-coded string.
     Processing the section that was in the original text is not an option
-    because the reference the Latex file does not apply to the man pages. """
+    because the reference the Latex file does not apply to the man pages. 
+    """
 
     if (tex.find("\\ref{subsec:memory_model}") != -1):
         while(tex.find("\\ref{subsec:memory_model}") != -1):
@@ -611,7 +666,8 @@ def refMEMReplacements(tex):
     return tex
 
 def parseRefTables(tableTex):
-    """ The function takes in a tex file that contains a type table as input
+    """ 
+    The function takes in a tex file that contains a type table as input
     and returns the processed table in tabular form.
     All elements within the tex file that is desired will follow the 
     following pattern:
@@ -631,12 +687,12 @@ def parseRefTables(tableTex):
     where <number> is the number of spaces between the start of firstCol
     and the start of secondCol. 
     Displays as:
-                    <firstCol>                   <secondCol>
+                    <firstCol>                     <secondCol>
                     <----------<number>---------->
     If the length of <firstCol> surpasses <number>, it will display as:
                     <----------<number>---------->
                     <firstCol>                     
-                                                 <secondCol>
+                                                  <secondCol>
     
     Every row of the table must include the ".TP" or the text will be
     processed with default formatting. 
@@ -647,7 +703,8 @@ def parseRefTables(tableTex):
     for when the second column begins is the next "\\n" 
     
     .B at the start of a line will underline/italicize all text until
-    the next "\\n" """
+    the next "\\n" 
+    """
 
     startIdx = tableTex.find("\\hline")
     endIdx = tableTex.find("\\end{tabular}")
@@ -668,11 +725,13 @@ def parseRefTables(tableTex):
     return text
 
 def addRefTable(tableID, directory):
-    """ This function maps the tableID given to each reference table to its
+    """ 
+    This function maps the tableID given to each reference table to its
     corresponding to tex file that contains the table. It then calls a
     helper function to parse the table and returns the subsection text, 
     containing the subsection header, the caption for the table, and the
-    table. """
+    table. 
+    """
 
     if tableID == 1:
         tableTex = open(directory + "/stdrmatypes.tex", "r").read()
@@ -698,9 +757,14 @@ def addRefTable(tableID, directory):
 ##########################################################################
 
 def synCReplacements(tex, keyString):
-    """ Replaces the code identified between "\\begin{<keyString>}" and 
+    """ 
+    Replaces the code identified between "\\begin{<keyString>}" and 
     "\end{<keyString>}" to have C keywords (defined as a global variable) 
-    bolded and the argument variables underlined. 
+    bolded and the argument variables underlined. Also compiles a list, 
+    linkCFuncs, of all functions that falls within the scope of this manpage.
+    For instance, shmem_malloc, shmem_free, shmeme_realloc, and shmem_align 
+    all fall under the shmem_malloc manpage. In this case, linkCFuncs will
+    be ["shmem_malloc", "shmem_free", "shmeme_realloc", "shmem_align"].
     
     .B at the start of a line will bold all text until
     the next "\\n"
@@ -711,8 +775,10 @@ def synCReplacements(tex, keyString):
     
     .IB "A" "B" "C"
     
-    will have "A" and "C" as italicized and "B" will be bolded. """
+    will have "A" and "C" as italicized and "B" will be bolded. 
+    """
 
+    linkCFuncs = []
     while (tex.find("\\begin{" + keyString + "}") != -1):
         startOfText = tex.find("\\begin{" + keyString + "}")
         endOfText = tex.find("\\end{" + keyString + "}")
@@ -724,6 +790,14 @@ def synCReplacements(tex, keyString):
             line = line.strip()
             wordList = line.split()
             for i in xrange(len(wordList)):
+                if (wordList[i].find("shmem") != -1 and 
+                        wordList[i].find("TYPENAME") == -1 and
+                        wordList[i].find("SIZE") == -1):
+                    stripAsterisk = wordList[i].replace("*", "")
+                    argStart = stripAsterisk.find("(")
+                    funcName = stripAsterisk[:argStart]
+                    linkCFuncs.append(funcName.strip())
+
                 if(i < 2):
                     wordList[i] = "\n.B " + wordList[i]
                 else:
@@ -755,12 +829,17 @@ def synCReplacements(tex, keyString):
                 header + formattedCode  + "\n" + \
                 "./ sectionEnd\n" + \
                 tex[endOfText + len("\\end{" + keyString + "}"):]
-    return tex
+    return (tex, linkCFuncs)
 
 def synFReplacements(tex):
-    """ Replaces the code identified between "\\begin{Fsynopsis}" and 
+    """ 
+    Replaces the code identified between "\\begin{Fsynopsis}" and 
     "\end{Fsynopsis}" to have Fortran keywords (defined as a global 
-    variable) bolded. 
+    variable) bolded. Also compiles a list, linkFortranFuncs, of all 
+    functions that falls within the scope of this manpage. For instance, 
+    shmem_malloc, shmem_free, shmeme_realloc, and shmem_align all fall 
+    under the shmem_malloc manpage. In this case, linkCFuncs will be 
+    ["shmem_malloc", "shmem_free", "shmeme_realloc", "shmem_align"].
     
     .B at the start of a line will bold all text untilthe next "\\n"
 
@@ -768,8 +847,10 @@ def synFReplacements(tex):
     
     .BR "A" "B" "C"
     
-    will have "A" and "C" as bolded and "B" will be regular. """
+    will have "A" and "C" as bolded and "B" will be regular. 
+    """
 
+    linkFortranFuncs = []
     while (tex.find("\\begin{Fsynopsis}") != -1):
         startOfText = tex.find("\\begin{Fsynopsis}")
         endOfText = tex.find("\\end{Fsynopsis}")
@@ -787,31 +868,56 @@ def synFReplacements(tex):
                         " ".join(wordList[1:]) + "\""
             text = text[:s] + line + text[e:]
             last = s
+
+            if(wordList[0] == "CALL"):
+                argStart = wordList[1].find("(")
+                if (argStart < 0):
+                    funcName = wordList[1]
+                else:
+                    funcName = wordList[1][:argStart]
+                linkFortranFuncs.append(funcName.strip())
+
+            if(wordList[0] not in boldWordsF):
+                for i in xrange(len(wordList)):
+                    if (wordList[i].find("SHMEM") != -1):
+                        argStart = wordList[i].find("(")
+                        funcName = wordList[i][:argStart]
+                        linkFortranFuncs.append(funcName.strip())
+
         tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
                 ".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
                  "\n./ sectionEnd"  + "\n" + \
                  tex[endOfText + len("\\end{Fsynopsis}"):]
-    return tex
+    return (tex, linkFortranFuncs)
 
 def codeReplace(tex):
-    tex = synCReplacements(tex, "C11synopsis")
-    tex = synCReplacements(tex, "Csynopsis")
-    tex = synCReplacements(tex, "CsynopsisCol")
-    tex = synFReplacements(tex)
-    return tex
+    linkFuncsAll = []
+    (tex, linkC11) = synCReplacements(tex, "C11synopsis")
+    (tex, linkC) = synCReplacements(tex, "Csynopsis")
+    (tex, linkCCol) = synCReplacements(tex, "CsynopsisCol")
+    (tex, linkFortran) = synFReplacements(tex)
+    linkFuncsAll.extend(linkC11)
+    linkFuncsAll.extend(linkC)
+    linkFuncsAll.extend(linkCCol)
+    linkFuncsAll.extend(linkFortran)
+    print(linkFuncsAll)
+    return (tex, linkFuncsAll)
 
 ##########################################################################
 ##                            HELPER FUNCTIONS                          ##
 ##########################################################################
 
 def cleanText(text):
-    """ Gets rid of consecutive spaces and tabs in the given text but maintains
+    """ 
+    Gets rid of consecutive spaces and tabs in the given text but maintains
     any "\\n\\n" which is the indicator of a new paragraph. For every para-
     graph, the code will replace all macros and rejoin the paragraphs as 
     the final return string.
     NOTE: Typically manpages ignores "\\n" within the text and displays
     the text as if there is no "\\n". "\\n\\n" will parsed as the beginning
-    of a new paragraph. """
+    of a new paragraph. 
+    """
+
     text = text.replace("\t", "")
     while(text.find("  ") != -1):
         text = text.replace("  ", " ")
@@ -831,6 +937,7 @@ def macroReplacements(paragraph):
     paragraph = variableReplacements(paragraph)
     paragraph = generalReplacements(paragraph)
     paragraph = constReplacements(paragraph)
+    paragraph = cTypeReplacements(paragraph)
     paragraph = oprReplacements(paragraph)
     paragraph = funcReplacements(paragraph)
     paragraph = italReplacements(paragraph)
@@ -838,9 +945,11 @@ def macroReplacements(paragraph):
     return paragraph
 
 def generateRoutineList(TOC):
-    """ Takes the Table of Contents and compiles a list of all function names
+    """ 
+    Takes the Table of Contents and compiles a list of all function names
     that needs to be parsed to manpages. The code assumes that every function
-    entry will be preceded by the macro, "\\subsubsection{\\textbf" """
+    entry will be preceded by the macro, "\\subsubsection{\\textbf" 
+    """
 
     count = 0;
     routineList = []
@@ -857,9 +966,12 @@ def generateRoutineList(TOC):
     return routineList
 
 def findMatchingBrace(tex, ind):
-    """ Takes in the tex string and the index of the open brace to which we 
+    """ 
+    Takes in the tex string and the index of the open brace to which we 
     need to find the matching brace. 
-    Function returns the index of the matching brace """
+    Function returns the index of the matching brace 
+    """
+
     count = 0
     if (tex[ind] == "{"):
         count += 1
@@ -871,6 +983,55 @@ def findMatchingBrace(tex, ind):
             count = count - 1
         ptr += 1
     return ptr - 1
+
+##########################################################################
+##                        REDIRECTION FUNCTIONS                         ##
+##########################################################################
+
+def writeLinkFunctions(functionName, linkFunctions, gen_dir):
+    """
+    Takes in a list of all functions that refers to the same man page as
+    the one with <functionName>, which is the parent man page. 
+    """
+    for link in linkFunctions:
+        if link != functionName:
+            manFile = open(gen_dir + '/' + link + ".3", "w")
+            manFile.write(".so " + functionName + ".3\n")
+            manFile.close()
+
+def parseDeprecationTable(directory, gen_dir):
+    """ 
+    ***PREREQUISITE: This function only gets calls when the user gives
+    a directory to the script. The main routines from the Table of Con-
+    tents must have been converted for this functin to execute properly.
+
+    Parse the deprecation table in the Appendix of the specification.
+    Creates and directs the deprecated functions to the most updated ver-
+    sion. 
+    If the deprecated function has an entry in the Table of Contents, no
+    new page will be created.
+    If the deprecated function already has an entry in the output, no new
+    page will be created.
+    """
+    tableTex = open(directory + "/deprecationTable.tex", "r").read()
+    tableRows = tableTex.split("\\hline")
+    for row in tableRows:
+        columns = row.split("&")
+        if (columns[0].find("\\FUNC") != -1):
+            argStart = columns[0].find("\\FUNC{") + len("\\FUNC{")
+            argEnd = columns[0].find("}", argStart)
+            deprFuncName = columns[0][argStart:argEnd].replace("\\", "")
+            if not os.path.isfile(gen_dir + "/" + deprFuncName + ".3"):
+                manFile = open(gen_dir + '/' + deprFuncName + ".3", "w")
+                argStartPar = columns[3].find("\\FUNC{") + len("\\FUNC{")
+                argEndPar = columns[3].find("}", argStartPar)
+                parentName = columns[3][argStartPar:argEndPar].replace("\\", "")
+                if not os.path.isfile(gen_dir + "/" + parentName + ".3"):
+                    print("Error: " + deprFuncName + " redirects to "
+                        + parentName + ", which has not been generated yet.\n")
+                    exit(1)
+                manFile.write(".so " + parentName + ".3\n")
+                manFile.close()
 
 ##########################################################################
 ##                            MAIN FUNCTIONS                            ##
@@ -886,8 +1047,10 @@ def convertFile(functionName, directory, gen_dir):
     manFile.write(titleHeader)
 
     tex = texFile.read()
-    tex = tex.replace("\\begin{DeprecateBlock}", "")
-    tex = tex.replace("\\end{DeprecateBlock}", "")
+    tex = tex.replace("\\begin{DeprecateBlock}", 
+        "./ sectionStart\n.B ***********DEPRECATED***********\n./ sectionEnd\n")
+    tex = tex.replace("\\end{DeprecateBlock}", 
+        "./ sectionStart\n.B ********************************\n./ sectionEnd\n")
     tex = tex.replace("\\begin{apidefinition}\n", 
                 "./ sectionStart\n.SH   SYNOPSIS\n./ sectionEnd")
     tex = sumReplacements(tex, functionName)
@@ -897,7 +1060,7 @@ def convertFile(functionName, directory, gen_dir):
     tex = notesReplacements(tex)
     tex = retReplacements(tex)
     tex = boldReplacements(tex)
-    tex = codeReplace(tex)
+    (tex, linkFunctions) = codeReplace(tex)
     if (tex.find("\\apiimpnotes{") != -1):
         tex = impnotesReplacements(tex)
     while(tex.find("\\apidesctable{") != -1):
@@ -930,11 +1093,12 @@ def convertFile(functionName, directory, gen_dir):
     print("Finished converting " + functionName + ".tex")
     manFile.close()
     texFile.close()
+    writeLinkFunctions(functionName, linkFunctions, gen_dir)
 
 def main():
     parser = argparse.ArgumentParser(description='Generate OpenSHMEM manpages')
     parser.add_argument('-d', '--directory', type=str, required=False,
-                        help='OpenSHMEM specification LaTeX directory path')
+                        help='OpenSHMEM specification content LaTeX directory path')
     parser.add_argument('-o', '--output-directory', type=str, required=False, default="./man",
                         help='Output directory for generated manpages')
     parser.add_argument('-f', '--filename', type=str, required=False,
@@ -964,6 +1128,7 @@ def main():
                     exit(1)
                 else:
                     convertFile(routine, args.directory, args.output_directory)
+            parseDeprecationTable(args.directory, args.output_directory)
     else:
         if not os.path.isfile(args.filename):
             print("Error: input file, " + args.filename + ", does not appear to exist.")

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -4,6 +4,7 @@ import sys
 import os
 import string
 import argparse
+import time
 
 # boldWordsC and boldWordsF are a set of the key words that will be
 # bolded in the man page
@@ -20,8 +21,8 @@ def writePageHeader(functionName):
     """
 
     titleHeader = ".TH " + functionName.upper() + " 3 " \
-                     + "" + "" \
-                     + "\"Open Source Software Solutions, Inc.\"" + "" \
+                     + "\"Open Source Software Solutions, Inc.\" " \
+                     + time.strftime("%m/%d/%Y") + " " \
                      + "\"OpenSHEMEM Library Documentation\"" + "\n"
     return titleHeader
 
@@ -850,7 +851,7 @@ def synFReplacements(tex):
     will have "A" and "C" as bolded and "B" will be regular. 
     """
 
-    linkFortranFuncs = []
+    # linkFortranFuncs = []
     while (tex.find("\\begin{Fsynopsis}") != -1):
         startOfText = tex.find("\\begin{Fsynopsis}")
         endOfText = tex.find("\\end{Fsynopsis}")
@@ -869,38 +870,38 @@ def synFReplacements(tex):
             text = text[:s] + line + text[e:]
             last = s
 
-            if(wordList[0] == "CALL"):
-                argStart = wordList[1].find("(")
-                if (argStart < 0):
-                    funcName = wordList[1]
-                else:
-                    funcName = wordList[1][:argStart]
-                linkFortranFuncs.append(funcName.strip())
+            # if(wordList[0] == "CALL"):
+            #     argStart = wordList[1].find("(")
+            #     if (argStart < 0):
+            #         funcName = wordList[1]
+            #     else:
+            #         funcName = wordList[1][:argStart]
+            #     linkFortranFuncs.append(funcName.strip())
 
-            if(wordList[0] not in boldWordsF):
-                for i in xrange(len(wordList)):
-                    if (wordList[i].find("SHMEM") != -1):
-                        argStart = wordList[i].find("(")
-                        funcName = wordList[i][:argStart]
-                        linkFortranFuncs.append(funcName.strip())
+            # if(wordList[0] not in boldWordsF):
+            #     for i in xrange(len(wordList)):
+            #         if (wordList[i].find("SHMEM") != -1):
+            #             argStart = wordList[i].find("(")
+            #             funcName = wordList[i][:argStart]
+            #             linkFortranFuncs.append(funcName.strip())
 
         tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
                 ".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
                  "\n./ sectionEnd"  + "\n" + \
                  tex[endOfText + len("\\end{Fsynopsis}"):]
-    return (tex, linkFortranFuncs)
+    return tex 
 
 def codeReplace(tex):
     linkFuncsAll = []
     (tex, linkC11) = synCReplacements(tex, "C11synopsis")
     (tex, linkC) = synCReplacements(tex, "Csynopsis")
     (tex, linkCCol) = synCReplacements(tex, "CsynopsisCol")
-    (tex, linkFortran) = synFReplacements(tex)
+    tex = synFReplacements(tex)
     linkFuncsAll.extend(linkC11)
     linkFuncsAll.extend(linkC)
     linkFuncsAll.extend(linkCCol)
-    linkFuncsAll.extend(linkFortran)
-    print(linkFuncsAll)
+    # linkFuncsAll.extend(linkFortran)
+    # print(linkFuncsAll)
     return (tex, linkFuncsAll)
 
 ##########################################################################
@@ -1021,7 +1022,8 @@ def parseDeprecationTable(directory, gen_dir):
             argStart = columns[0].find("\\FUNC{") + len("\\FUNC{")
             argEnd = columns[0].find("}", argStart)
             deprFuncName = columns[0][argStart:argEnd].replace("\\", "")
-            if not os.path.isfile(gen_dir + "/" + deprFuncName + ".3"):
+            if not os.path.isfile(gen_dir + "/" + deprFuncName + ".3") \
+                            and deprFuncName.islower():
                 manFile = open(gen_dir + '/' + deprFuncName + ".3", "w")
                 argStartPar = columns[3].find("\\FUNC{") + len("\\FUNC{")
                 argEndPar = columns[3].find("}", argStartPar)

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -5,6 +5,7 @@ import os
 import string
 import argparse
 import time
+import platform
 
 # boldWordsC and boldWordsF are a set of the key words that will be
 # bolded in the man page
@@ -832,7 +833,7 @@ def synCReplacements(tex, keyString):
                 tex[endOfText + len("\\end{" + keyString + "}"):]
     return (tex, linkCFuncs)
 
-def synFReplacements(tex):
+def synFReplacements(tex, build_fortran):
     """ 
     Replaces the code identified between "\\begin{Fsynopsis}" and 
     "\end{Fsynopsis}" to have Fortran keywords (defined as a global 
@@ -851,7 +852,7 @@ def synFReplacements(tex):
     will have "A" and "C" as bolded and "B" will be regular. 
     """
 
-    # linkFortranFuncs = []
+    linkFortranFuncs = []
     while (tex.find("\\begin{Fsynopsis}") != -1):
         startOfText = tex.find("\\begin{Fsynopsis}")
         endOfText = tex.find("\\end{Fsynopsis}")
@@ -870,38 +871,38 @@ def synFReplacements(tex):
             text = text[:s] + line + text[e:]
             last = s
 
-            # if(wordList[0] == "CALL"):
-            #     argStart = wordList[1].find("(")
-            #     if (argStart < 0):
-            #         funcName = wordList[1]
-            #     else:
-            #         funcName = wordList[1][:argStart]
-            #     linkFortranFuncs.append(funcName.strip())
+            if (build_fortran):
+                if(wordList[0] == "CALL"):
+                    argStart = wordList[1].find("(")
+                    if (argStart < 0):
+                        funcName = wordList[1]
+                    else:
+                        funcName = wordList[1][:argStart]
+                    linkFortranFuncs.append(funcName.strip())
 
-            # if(wordList[0] not in boldWordsF):
-            #     for i in xrange(len(wordList)):
-            #         if (wordList[i].find("SHMEM") != -1):
-            #             argStart = wordList[i].find("(")
-            #             funcName = wordList[i][:argStart]
-            #             linkFortranFuncs.append(funcName.strip())
+                if(wordList[0] not in boldWordsF):
+                    for i in xrange(len(wordList)):
+                        if (wordList[i].find("SHMEM") != -1):
+                            argStart = wordList[i].find("(")
+                            funcName = wordList[i][:argStart]
+                            linkFortranFuncs.append(funcName.strip())
 
         tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
                 ".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
                  "\n./ sectionEnd"  + "\n" + \
                  tex[endOfText + len("\\end{Fsynopsis}"):]
-    return tex 
+    return (tex, linkFortranFuncs)
 
-def codeReplace(tex):
+def codeReplace(tex, build_fortran):
     linkFuncsAll = []
     (tex, linkC11) = synCReplacements(tex, "C11synopsis")
     (tex, linkC) = synCReplacements(tex, "Csynopsis")
     (tex, linkCCol) = synCReplacements(tex, "CsynopsisCol")
-    tex = synFReplacements(tex)
+    (tex, linkFortran) = synFReplacements(tex, build_fortran)
     linkFuncsAll.extend(linkC11)
     linkFuncsAll.extend(linkC)
     linkFuncsAll.extend(linkCCol)
-    # linkFuncsAll.extend(linkFortran)
-    # print(linkFuncsAll)
+    linkFuncsAll.extend(linkFortran)
     return (tex, linkFuncsAll)
 
 ##########################################################################
@@ -1000,11 +1001,11 @@ def writeLinkFunctions(functionName, linkFunctions, gen_dir):
             manFile.write(".so " + functionName + ".3\n")
             manFile.close()
 
-def parseDeprecationTable(directory, gen_dir):
+def parseDeprecationTable(directory, gen_dir, build_fortran):
     """ 
     ***PREREQUISITE: This function only gets calls when the user gives
     a directory to the script. The main routines from the Table of Con-
-    tents must have been converted for this functin to execute properly.
+    tents must have been converted for this function to execute properly.
 
     Parse the deprecation table in the Appendix of the specification.
     Creates and directs the deprecated functions to the most updated ver-
@@ -1022,8 +1023,9 @@ def parseDeprecationTable(directory, gen_dir):
             argStart = columns[0].find("\\FUNC{") + len("\\FUNC{")
             argEnd = columns[0].find("}", argStart)
             deprFuncName = columns[0][argStart:argEnd].replace("\\", "")
-            if not os.path.isfile(gen_dir + "/" + deprFuncName + ".3") \
-                            and deprFuncName.islower():
+            if "Fortran" in columns[0] and not build_fortran:
+                continue
+            if not os.path.isfile(gen_dir + "/" + deprFuncName + ".3"):
                 manFile = open(gen_dir + '/' + deprFuncName + ".3", "w")
                 argStartPar = columns[3].find("\\FUNC{") + len("\\FUNC{")
                 argEndPar = columns[3].find("}", argStartPar)
@@ -1039,7 +1041,7 @@ def parseDeprecationTable(directory, gen_dir):
 ##                            MAIN FUNCTIONS                            ##
 ##########################################################################
 
-def convertFile(functionName, directory, gen_dir):
+def convertFile(functionName, directory, gen_dir, build_fortran=False):
     filename = directory + '/' + functionName + ".tex"
     texFile = open(filename, "r")
     if not os.path.exists(gen_dir):
@@ -1062,7 +1064,7 @@ def convertFile(functionName, directory, gen_dir):
     tex = notesReplacements(tex)
     tex = retReplacements(tex)
     tex = boldReplacements(tex)
-    (tex, linkFunctions) = codeReplace(tex)
+    (tex, linkFunctions) = codeReplace(tex, build_fortran)
     if (tex.find("\\apiimpnotes{") != -1):
         tex = impnotesReplacements(tex)
     while(tex.find("\\apidesctable{") != -1):
@@ -1105,11 +1107,17 @@ def main():
                         help='Output directory for generated manpages')
     parser.add_argument('-f', '--filename', type=str, required=False,
                         help='LaTeX file path for an OpenSHMEM routine')
+    parser.add_argument('--build-fortran', required=False, default=False, action="store_true",
+                        help='build Fortran manpages (requires setting -d)')
     args = parser.parse_args()
 
     if (args.directory == None) and (args.filename == None):
         parser.print_usage()
         exit(1)
+
+    if platform.system() == 'Darwin' and args.build_fortran:
+        print("Warning: OSX may have a case-insensitive filesystem, which " +
+              "would break some Fortran manpages.")
 
     if args.directory != None:
         if not os.path.realpath(args.directory):
@@ -1129,8 +1137,8 @@ def main():
                     print("Error: " + routine + ".tex is not in the given directory")
                     exit(1)
                 else:
-                    convertFile(routine, args.directory, args.output_directory)
-            parseDeprecationTable(args.directory, args.output_directory)
+                    convertFile(routine, args.directory, args.output_directory, args.build_fortran)
+            parseDeprecationTable(args.directory, args.output_directory, args.build_fortran)
     else:
         if not os.path.isfile(args.filename):
             print("Error: input file, " + args.filename + ", does not appear to exist.")

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -1,0 +1,981 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import string
+import argparse
+
+# boldWordsC and boldWordsF are a set of the key words that will be
+# bolded in the man page
+boldWordsC = {"void", "int", "const", "size_t", "short", "ptrdiff_t", 
+			"long", "TYPE", "shmem_global_exit(int"}
+boldWordsF = {"INTEGER", "CALL", "POINTER", "LOGICAL", "INTEGER*4",
+				"INTEGER*8", "REAL*4", "REAL*8", "CHARACTER"}
+
+def writePageHeader(functionName):
+	"""Write the page header for the man page. Takes in the form of:
+	.TH [name of program] [section number] [center footer] [left footer] 
+		  [center header]"""
+
+	titleHeader = ".TH " + functionName.upper() + " 3 " \
+					 + "" + "" \
+					 + "\"Open Source Software Solutions, Inc.\"" + "" \
+					 + "\"OpenSHEMEM Library Documentation\"" + "\n"
+	return titleHeader
+
+##########################################################################
+##							MACRO REPLACEMENTS 							##
+##########################################################################
+
+def funcReplacements(tex):
+	"""Convert every FUNC macro with the bolded argument string 
+	(.B <argument>).
+	-- Special consideration to any periods after the macro, since a 
+	period at the beginning of a line denotes a comment and the 
+	entire line will not appear.
+	(.BR <argument> .)"""
+
+	keyString = "\FUNC{"
+	while (tex.find(keyString) != -1):
+		index = tex.find(keyString)
+		startBrace = tex.find("{", index)
+		endBrace = tex.find("}", startBrace)
+		innerText = tex[startBrace+1:endBrace]
+		if(endBrace + 1 < len(tex) and tex[endBrace + 1] == "."):
+			tex = tex[:index] + "\n" + \
+					".BR \"" + innerText + \
+					"\" .\n" + tex[endBrace+2:]
+		else:                                                                
+			tex = tex[:index] + "\n" + \
+				".B " + innerText + \
+				"\n" + tex[endBrace+1:]
+	return tex
+
+def varReplacements(tex, keyString):
+	"""Convert every VAR/VARTH macro with the bolded argument string 
+	(.I <argument>).
+	-- Special consideration to any periods after the macro, since a 
+	period at the beginning of a line denotes a comment and the 
+	entire line will not appear.
+	(.IR <argument> .)
+	-- Special consideration to any argument of "VARTH", which will 
+	require appending "th" to the argument string."""
+
+	while (tex.find(keyString) != -1):
+		index = tex.find(keyString)
+		startBrace = tex.find("{", index)
+		endBrace = tex.find("}", startBrace)
+		innerText = tex[startBrace+1:endBrace]
+		if keyString == "\VARTH{":
+			innerText += "th"
+		if (endBrace + 1 == len(tex)):
+			tex = tex[:index] + "\n.I " + innerText + "\n"
+		else:
+			if (tex[endBrace + 1] != "."):
+				tex = tex[:index] + "\n.I " + innerText \
+						    	+ "\n" + tex[endBrace+1:]
+			else:
+				tex = tex[:index] + "\n.IR \"" + innerText \
+						    	+ "\" .\n" + tex[endBrace+1:]
+	return tex
+
+def variableReplacements(tex):
+	tex = varReplacements(tex, "\VAR{")
+	tex = varReplacements(tex, "\VARTH{")
+	return tex
+
+def mBoxReplacements(tex):
+	"""Replace the Latex command "|mbox{<argument>}|" with just argument """
+
+	while (tex.find("|\mbox") != -1):
+		index = tex.find("|\mbox")
+		sbrace = tex.find("{", index)
+		ebrace = tex.find("}", sbrace)
+		ebar = tex.find("|", sbrace)
+		tex = tex[:index] + tex[sbrace+1:ebrace] \
+					    + tex[ebar+1:]
+	return tex
+
+def boldReplacements(tex):
+	"""SPECIFIC TO shmem_reductions:
+	Replace the Latex command: 
+	"\\textbf{<NAME>} \\newline <text> <code> \\newline...\\bigskip" 
+	--NAME will the title of a new section header with <text> as the 
+	immediate content. 
+	-- <code> will be replaced as normal (See function codeReplace(tex))
+	-- \\bigskip will be replaced by the empty string. """
+
+	while (tex.find("\\textbf{") != -1):
+		beg = tex.find("\\textbf{")
+		sbrace = tex.find("{", beg)
+		ebrace = tex.find("}", sbrace)
+		fnewline = tex.find("\\newline", ebrace)
+		snewline = tex.find("\\newline", fnewline + 1)
+		clean = tex[fnewline + len("\\newline"):snewline]
+		clean = macroReplacements(clean)
+		tex = tex[:beg] + "\n.SH " + tex[sbrace+1:ebrace] \
+				    	+ "\n" + clean \
+				    	+ tex[snewline + len("\\newline"):]
+	tex = tex.replace("\\bigskip", "")
+	return tex
+
+def italReplacements(tex):
+	""" Replace the Latex command "\\textit{<argument>}" with just 
+	argument """
+
+	while (tex.find("\\textit{") != -1):
+		beg = tex.find("\\textit{")
+		sbrace = tex.find("{", beg)
+		ebrace = tex.find("}", sbrace)
+		tex = tex[:beg] + tex[sbrace+1:ebrace] \
+				    	+ tex[ebrace+1:]
+	return tex
+
+def oprReplacements(tex):
+	"""Convert every OPR macro with the bolded argument string 
+	(.I <argument>).
+	-- Special consideration to any periods after the macro, since a 
+	period at the beginning of a line denotes a comment and the 
+	entire line will not appear.
+	(.IR <argument> .)
+	-- Special consideration to any argument of "VARTH", which will 
+	require appending "th" to the argument string. """
+
+	while (tex.find("\\OPR") != -1):
+		index = tex.find("\\OPR")
+		startBrace = tex.find("{", index)
+		endBrace = tex.find("}", index)
+		if (endBrace + 1 == len(tex) or tex[endBrace + 1] != "."):
+			tex = tex[:index] + "\n.I " + tex[startBrace+1:endBrace] \
+					    	+ "\n" + tex[endBrace+1:]
+		else:
+			tex = tex[:index] + "\n.IR \"" + tex[startBrace+1:endBrace] \
+					    	+ "\" .\n" + tex[endBrace+1:]
+	return tex
+
+def constReplacements(tex):
+	"""Replace the Latex command "\CONST{<argument>}" with just 
+	argument. """
+
+	while (tex.find("\\CONST") != -1):
+		index = tex.find("\\CONST")
+		startBrace = tex.find("{", index)
+		endBrace = tex.find("}", startBrace)
+		tex = tex[:index] + tex[startBrace+1:endBrace] + tex[endBrace+1:]
+	return tex
+
+def generalReplacements(tex):
+	"""Replace the common Latex macros that take in no arguments and all 
+	Latex definitions that contain a backslash (which may have unde-
+	fined behavior in the actual manpage). Some text may need to be 
+	processed separately if it is followed by a period, which will 
+	cause all text in the same line following the period to be not 
+	shown."""
+
+	tex = tex.replace("\openshmem{}", "OpenSHMEM")
+	tex = tex.replace("\openshmem", "OpenSHMEM")
+	tex = tex.replace("\\acp{PE}", "PEs")
+	tex = tex.replace("\\ac{PE}", "PE")
+	tex = tex.replace("\\ac{MPI}", "MPI")
+	tex = tex.replace("\\acp{AMO}", "AMOs")
+	tex = tex.replace("\\ac{AMO}", "AMO")
+	tex = tex.replace("\\ac{API}", "API")
+	tex = tex.replace("\\acp{RMA}", "RMAs")
+	tex = tex.replace("\\ac{RMA}", "RMA")
+	tex = tex.replace("\\CorCpp{}", " C/C++")
+	tex = tex.replace("\\CorCpp", " C/C++")
+	tex = tex.replace("\\Fortran{}", "Fortran")
+	tex = tex.replace("\\Fortran", "Fortran")
+	tex = tex.replace("\\Cstd", "C")
+	tex = tex.replace("\\PUT{}", "PUT")
+	tex = tex.replace("\\GET{}", "GET")
+	tex = tex.replace("\\SIZE{}", "SIZE")
+	tex = tex.replace("\\activeset.", "\n.IR \"Active set\" .\n")
+	tex = tex.replace("\\activeset{}", "\\activeset")
+	tex = tex.replace("\\activeset", "\n.I \"Active set\"\n")
+	tex = tex.replace("\\activeset ", "\n.I \"Active set\"\n")
+	tex = tex.replace("\\dest.", "\n.IR \"dest\" .\n")
+	tex = tex.replace("\\source.", "\n.IR \"source\" .\n")
+	tex = tex.replace("\\dest{}", "\n.I \"dest\"\n")
+	tex = tex.replace("\\source{}", "\n.I \"source\"\n")
+	tex = tex.replace("\\TYPE{}", "TYPE")
+	tex = tex.replace("\\TYPENAME{}", "TYPENAME")
+	return tex
+
+##########################################################################
+##							SECTION REPLACEMENTS 						##
+##########################################################################
+
+def descrReplacements(tex):
+	"""Search tex file for the keyString "\\apidecription{" and its matching
+	parenthesis. All text between will be processed such that there are no
+	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+	have all the macros replaced and put back into its corresponding place
+	in the text file. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of the processed text, respectively, for differenti-
+	ation between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	startOfText = tex.find("\\apidescription{")
+	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+	sectionText = cleanText(tex[startOfText:endOfText])
+	tex = tex[:startOfText] + \
+			"./ sectionStart\n" + "\n.SS API Description\n" + \
+			sectionText + "\n./ sectionEnd\n" + tex[endOfText+1:]
+	tex = tex.replace("\\apidescription{", "")
+	return tex
+
+def retReplacements(tex):
+	"""Search tex file for the keyString "\\apireturnavalues{" and its matching
+	parenthesis. All text between will be processed such that there are no
+	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+	have all the macros replaced and put back into its corresponding place
+	in the text file. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of the processed text, respectively, for differenti-
+	ation between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	startOfText = tex.find("\\apireturnvalues{")
+	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+	sectionText = cleanText(tex[startOfText:endOfText])
+	tex = tex[:startOfText] + \
+			"./ sectionStart\n" + "\n.SS Return Values\n" + \
+			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+	tex = tex.replace("\\apireturnvalues{", "")
+	return tex
+
+def notesReplacements(tex):
+	"""Search tex file for the keyString "\\apinotes{" and its matching
+	parenthesis. All text between will be processed such that there are no
+	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+	have all the macros replaced and put back into its corresponding place
+	in the text file. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of the processed text, respectively, for differenti-
+	ation between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	startOfText = tex.find("\\apinotes{")
+	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+	sectionText = cleanText(tex[startOfText:endOfText])
+	tex = tex[:startOfText] + \
+			"./ sectionStart\n" + "\n.SS API Notes\n" + \
+			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+	tex = tex.replace("\\apinotes{", "")
+	return tex
+
+def impnotesReplacements(tex):
+	"""Search tex file for the keyString "\\apiimpnotes{" and its matching
+	parenthesis. All text between will be processed such that there are no
+	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+	have all the macros replaced and put back into its corresponding place
+	in the text file. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of the processed text, respectively, for differenti-
+	ation between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	startOfText = tex.find("\\apiimpnotes{")
+	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+	sectionText = cleanText(tex[startOfText:endOfText])
+	tex = tex[:startOfText] + \
+			"./ sectionStart\n" + "\n.SS API Notes\n" + \
+			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+	tex = tex.replace("\\apiimpnotes{", "")
+	return tex
+
+def sumReplacements(tex, functionName):
+	"""Search tex file for the keyString "\\apisummary{" and its matching
+	parenthesis. All text between will be processed such that there are no
+	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+	have all the macros replaced and put back into its corresponding place
+	in the text file. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of the processed text, respectively, for differenti-
+	ation between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	startOfText = tex.find("\\apisummary{")
+	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+	sectionText = cleanText(tex[startOfText:endOfText])
+	tex = tex[:startOfText] + \
+			"./ sectionStart\n" + \
+			".SH NAME\n" + functionName + " \- " \
+			+ sectionText + "\n" + \
+			"./ sectionEnd\n" + tex[endOfText+1:]
+	tex = tex.replace("\\apisummary{", "")
+	return tex
+
+def exampleCodeReplace(sectionText, in_directory, keyString):
+	"""Searches throught the given text and replaces the files of code with
+	the actual code in the file. 
+	
+	All examples in the Latex file follows the following pattern:
+		\keyString{<pre-text>}{<directory to code>}{<post-text>}
+	-- The <pre-text> and <post-text> should have already been processed 
+	prior to this function call and will be concatenated to the return
+	string.
+	-- The pattern ".nf\\n ... .fi\\n" will have the text in between ".nf"
+	and "fi" be presented without formatting. """
+
+	while(sectionText.find(keyString) != -1):
+		startOfText = sectionText.find(keyString)
+		firstStartBrace = sectionText.find("{", startOfText)
+		firstEndBrace = sectionText.find("}", firstStartBrace)
+		secStartBrace = sectionText.find("{", firstEndBrace)
+		secEndBrace = sectionText.find("}", secStartBrace)
+		thirdStartBrace = sectionText.find("{", secEndBrace)
+		thirdEndBrace = sectionText.find("}", thirdStartBrace)
+		path = sectionText[secStartBrace+1:secEndBrace].strip()
+		code = open(in_directory + "/../" + path, "r").read()
+		sectionText = sectionText[:startOfText] + "\n" + \
+					sectionText[firstStartBrace+1:firstEndBrace] + "\n\n" + \
+					".nf\n" + \
+					code + \
+					".fi\n" + \
+					sectionText[thirdStartBrace+1:thirdEndBrace] + \
+					sectionText[thirdEndBrace + 1:]
+	return sectionText
+
+def exampleReplacements(tex, in_directory):
+	"""Search tex file for the keyString "\\begin{apiexamples}" and its matching
+	"\\end{apiexamples}". All text between will be processed such that there 
+	are no consecutive spaces, no tabs, and unnecessary "\\n". The text will 
+	then have all the macros replaced and put back into its corresponding 
+	placein the text file. 
+	The string "./ sectionStart" is appended at the beginning of the pro-
+	cessed text, for differentiation between the text with sections and 
+	"dangling text". These strings will not appear in the manpage as any 
+	line that begins with a period will be treated as a comment. 
+	NOTE: There is no corresponding "./ sectionEnd" in this section because
+	the example section of the manpage is always the last section. 
+	Dangling text is identified as the text between a "./ sectionEnd" and
+	./sectionStart. Since there will be no text following this section, the
+	"./ sectionEnd" flag is no necessary. """
+
+	startOfText = tex.find("\\begin{apiexamples}")
+	endOfText = tex.find("\\end{apiexamples}")
+	text = tex[startOfText + len("\\begin{apiexamples}"):endOfText]
+	sectionText = cleanText(text)
+
+	sectionText = exampleCodeReplace(sectionText, in_directory, 
+					"\\apicexample")
+	sectionText = exampleCodeReplace(sectionText, in_directory,
+					"\\apifexample")
+
+	tex = tex[:startOfText] + "\n" \
+			"./ sectionStart" + "\n.SS Examples\n" + \
+			sectionText + \
+			tex[endOfText + len("\\end{apiexamples}"):]
+	return tex
+
+def argReplacements(tex):
+	"""All elements within the section defined between "\\begin{apiarguments}"
+	and "\end{apiarguments}" will follow the following pattern:
+			\\apiargument{<STATUS>}{<name>}{<description>}
+	The following code will convert the above text such that STATUS will be
+	bolded, <name> will be underlined/italicized, and <description> will be
+	regular. 
+	In the special case that there are no arguments, the macro will be of 
+	the form:
+			\\apiargument{"None."}{}{}
+	in which case, the code will conver the macro above to have "None." as
+	bolded. """
+
+	startOfText = tex.find("\\apiargument")
+	endOfText = tex.find("\\end{apiarguments}")
+	sectionText = tex[startOfText + len("\\apiargument"):endOfText].strip()
+	argList = sectionText.split("\\apiargument")
+	cleanArgList = []
+	for arg in argList:
+		firstStartBrace = arg.find("{")
+		firstEndBrace = findMatchingBrace(arg, firstStartBrace)
+		secStartBrace = arg.find("{", firstEndBrace)
+		secEndBrace = findMatchingBrace(arg, secStartBrace)
+		thirdStartBrace = arg.find("{", secEndBrace)
+		thirdEndBrace = findMatchingBrace(arg, thirdStartBrace)
+
+		status = cleanText(arg[firstStartBrace+1:firstEndBrace])
+		name = cleanText(arg[secStartBrace+1:secEndBrace])
+		text = cleanText(arg[thirdStartBrace+1:thirdEndBrace])
+		if (arg[firstStartBrace+1:firstEndBrace] == "None."):
+			cleanArgList.append(".B None.")
+		else:
+			cleanArgList.append(".BR \"" + status + \
+						" \" -" + "\n.I " + name + \
+						"\n- " + text + \
+						arg[thirdEndBrace+1:])
+	sectionText = "\n\n".join(cleanArgList)
+	tex = tex[:startOfText] + "\n" + \
+			"./ sectionStart\n" + "\n" + \
+			".SH DESCRIPTION\n.SS Arguments\n" + \
+			sectionText + "\n./ sectionEnd\n" + tex[endOfText:]
+	tex = tex.replace("\\begin{apiarguments}", "")
+	tex = tex.replace("\\end{apiarguments}", "")
+	return tex
+
+##########################################################################
+##							TABLE REPLACEMENTS	 						##
+##########################################################################
+
+def descTReplacements(tex):
+	"""All elements within the tex file defined to begin with "\\apidesctable{"
+	will follow the following pattern:
+			\\apidesctable{{<desc>}{<firstColHead>}{<secondColHead>}
+	The following code will convert the above text to display such that 
+	<desc> will display as regular text, <firstColHead> and <secondColHead>
+	will follow the tabular header.
+	
+	The tabular header is:
+					.TP <number>
+					<firstCol>
+					<secondCol>
+	where <number> is the number of spaces between the start of firstCol
+	and the start of secondCol. 
+	Displays as:
+					<firstCol>					 <secondCol>
+					<----------<number>---------->
+	If the length of <firstCol> surpasses <number>, it will display as:
+					<----------<number>---------->
+					<firstCol>					 
+												 <secondCol>
+	
+	Every row of the table must include the ".TP" or the text will be
+	processed with default formatting. 
+	If there there is no <number>, the script will default to 1, or the
+	lastest definition of <number> in the current table
+	NOTE: Typically manpages ignores "\\n" within the text and displays
+	the text as if there is no "\\n". Under the ".TP" header, the flag
+	for when the second column begins is the next "\\n" 
+	
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of every row processed, respectively, for differenti-
+	ating between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	index = tex.find("\\apidesctable{")
+	firstStartBrace = tex.find("{", index)
+	firstEndBrace = findMatchingBrace(tex, firstStartBrace)
+	secStartBrace = tex.find("{", firstEndBrace)
+	secEndBrace = findMatchingBrace(tex, secStartBrace)
+	thirdStartBrace = tex.find("{", secEndBrace)
+	thirdEndBrace = findMatchingBrace(tex, thirdStartBrace)
+
+	desc = cleanText(tex[firstStartBrace + 1: firstEndBrace])
+	firstColHead = cleanText(tex[secStartBrace + 1: secEndBrace])
+	secondColHead = cleanText(tex[thirdStartBrace + 1: thirdEndBrace])
+
+	tex = tex[:index] + "\n./ sectionStart\n" + desc + \
+			"\n.TP 25\n" + firstColHead + "\n" + \
+			secondColHead + "\n./ sectionEnd\n" + tex[thirdEndBrace+1:]
+	return tex
+
+def tablerowReplacements(tex):
+	"""All elements within the tex file defined to begin with "\\apitablerow"
+	will follow the following pattern:
+			\\apitablerow{<firstCol>}{<secondCol>}
+	The following code will convert the above text to display in tabular 
+	form. 
+	
+	The tabular header is:
+					.TP <number>
+					<firstCol>
+					<secondCol>
+	where <number> is the number of spaces between the start of firstCol
+	and the start of secondCol. 
+	Displays as:
+					<firstCol>					 <secondCol>
+					<----------<number>---------->
+	If the length of <firstCol> surpasses <number>, it will display as:
+					<----------<number>---------->
+					<firstCol>					 
+												 <secondCol>
+	
+	Every row of the table must include the ".TP" or the text will be
+	processed with default formatting. 
+	If there there is no <number>, the script will default to 1, or the
+	lastest definition of <number> in the current table
+	NOTE: Typically manpages ignores "\\n" within the text and displays
+	the text as if there is no "\\n". Under the ".TP" header, the flag
+	for when the second column begins is the next "\\n" 
+	
+	In the special case that there is no text in the first column (a 
+	method to get the proper indentation in the Latex), continue the 
+	text in <secondCol> from the previous row's <secondCol> text will
+	have the same behavior from Latex. 
+	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+	beginning and end of every row processed, respectively, for differenti-
+	ating between the text with sections and "dangling text".
+	These strings will not appear in the manpage as any line that begins 
+	with a period will be treated as a comment. """
+
+	while(tex.find("\\apitablerow") != -1):
+		startOfText = tex.find("\\apitablerow")
+		firstStartBrace = tex.find("{", startOfText)
+		firstEndBrace = findMatchingBrace(tex, firstStartBrace)
+		secStartBrace = tex.find("{", firstEndBrace)
+		secEndBrace = findMatchingBrace(tex, secStartBrace)
+
+		firstCol = tex[firstStartBrace + 1:firstEndBrace]
+		firstCol = firstCol.replace("\n", " ")
+		firstCol = macroReplacements(firstCol)
+
+		secondCol = tex[secStartBrace + 1: secEndBrace]
+		secondCol = secondCol.replace("\n", " ")
+		secondCol = cleanText(secondCol)
+
+		if (firstCol != ""):
+			tex = tex[:startOfText] + "\n" + \
+				"./ sectionStart\n.TP 25\n" + firstCol + "\n" + \
+				secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
+		else:
+			tex = tex[:startOfText] + "\n" + "\n./ sectionStart" + \
+				"\n" + secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
+	return tex
+
+
+##########################################################################
+##					REFERENCES AND REF TABLE REPLACEMENTS	 			##
+##########################################################################
+
+def refTextReplacements(tex):
+	"""Searches through the tex file and processes "dangling text", or text that
+	does not belong to a designated section. It finds these strings by search-
+	ing for text in between any two consecutive "./ sectionStart" and 
+	"./ sectionEnd" These text will sometimes have references to tables, iden-
+	tifiable by the argument in the "\\ref{<argument>}" macro. Each table will
+	have a unique integer that it can be identified with, consistent with the
+	Latex file.
+	The function will return the processed string with an indication array of 
+	which tables are to be appended to the end of the man page. """
+
+	tables = [0, 0, 0, 0, 0]
+	last = 0
+	while(tex.find("./ sectionEnd", last) > 0):
+		firstEnd = tex.find("./ sectionEnd", last)
+		secStart = tex.find("./ sectionStart", firstEnd)
+		last = secStart
+		if(tex[firstEnd + len("./ sectionEnd"):secStart].strip() != ""):
+			sectionText = tex[firstEnd + len("./ sectionEnd"):secStart].strip()
+			sectionText = cleanText(sectionText)
+
+			if (tex.find("\\ref{stdrmatypes}") != -1):
+				sectionText = sectionText.replace("\\ref{stdrmatypes}", "1")
+				tables[0] = 1
+			if (tex.find("\\ref{stdamotypes}") != -1):
+				sectionText = sectionText.replace("\\ref{stdamotypes}", "2")
+				tables[1] = 1
+			if (tex.find("\\ref{extamotypes}") != -1):
+				sectionText = sectionText.replace("\\ref{extamotypes}", "3")
+				tables[2] = 1
+			if (tex.find("\\ref{bitamotypes}") != -1):
+				sectionText = sectionText.replace("\\ref{bitamotypes}", "4")
+				tables[3] = 1
+			if (tex.find("\\ref{p2psynctypes}") != -1):
+				sectionText = sectionText.replace("\\ref{p2psynctypes}", "5")
+				tables[4] = 1
+
+			sectionText = sectionText.replace("~", " ")
+			tex = tex[:firstEnd + len("./ sectionEnd\n")] + "\n\n" + \
+					sectionText + "\n" + tex[secStart:]
+	return (tex, tables)
+
+def refMEMReplacements(tex):
+	""" Searches through the tex for any reference that specifically points to 
+	the memory modelled and replaces that sentence with a hard-coded string.
+	Processing the section that was in the original text is not an option
+	because the reference the Latex file does not apply to the man pages. """
+
+	if (tex.find("\\ref{subsec:memory_model}") != -1):
+		while(tex.find("\\ref{subsec:memory_model}") != -1):
+			index = tex.find("\\ref{subsec:memory_model}")
+			enter = 0
+			last = 0
+			while (enter < index):
+				last = enter
+				enter = tex.find("\n", enter + 1)
+			period = tex.find(".", index)
+			sentence = tex[last + 1: period + 1]
+			tex = tex[:last + 1] + \
+				"Please refer to the subsection on the Memory Model for the" + \
+				" definition of the term \"remotely accessible\"." + \
+				tex[period + 1:]
+	return tex
+
+def parseRefTables(tableTex):
+	""" The function takes in a tex file that contains a type table as input
+	and returns the processed table in tabular form.
+	All elements within the tex file that is desired will follow the 
+	following pattern:
+	
+			<firstCol>	&	<secondCol> \\\\ \hline
+	
+	The following code will convert the above text to display in tabular 
+	form. 
+	In the special case of the first row that follows the pattern above,
+	the code will bold the strings of <firstCol> and <secondCol> for this
+	row only, for these are the column headers 
+	
+	The tabular header is:
+					.TP <number>
+					<firstCol>
+					<secondCol>
+	where <number> is the number of spaces between the start of firstCol
+	and the start of secondCol. 
+	Displays as:
+					<firstCol>					 <secondCol>
+					<----------<number>---------->
+	If the length of <firstCol> surpasses <number>, it will display as:
+					<----------<number>---------->
+					<firstCol>					 
+												 <secondCol>
+	
+	Every row of the table must include the ".TP" or the text will be
+	processed with default formatting. 
+	If there there is no <number>, the script will default to 1, or the
+	lastest definition of <number> in the current table
+	NOTE: Typically manpages ignores "\\n" within the text and displays
+	the text as if there is no "\\n". Under the ".TP" header, the flag
+	for when the second column begins is the next "\\n" 
+	
+	.B at the start of a line will underline/italicize all text until
+	the next "\\n" """
+
+	startIdx = tableTex.find("\\hline")
+	endIdx = tableTex.find("\\end{tabular}")
+	table = cleanText(tableTex[startIdx + len("\\hline"):endIdx])
+	text = ""
+	count = 0
+	while(table.find("\\hline") >= 0):
+		line = table[:table.find("\\hline")]
+		firstCol = line[:line.find("&")].strip()
+		secondCol = line[line.find("&")+1:line.find("\\\\")].strip()
+		if (count == 0):
+			text += ".TP 25\n" + ".B " + firstCol + "\n" + \
+					".B " + secondCol + "\n"
+		else:
+			text += ".TP\n" + firstCol + "\n" + secondCol + "\n"
+		table = table[table.find("\\hline") + len("\\hline"):]
+		count += 1
+	return text
+
+def addRefTable(tableID, directory):
+	""" This function maps the tableID given to each reference table to its
+	corresponding to tex file that contains the table. It then calls a
+	helper function to parse the table and returns the subsection text, 
+	containing the subsection header, the caption for the table, and the
+	table. """
+
+	if tableID == 1:
+		tableTex = open(directory + "/stdrmatypes.tex", "r").read()
+	elif tableID == 2: 
+		tableTex = open(directory + "/stdamotypes.tex", "r").read()
+	elif tableID == 3:
+		tableTex = open(directory + "/extamotypes.tex", "r").read()
+	elif tableID == 4:
+		tableTex = open(directory + "/bitamotypes.tex", "r").read()
+	else:
+		tableTex = open(directory + "/p2psynctypes.tex", "r").read()
+	captionIdx = tableTex.find("\\caption")
+	startBrace = captionIdx + len("\\caption")
+	endBrace = findMatchingBrace(tableTex, startBrace)
+
+	caption = generalReplacements(tableTex[startBrace+1:endBrace])
+	text = ".SS Table " + str(tableID) + ":\n" + caption + "\n" + \
+			parseRefTables(tableTex)
+	return text
+
+##########################################################################
+##							CODE REPLACEMENTS	 						##
+##########################################################################
+
+def synCReplacements(tex, keyString):
+	""" Replaces the code identified between "\\begin{<keyString>}" and 
+	"\end{<keyString>}" to have C keywords (defined as a global variable) 
+	bolded and the argument variables underlined. 
+	
+	.B at the start of a line will bold all text until
+	the next "\\n"
+	.I at the start of a line will underline/italicize all text until
+	the next "\\n"
+	.IB will alternate between bold and underline/italicize font. For 
+	example:
+	
+	.IB "A" "B" "C"
+	
+	will have "A" and "C" as italicized and "B" will be bolded. """
+
+	while (tex.find("\\begin{" + keyString + "}") != -1):
+		startOfText = tex.find("\\begin{" + keyString + "}")
+		endOfText = tex.find("\\end{" + keyString + "}")
+		text = tex[startOfText + len("\\begin{" + keyString + "}"):endOfText]
+		codeList = text.split(";")
+		formattedCode = [];
+
+		for line in codeList:
+			line = line.strip()
+			wordList = line.split()
+			for i in xrange(len(wordList)):
+				if(i < 2):
+					wordList[i] = "\n.B " + wordList[i]
+				else:
+					if (wordList[i] in boldWordsC):
+						wordList[i] = "\n.B " + wordList[i]
+					else:
+						if (wordList[i].find(")") != -1):
+							wordList[i] = "\n.I " + \
+								wordList[i][: wordList[i].find(")")] + \
+								"\n.B );\n"
+						elif (wordList[i].find(",") != -1):
+							wordList[i] = "\n.IB \"" + \
+								wordList[i][: wordList[i].find(",")] \
+								+ "\" ,"
+						else:
+							wordList[i] = "\n.I " + wordList[i]
+			line = "".join(wordList)
+			formattedCode.append(line)
+
+		formattedCode = "\n\n".join(formattedCode)
+		if (keyString == "C11synopsis"):
+			header = ".SS C11:\n"
+		elif (keyString == "Csynopsis"):
+			header = ".SS C/C++:\n"
+		else:
+			header = ""
+
+		tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
+				header + formattedCode  + "\n" + \
+				"./ sectionEnd\n" + \
+				tex[endOfText + len("\\end{" + keyString + "}"):]
+	return tex
+
+def synFReplacements(tex):
+	""" Replaces the code identified between "\\begin{Fsynopsis}" and 
+	"\end{Fsynopsis}" to have Fortran keywords (defined as a global 
+	variable) bolded. 
+	
+	.B at the start of a line will bold all text untilthe next "\\n"
+
+	.BR will alternate between bold and regular font. For example:
+	
+	.BR "A" "B" "C"
+	
+	will have "A" and "C" as bolded and "B" will be regular. """
+
+	while (tex.find("\\begin{Fsynopsis}") != -1):
+		startOfText = tex.find("\\begin{Fsynopsis}")
+		endOfText = tex.find("\\end{Fsynopsis}")
+		text = tex[startOfText + len("\\begin{Fsynopsis}\n"):endOfText]
+		text = "\n" + text.replace("\n", ";\n")
+		last = 0;
+		while(text.find(";") != -1):
+			s = text.find("\n", last) + len("\n")
+			e = text.find(";", s) + len(";")
+			line = text[s:e]
+			line = line.replace(";", "")
+			wordList = line.split()
+			if(wordList[0] in boldWordsF):
+				line = ".BR \"" + wordList[0] + " \" \"" + \
+						" ".join(wordList[1:]) + "\""
+			text = text[:s] + line + text[e:]
+			last = s
+		tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
+				".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
+				 "\n./ sectionEnd"  + "\n" + \
+				 tex[endOfText + len("\\end{Fsynopsis}"):]
+	return tex
+
+def codeReplace(tex):
+	tex = synCReplacements(tex, "C11synopsis")
+	tex = synCReplacements(tex, "Csynopsis")
+	tex = synCReplacements(tex, "CsynopsisCol")
+	tex = synFReplacements(tex)
+	return tex
+
+##########################################################################
+##							HELPER FUNCTIONS	 						##
+##########################################################################
+
+def cleanText(text):
+	""" Gets rid of consecutive spaces and tabs in the given text but maintains
+	any "\\n\\n" which is the indicator of a new paragraph. For every para-
+	graph, the code will replace all macros and rejoin the paragraphs as 
+	the final return string.
+	NOTE: Typically manpages ignores "\\n" within the text and displays
+	the text as if there is no "\\n". "\\n\\n" will parsed as the beginning
+	of a new paragraph. """
+	text = text.replace("\t", "")
+	while(text.find("  ") != -1):
+		text = text.replace("  ", " ")
+	text = text.replace("\n ", "\n")
+	paragraphList = text.split("\n\n")
+
+	cleanParagraphList = []
+	for paragraph in paragraphList:
+		paragraph = macroReplacements(paragraph)
+		while (paragraph.find("\n\n") != -1):
+			paragraph = paragraph.replace("\n\n", "\n")
+		cleanParagraphList.append(paragraph)
+	sectionText = "\n\n".join(cleanParagraphList)
+	return sectionText
+
+def macroReplacements(paragraph):
+	paragraph = variableReplacements(paragraph)
+	paragraph = generalReplacements(paragraph)
+	paragraph = constReplacements(paragraph)
+	paragraph = oprReplacements(paragraph)
+	paragraph = funcReplacements(paragraph)
+	paragraph = italReplacements(paragraph)
+	paragraph = paragraph.replace("\n ", "\n")
+	return paragraph
+
+def generateRoutineList(TOC):
+	""" Takes the Table of Contents and compiles a list of all function names
+	that needs to be parsed to manpages. The code assumes that every function
+	entry will be preceded by the macro, "\\subsubsection{\\textbf" """
+
+	count = 0;
+	routineList = []
+	while(TOC.find("\\subsubsection{\\textbf", count) > 0):
+		currIdx = TOC.find("\\subsubsection{\\textbf", count)
+		startBrace = TOC.find("\\textbf", currIdx) + len("\\textbf")
+		endBrace = TOC.find("}", startBrace)
+		func = TOC[startBrace+1:endBrace]
+		if (func.find(",") != -1):
+			func = func[:func.find(",")]
+		name = func.lower().replace("\\", "")
+		routineList.append(name)
+		count = currIdx + len("\\subsubsection{\\textbf")
+	return routineList
+
+def findMatchingBrace(tex, ind):
+	""" Takes in the tex string and the index of the open brace to which we 
+	need to find the matching brace. 
+	Function returns the index of the matching brace """
+	count = 0
+	if (tex[ind] == "{"):
+		count += 1
+		ptr = ind + 1
+	while(count != 0):
+		if(tex[ptr] == "{"):
+			count = count + 1
+		if(tex[ptr] == "}"):
+			count = count - 1
+		ptr += 1
+	return ptr - 1
+
+##########################################################################
+##							MAIN FUNCTIONS		 						##
+##########################################################################
+
+def convertFile(functionName, directory, gen_dir):
+	filename = directory + '/' + functionName + ".tex"
+	texFile = open(filename, "r")
+	if not os.path.exists(gen_dir):
+	    os.makedirs(gen_dir)
+	manFile = open(gen_dir + '/' + functionName + ".3", "w")
+	titleHeader = writePageHeader(functionName)
+	manFile.write(titleHeader)
+
+	tex = texFile.read()
+	tex = tex.replace("\\begin{DeprecateBlock}", "")
+	tex = tex.replace("\\end{DeprecateBlock}", "")
+	tex = tex.replace("\\begin{apidefinition}\n", 
+				"./ sectionStart\n.SH   SYNOPSIS\n./ sectionEnd")
+	tex = sumReplacements(tex, functionName)
+	tex = mBoxReplacements(tex)
+	tex = argReplacements(tex)
+	tex = descrReplacements(tex)
+	tex = notesReplacements(tex)
+	tex = retReplacements(tex)
+	tex = boldReplacements(tex)
+	tex = codeReplace(tex)
+	if (tex.find("\\apiimpnotes{") != -1):
+		tex = impnotesReplacements(tex)
+	while(tex.find("\\apidesctable{") != -1):
+		tex = descTReplacements(tex)
+	tex = tablerowReplacements(tex)
+	tex = refMEMReplacements(tex)
+	if (tex.find("\\begin{apiexamples}") != -1):
+		tex = exampleReplacements(tex, directory)
+	(tex, tables) = refTextReplacements(tex)
+	if (tables[0]):
+		tex = tex + addRefTable(1, directory)
+	if (tables[1]):
+		tex = tex + addRefTable(2, directory)
+	if (tables[2]):
+		tex = tex + addRefTable(3, directory)
+	if (tables[3]):
+		tex = tex + addRefTable(4, directory)
+	if (tables[4]):
+		tex = tex + addRefTable(5, directory)
+	tex = tex.replace("\\begin{apidefinition}", "")
+	tex = tex.replace("\\end{apidefinition}", "")
+	text = tex[:tex.find(".SS Examples")]
+	while(text.find("\n ") != -1):
+		text = text.replace("\n ", "\n")
+	text = text.replace("\\\\", "\n")
+	text = text.replace("$", "")
+	tex = text + tex[tex.find(".SS Examples"):]
+	tex = tex.replace("\n ", "\n")
+	manFile.write(tex.replace("\\n", "\\\\" + "n"))
+	print("Finished converting " + functionName + ".tex")
+	manFile.close()
+	texFile.close()
+
+def main():
+	parser = argparse.ArgumentParser(description='Generate OpenSHMEM manpages')
+	parser.add_argument('-d', '--directory', type=str, required=False,
+                        help='OpenSHMEM specification LaTeX directory path')
+	parser.add_argument('-o', '--output-directory', type=str, required=False, default="./man",
+                        help='Output directory for generated manpages')
+	parser.add_argument('-f', '--filename', type=str, required=False,
+                        help='LaTeX file path for an OpenSHMEM routine')
+	args = parser.parse_args()
+
+	if (args.directory == None) and (args.filename == None):
+		parser.print_usage()
+		exit(1)
+
+	if args.directory != None:
+		if not os.path.realpath(args.directory):
+			print("Error: input directory, " + args.directory + ", does not appear to exist")
+			exit(1)
+		else:
+			print("Dir found")
+            
+			if not os.path.isfile(args.directory + "/../main_spec.tex"):
+				print("Error: main_spec.tex is not found in the parent of the given directory.")
+				exit(1)
+
+			TOC = open(args.directory + "/../main_spec.tex").read()
+			routineList = generateRoutineList(TOC)
+			for routine in routineList:
+				if routine + ".tex" not in os.listdir(args.directory):
+					print("Error: " + routine + ".tex is not in the given directory")
+					exit(1)
+				else:
+					convertFile(routine, args.directory, args.output_directory)
+	else:
+		if not os.path.isfile(args.filename):
+			print("Error: input file, " + args.filename + ", does not appear to exist.")
+			exit(1)
+		else:
+			per = args.filename.find(".tex")
+			last = 0;
+			while (args.filename.find("/", last) >= 0):
+				last = args.filename.find("/", last) + 1
+
+			functionName = args.filename[last:per]
+			convertFile(functionName, args.filename[:last], args.output_directory)
+
+if __name__== "__main__":
+    main()

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -543,7 +543,7 @@ def tablerowReplacements(tex):
 
 
 ##########################################################################
-##                    REFERENCES AND REF TABLE REPLACEMENTS                 ##
+##                    REFERENCES AND REF TABLE REPLACEMENTS             ##
 ##########################################################################
 
 def refTextReplacements(tex):
@@ -631,7 +631,7 @@ def parseRefTables(tableTex):
     where <number> is the number of spaces between the start of firstCol
     and the start of secondCol. 
     Displays as:
-                    <firstCol>                     <secondCol>
+                    <firstCol>                   <secondCol>
                     <----------<number>---------->
     If the length of <firstCol> surpasses <number>, it will display as:
                     <----------<number>---------->
@@ -694,7 +694,7 @@ def addRefTable(tableID, directory):
     return text
 
 ##########################################################################
-##                            CODE REPLACEMENTS                             ##
+##                            CODE REPLACEMENTS                         ##
 ##########################################################################
 
 def synCReplacements(tex, keyString):
@@ -801,7 +801,7 @@ def codeReplace(tex):
     return tex
 
 ##########################################################################
-##                            HELPER FUNCTIONS                             ##
+##                            HELPER FUNCTIONS                          ##
 ##########################################################################
 
 def cleanText(text):
@@ -873,7 +873,7 @@ def findMatchingBrace(tex, ind):
     return ptr - 1
 
 ##########################################################################
-##                            MAIN FUNCTIONS                                 ##
+##                            MAIN FUNCTIONS                            ##
 ##########################################################################
 
 def convertFile(functionName, directory, gen_dir):

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -24,7 +24,7 @@ def writePageHeader(functionName):
     titleHeader = ".TH " + functionName.upper() + " 3 " \
                      + "\"Open Source Software Solutions, Inc.\" " \
                      + time.strftime("%m/%d/%Y") + " " \
-                     + "\"OpenSHEMEM Library Documentation\"" + "\n"
+                     + "\"OpenSHMEM Library Documentation\"" + "\n"
     return titleHeader
 
 ##########################################################################
@@ -1038,6 +1038,139 @@ def parseDeprecationTable(directory, gen_dir, build_fortran):
                 manFile.close()
 
 ##########################################################################
+##                        EXECUTABLE  FUNCTIONS                         ##
+##########################################################################
+    
+def writeOshcc(gen_dir):
+    manFile = open(gen_dir + '/' + "oshcc.1", "w")
+    manFile.write(".TH " + "OSHCC" + " 1 " \
+                     + "\"Open Source Software Solutions, Inc.\" " \
+                     + time.strftime("%m/%d/%Y") + " " \
+                     + "\"OpenSHMEM Library Documentation\"" + "\n")
+    manFile.write(".SH NAME\n")
+    manFile.write("oshcc - Compiles and links OpenSHMEM programs " + \
+        "written in C\n")
+    manFile.write(".SH DESCRIPTION\n")
+    manFile.write("This command can be used to compile and link Open" + \
+        "SHMEM programs written in C.\n")
+    manFile.write("It provides the options and any special libraries " + \
+        "that are needed to compile and link OpenSHMEM programs.\n\n" + \
+        "It is important to use this command, particularly when link" + \
+        "ing programs, as it provides the necessary libraries.\n\n")
+    manFile.write("usage: oshcc [oshcc_options] [compiler_arguments]\n")
+    manFile.write(".SH COMMAND LINE ARGUMENTS\n")
+    manFile.write(".TP 8\n")
+    manFile.write(".B --help\n")
+    manFile.write("- Display this information\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -showme | -show\n")
+    manFile.write("- Print the command that would be run without executing it\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -E | -M\n")
+    manFile.write("- Disable compilation and linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -S\n")
+    manFile.write("- Disable linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -c\n")
+    manFile.write("- Compile and assemble. Disable link\n")
+    manFile.close()
+
+def writeOshCC(gen_dir):
+    manFile = open(gen_dir + '/' + "oshc++.1", "w")
+    manFile.write(".TH " + "OSHC++" + " 1 " \
+                     + "\"Open Source Software Solutions, Inc.\" " \
+                     + time.strftime("%m/%d/%Y") + " " \
+                     + "\"OpenSHMEM Library Documentation\"" + "\n")
+    manFile.write(".SH NAME\n")
+    manFile.write("oshc++ - Compiles and links OpenSHMEM programs " + \
+        "written in C++\n")
+    manFile.write(".SH DESCRIPTION\n")
+    manFile.write("This command can be used to compile and link Open" + \
+        "SHMEM programs written in C++.\n")
+    manFile.write("It provides the options and any special libraries " + \
+        "that are needed to compile and link OpenSHMEM programs.\n\n" + \
+        "It is important to use this command, particularly when link" + \
+        "ing programs, as it provides the necessary libraries.\n\n")
+    manFile.write("usage: oshc++ [oshc++_options] [compiler_arguments]\n")
+    manFile.write(".SH COMMAND LINE ARGUMENTS\n")
+    manFile.write(".TP 8\n")
+    manFile.write(".B --help\n")
+    manFile.write("- Display this information\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -showme | -show\n")
+    manFile.write("- Print the command that would be run without executing it\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -E | -M\n")
+    manFile.write("- Disable compilation and linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -S\n")
+    manFile.write("- Disable linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -c\n")
+    manFile.write("- Compile and assemble. Disable link\n")
+    manFile.close()
+
+def writeOshfort(gen_dir):
+    manFile = open(gen_dir + '/' + "oshfort.1", "w")
+    manFile.write(".TH " + "OSHFORT" + " 1 " \
+                     + "\"Open Source Software Solutions, Inc.\" " \
+                     + time.strftime("%m/%d/%Y") + " " \
+                     + "\"OpenSHMEM Library Documentation\"" + "\n")
+    manFile.write(".SH NAME\n")
+    manFile.write("oshfort - Compiles and links OpenSHMEM programs " + \
+        "written in Fortran\n")
+    manFile.write(".SH DESCRIPTION\n")
+    manFile.write("This command can be used to compile and link Open" + \
+        "SHMEM programs written in Fortran.\n")
+    manFile.write("It provides the options and any special libraries " + \
+        "that are needed to compile and link OpenSHMEM programs.\n\n" + \
+        "It is important to use this command, particularly when link" + \
+        "ing programs, as it provides the necessary libraries.\n\n")
+    manFile.write("usage: oshfort [oshfort_options] [compiler_arguments]\n")
+    manFile.write(".SH COMMAND LINE ARGUMENTS\n")
+    manFile.write(".TP 8\n")
+    manFile.write(".B --help\n")
+    manFile.write("- Display this information\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -showme | -show\n")
+    manFile.write("- Print the command that would be run without executing it\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -E | -M\n")
+    manFile.write("- Disable compilation and linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -S\n")
+    manFile.write("- Disable linking\n")
+    manFile.write(".TP\n")
+    manFile.write(".B -c\n")
+    manFile.write("- Compile and assemble. Disable link\n")
+    manFile.close()
+
+def writeOshrun(gen_dir):
+    manFile = open(gen_dir + '/' + "oshrun.1", "w")
+    manFile.write(".TH " + "OSHRUN" + " 1 " \
+                     + "\"Open Source Software Solutions, Inc.\" " \
+                     + time.strftime("%m/%d/%Y") + " " \
+                     + "\"OpenSHMEM Library Documentation\"" + "\n")
+    manFile.write(".SH NAME\n")
+    manFile.write("oshrun - Run a OpenSHMEM program\n")
+    manFile.write(".SH DESCRIPTION\n")
+    manFile.write(".B oshrun\n")
+    manFile.write("launches the OpenSHMEM programs with a given number " + \
+        "of processes.\n\n")
+    manFile.write(".SH COMMAND LINE ARGUMENTS\n")
+    manFile.write(".TP 8\n")
+    manFile.write(".B --help | -h\n")
+    manFile.write("- Display this information\n")
+    manFile.close()
+
+def writeExecFunctions(gen_dir):
+    writeOshfort(gen_dir)
+    writeOshcc(gen_dir)
+    writeOshCC(gen_dir)
+    writeOshrun(gen_dir)
+
+##########################################################################
 ##                            MAIN FUNCTIONS                            ##
 ##########################################################################
 
@@ -1139,6 +1272,7 @@ def main():
                 else:
                     convertFile(routine, args.directory, args.output_directory, args.build_fortran)
             parseDeprecationTable(args.directory, args.output_directory, args.build_fortran)
+            writeExecFunctions(args.output_directory)
     else:
         if not os.path.isfile(args.filename):
             print("Error: input file, " + args.filename + ", does not appear to exist.")

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -8,974 +8,974 @@ import argparse
 # boldWordsC and boldWordsF are a set of the key words that will be
 # bolded in the man page
 boldWordsC = {"void", "int", "const", "size_t", "short", "ptrdiff_t", 
-			"long", "TYPE", "shmem_global_exit(int"}
+        "long", "TYPE", "shmem_global_exit(int"}
 boldWordsF = {"INTEGER", "CALL", "POINTER", "LOGICAL", "INTEGER*4",
-				"INTEGER*8", "REAL*4", "REAL*8", "CHARACTER"}
+        "INTEGER*8", "REAL*4", "REAL*8", "CHARACTER"}
 
 def writePageHeader(functionName):
-	"""Write the page header for the man page. Takes in the form of:
-	.TH [name of program] [section number] [center footer] [left footer] 
-		  [center header]"""
+    """Write the page header for the man page. Takes in the form of:
+    .TH [name of program] [section number] [center footer] [left footer] 
+        [center header]"""
 
-	titleHeader = ".TH " + functionName.upper() + " 3 " \
-					 + "" + "" \
-					 + "\"Open Source Software Solutions, Inc.\"" + "" \
-					 + "\"OpenSHEMEM Library Documentation\"" + "\n"
-	return titleHeader
+    titleHeader = ".TH " + functionName.upper() + " 3 " \
+            + "" + "" \
+            + "\"Open Source Software Solutions, Inc.\"" + "" \
+            + "\"OpenSHEMEM Library Documentation\"" + "\n"
+    return titleHeader
 
 ##########################################################################
-##							MACRO REPLACEMENTS 							##
+##                       MACRO REPLACEMENTS                             ##
 ##########################################################################
 
 def funcReplacements(tex):
-	"""Convert every FUNC macro with the bolded argument string 
-	(.B <argument>).
-	-- Special consideration to any periods after the macro, since a 
-	period at the beginning of a line denotes a comment and the 
-	entire line will not appear.
-	(.BR <argument> .)"""
+    """Convert every FUNC macro with the bolded argument string 
+    (.B <argument>).
+    -- Special consideration to any periods after the macro, since a 
+    period at the beginning of a line denotes a comment and the 
+    entire line will not appear.
+    (.BR <argument> .)"""
 
-	keyString = "\FUNC{"
-	while (tex.find(keyString) != -1):
-		index = tex.find(keyString)
-		startBrace = tex.find("{", index)
-		endBrace = tex.find("}", startBrace)
-		innerText = tex[startBrace+1:endBrace]
-		if(endBrace + 1 < len(tex) and tex[endBrace + 1] == "."):
-			tex = tex[:index] + "\n" + \
-					".BR \"" + innerText + \
-					"\" .\n" + tex[endBrace+2:]
-		else:                                                                
-			tex = tex[:index] + "\n" + \
-				".B " + innerText + \
-				"\n" + tex[endBrace+1:]
-	return tex
+    keyString = "\FUNC{"
+    while (tex.find(keyString) != -1):
+        index = tex.find(keyString)
+        startBrace = tex.find("{", index)
+        endBrace = tex.find("}", startBrace)
+        innerText = tex[startBrace+1:endBrace]
+        if(endBrace + 1 < len(tex) and tex[endBrace + 1] == "."):
+            tex = tex[:index] + "\n" + \
+                ".BR \"" + innerText + \
+                "\" .\n" + tex[endBrace+2:]
+        else:                                                                
+            tex = tex[:index] + "\n" + \
+                ".B " + innerText + \
+                "\n" + tex[endBrace+1:]
+    return tex
 
 def varReplacements(tex, keyString):
-	"""Convert every VAR/VARTH macro with the bolded argument string 
-	(.I <argument>).
-	-- Special consideration to any periods after the macro, since a 
-	period at the beginning of a line denotes a comment and the 
-	entire line will not appear.
-	(.IR <argument> .)
-	-- Special consideration to any argument of "VARTH", which will 
-	require appending "th" to the argument string."""
+    """Convert every VAR/VARTH macro with the bolded argument string 
+    (.I <argument>).
+    -- Special consideration to any periods after the macro, since a 
+    period at the beginning of a line denotes a comment and the 
+    entire line will not appear.
+    (.IR <argument> .)
+    -- Special consideration to any argument of "VARTH", which will 
+    require appending "th" to the argument string."""
 
-	while (tex.find(keyString) != -1):
-		index = tex.find(keyString)
-		startBrace = tex.find("{", index)
-		endBrace = tex.find("}", startBrace)
-		innerText = tex[startBrace+1:endBrace]
-		if keyString == "\VARTH{":
-			innerText += "th"
-		if (endBrace + 1 == len(tex)):
-			tex = tex[:index] + "\n.I " + innerText + "\n"
-		else:
-			if (tex[endBrace + 1] != "."):
-				tex = tex[:index] + "\n.I " + innerText \
-						    	+ "\n" + tex[endBrace+1:]
-			else:
-				tex = tex[:index] + "\n.IR \"" + innerText \
-						    	+ "\" .\n" + tex[endBrace+1:]
-	return tex
+    while (tex.find(keyString) != -1):
+        index = tex.find(keyString)
+        startBrace = tex.find("{", index)
+        endBrace = tex.find("}", startBrace)
+        innerText = tex[startBrace+1:endBrace]
+        if keyString == "\VARTH{":
+            innerText += "th"
+        if (endBrace + 1 == len(tex)):
+            tex = tex[:index] + "\n.I " + innerText + "\n"
+        else:
+            if (tex[endBrace + 1] != "."):
+                tex = tex[:index] + "\n.I " + innerText \
+                    + "\n" + tex[endBrace+1:]
+            else:
+                tex = tex[:index] + "\n.IR \"" + innerText \
+                    + "\" .\n" + tex[endBrace+1:]
+    return tex
 
 def variableReplacements(tex):
-	tex = varReplacements(tex, "\VAR{")
-	tex = varReplacements(tex, "\VARTH{")
-	return tex
+    tex = varReplacements(tex, "\VAR{")
+    tex = varReplacements(tex, "\VARTH{")
+    return tex
 
 def mBoxReplacements(tex):
-	"""Replace the Latex command "|mbox{<argument>}|" with just argument """
+    """Replace the Latex command "|mbox{<argument>}|" with just argument """
 
-	while (tex.find("|\mbox") != -1):
-		index = tex.find("|\mbox")
-		sbrace = tex.find("{", index)
-		ebrace = tex.find("}", sbrace)
-		ebar = tex.find("|", sbrace)
-		tex = tex[:index] + tex[sbrace+1:ebrace] \
-					    + tex[ebar+1:]
-	return tex
+    while (tex.find("|\mbox") != -1):
+        index = tex.find("|\mbox")
+        sbrace = tex.find("{", index)
+        ebrace = tex.find("}", sbrace)
+        ebar = tex.find("|", sbrace)
+        tex = tex[:index] + tex[sbrace+1:ebrace] \
+            + tex[ebar+1:]
+    return tex
 
 def boldReplacements(tex):
-	"""SPECIFIC TO shmem_reductions:
-	Replace the Latex command: 
-	"\\textbf{<NAME>} \\newline <text> <code> \\newline...\\bigskip" 
-	--NAME will the title of a new section header with <text> as the 
-	immediate content. 
-	-- <code> will be replaced as normal (See function codeReplace(tex))
-	-- \\bigskip will be replaced by the empty string. """
+    """SPECIFIC TO shmem_reductions:
+    Replace the Latex command: 
+    "\\textbf{<NAME>} \\newline <text> <code> \\newline...\\bigskip" 
+    --NAME will the title of a new section header with <text> as the 
+    immediate content. 
+    -- <code> will be replaced as normal (See function codeReplace(tex))
+    -- \\bigskip will be replaced by the empty string. """
 
-	while (tex.find("\\textbf{") != -1):
-		beg = tex.find("\\textbf{")
-		sbrace = tex.find("{", beg)
-		ebrace = tex.find("}", sbrace)
-		fnewline = tex.find("\\newline", ebrace)
-		snewline = tex.find("\\newline", fnewline + 1)
-		clean = tex[fnewline + len("\\newline"):snewline]
-		clean = macroReplacements(clean)
-		tex = tex[:beg] + "\n.SH " + tex[sbrace+1:ebrace] \
-				    	+ "\n" + clean \
-				    	+ tex[snewline + len("\\newline"):]
-	tex = tex.replace("\\bigskip", "")
-	return tex
+    while (tex.find("\\textbf{") != -1):
+        beg = tex.find("\\textbf{")
+        sbrace = tex.find("{", beg)
+        ebrace = tex.find("}", sbrace)
+        fnewline = tex.find("\\newline", ebrace)
+        snewline = tex.find("\\newline", fnewline + 1)
+        clean = tex[fnewline + len("\\newline"):snewline]
+        clean = macroReplacements(clean)
+        tex = tex[:beg] + "\n.SH " + tex[sbrace+1:ebrace] \
+            + "\n" + clean \
+            + tex[snewline + len("\\newline"):]
+    tex = tex.replace("\\bigskip", "")
+    return tex
 
 def italReplacements(tex):
-	""" Replace the Latex command "\\textit{<argument>}" with just 
-	argument """
+    """ Replace the Latex command "\\textit{<argument>}" with just 
+    argument """
 
-	while (tex.find("\\textit{") != -1):
-		beg = tex.find("\\textit{")
-		sbrace = tex.find("{", beg)
-		ebrace = tex.find("}", sbrace)
-		tex = tex[:beg] + tex[sbrace+1:ebrace] \
-				    	+ tex[ebrace+1:]
-	return tex
+    while (tex.find("\\textit{") != -1):
+        beg = tex.find("\\textit{")
+        sbrace = tex.find("{", beg)
+        ebrace = tex.find("}", sbrace)
+        tex = tex[:beg] + tex[sbrace+1:ebrace] \
+            + tex[ebrace+1:]
+    return tex
 
 def oprReplacements(tex):
-	"""Convert every OPR macro with the bolded argument string 
-	(.I <argument>).
-	-- Special consideration to any periods after the macro, since a 
-	period at the beginning of a line denotes a comment and the 
-	entire line will not appear.
-	(.IR <argument> .)
-	-- Special consideration to any argument of "VARTH", which will 
-	require appending "th" to the argument string. """
+    """Convert every OPR macro with the bolded argument string 
+    (.I <argument>).
+    -- Special consideration to any periods after the macro, since a 
+    period at the beginning of a line denotes a comment and the 
+    entire line will not appear.
+    (.IR <argument> .)
+    -- Special consideration to any argument of "VARTH", which will 
+    require appending "th" to the argument string. """
 
-	while (tex.find("\\OPR") != -1):
-		index = tex.find("\\OPR")
-		startBrace = tex.find("{", index)
-		endBrace = tex.find("}", index)
-		if (endBrace + 1 == len(tex) or tex[endBrace + 1] != "."):
-			tex = tex[:index] + "\n.I " + tex[startBrace+1:endBrace] \
-					    	+ "\n" + tex[endBrace+1:]
-		else:
-			tex = tex[:index] + "\n.IR \"" + tex[startBrace+1:endBrace] \
-					    	+ "\" .\n" + tex[endBrace+1:]
-	return tex
+    while (tex.find("\\OPR") != -1):
+        index = tex.find("\\OPR")
+        startBrace = tex.find("{", index)
+        endBrace = tex.find("}", index)
+        if (endBrace + 1 == len(tex) or tex[endBrace + 1] != "."):
+            tex = tex[:index] + "\n.I " + tex[startBrace+1:endBrace] \
+                + "\n" + tex[endBrace+1:]
+        else:
+            tex = tex[:index] + "\n.IR \"" + tex[startBrace+1:endBrace] \
+                + "\" .\n" + tex[endBrace+1:]
+    return tex
 
 def constReplacements(tex):
-	"""Replace the Latex command "\CONST{<argument>}" with just 
-	argument. """
+    """Replace the Latex command "\CONST{<argument>}" with just 
+    argument. """
 
-	while (tex.find("\\CONST") != -1):
-		index = tex.find("\\CONST")
-		startBrace = tex.find("{", index)
-		endBrace = tex.find("}", startBrace)
-		tex = tex[:index] + tex[startBrace+1:endBrace] + tex[endBrace+1:]
-	return tex
+    while (tex.find("\\CONST") != -1):
+        index = tex.find("\\CONST")
+        startBrace = tex.find("{", index)
+        endBrace = tex.find("}", startBrace)
+        tex = tex[:index] + tex[startBrace+1:endBrace] + tex[endBrace+1:]
+    return tex
 
 def generalReplacements(tex):
-	"""Replace the common Latex macros that take in no arguments and all 
-	Latex definitions that contain a backslash (which may have unde-
-	fined behavior in the actual manpage). Some text may need to be 
-	processed separately if it is followed by a period, which will 
-	cause all text in the same line following the period to be not 
-	shown."""
+    """Replace the common Latex macros that take in no arguments and all 
+    Latex definitions that contain a backslash (which may have unde-
+    fined behavior in the actual manpage). Some text may need to be 
+    processed separately if it is followed by a period, which will 
+    cause all text in the same line following the period to be not 
+    shown."""
 
-	tex = tex.replace("\openshmem{}", "OpenSHMEM")
-	tex = tex.replace("\openshmem", "OpenSHMEM")
-	tex = tex.replace("\\acp{PE}", "PEs")
-	tex = tex.replace("\\ac{PE}", "PE")
-	tex = tex.replace("\\ac{MPI}", "MPI")
-	tex = tex.replace("\\acp{AMO}", "AMOs")
-	tex = tex.replace("\\ac{AMO}", "AMO")
-	tex = tex.replace("\\ac{API}", "API")
-	tex = tex.replace("\\acp{RMA}", "RMAs")
-	tex = tex.replace("\\ac{RMA}", "RMA")
-	tex = tex.replace("\\CorCpp{}", " C/C++")
-	tex = tex.replace("\\CorCpp", " C/C++")
-	tex = tex.replace("\\Fortran{}", "Fortran")
-	tex = tex.replace("\\Fortran", "Fortran")
-	tex = tex.replace("\\Cstd", "C")
-	tex = tex.replace("\\PUT{}", "PUT")
-	tex = tex.replace("\\GET{}", "GET")
-	tex = tex.replace("\\SIZE{}", "SIZE")
-	tex = tex.replace("\\activeset.", "\n.IR \"Active set\" .\n")
-	tex = tex.replace("\\activeset{}", "\\activeset")
-	tex = tex.replace("\\activeset", "\n.I \"Active set\"\n")
-	tex = tex.replace("\\activeset ", "\n.I \"Active set\"\n")
-	tex = tex.replace("\\dest.", "\n.IR \"dest\" .\n")
-	tex = tex.replace("\\source.", "\n.IR \"source\" .\n")
-	tex = tex.replace("\\dest{}", "\n.I \"dest\"\n")
-	tex = tex.replace("\\source{}", "\n.I \"source\"\n")
-	tex = tex.replace("\\TYPE{}", "TYPE")
-	tex = tex.replace("\\TYPENAME{}", "TYPENAME")
-	return tex
+    tex = tex.replace("\openshmem{}", "OpenSHMEM")
+    tex = tex.replace("\openshmem", "OpenSHMEM")
+    tex = tex.replace("\\acp{PE}", "PEs")
+    tex = tex.replace("\\ac{PE}", "PE")
+    tex = tex.replace("\\ac{MPI}", "MPI")
+    tex = tex.replace("\\acp{AMO}", "AMOs")
+    tex = tex.replace("\\ac{AMO}", "AMO")
+    tex = tex.replace("\\ac{API}", "API")
+    tex = tex.replace("\\acp{RMA}", "RMAs")
+    tex = tex.replace("\\ac{RMA}", "RMA")
+    tex = tex.replace("\\CorCpp{}", " C/C++")
+    tex = tex.replace("\\CorCpp", " C/C++")
+    tex = tex.replace("\\Fortran{}", "Fortran")
+    tex = tex.replace("\\Fortran", "Fortran")
+    tex = tex.replace("\\Cstd", "C")
+    tex = tex.replace("\\PUT{}", "PUT")
+    tex = tex.replace("\\GET{}", "GET")
+    tex = tex.replace("\\SIZE{}", "SIZE")
+    tex = tex.replace("\\activeset.", "\n.IR \"Active set\" .\n")
+    tex = tex.replace("\\activeset{}", "\\activeset")
+    tex = tex.replace("\\activeset", "\n.I \"Active set\"\n")
+    tex = tex.replace("\\activeset ", "\n.I \"Active set\"\n")
+    tex = tex.replace("\\dest.", "\n.IR \"dest\" .\n")
+    tex = tex.replace("\\source.", "\n.IR \"source\" .\n")
+    tex = tex.replace("\\dest{}", "\n.I \"dest\"\n")
+    tex = tex.replace("\\source{}", "\n.I \"source\"\n")
+    tex = tex.replace("\\TYPE{}", "TYPE")
+    tex = tex.replace("\\TYPENAME{}", "TYPENAME")
+    return tex
 
 ##########################################################################
-##							SECTION REPLACEMENTS 						##
+##                            SECTION REPLACEMENTS                      ##
 ##########################################################################
 
 def descrReplacements(tex):
-	"""Search tex file for the keyString "\\apidecription{" and its matching
-	parenthesis. All text between will be processed such that there are no
-	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
-	have all the macros replaced and put back into its corresponding place
-	in the text file. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of the processed text, respectively, for differenti-
-	ation between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """Search tex file for the keyString "\\apidecription{" and its matching
+    parenthesis. All text between will be processed such that there are no
+    consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+    have all the macros replaced and put back into its corresponding place
+    in the text file. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of the processed text, respectively, for differenti-
+    ation between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	startOfText = tex.find("\\apidescription{")
-	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
-	sectionText = cleanText(tex[startOfText:endOfText])
-	tex = tex[:startOfText] + \
-			"./ sectionStart\n" + "\n.SS API Description\n" + \
-			sectionText + "\n./ sectionEnd\n" + tex[endOfText+1:]
-	tex = tex.replace("\\apidescription{", "")
-	return tex
+    startOfText = tex.find("\\apidescription{")
+    endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+    sectionText = cleanText(tex[startOfText:endOfText])
+    tex = tex[:startOfText] + \
+        "./ sectionStart\n" + "\n.SS API Description\n" + \
+        sectionText + "\n./ sectionEnd\n" + tex[endOfText+1:]
+    tex = tex.replace("\\apidescription{", "")
+    return tex
 
 def retReplacements(tex):
-	"""Search tex file for the keyString "\\apireturnavalues{" and its matching
-	parenthesis. All text between will be processed such that there are no
-	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
-	have all the macros replaced and put back into its corresponding place
-	in the text file. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of the processed text, respectively, for differenti-
-	ation between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """Search tex file for the keyString "\\apireturnavalues{" and its matching
+    parenthesis. All text between will be processed such that there are no
+    consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+    have all the macros replaced and put back into its corresponding place
+    in the text file. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of the processed text, respectively, for differenti-
+    ation between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	startOfText = tex.find("\\apireturnvalues{")
-	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
-	sectionText = cleanText(tex[startOfText:endOfText])
-	tex = tex[:startOfText] + \
-			"./ sectionStart\n" + "\n.SS Return Values\n" + \
-			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
-	tex = tex.replace("\\apireturnvalues{", "")
-	return tex
+    startOfText = tex.find("\\apireturnvalues{")
+    endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+    sectionText = cleanText(tex[startOfText:endOfText])
+    tex = tex[:startOfText] + \
+        "./ sectionStart\n" + "\n.SS Return Values\n" + \
+        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+    tex = tex.replace("\\apireturnvalues{", "")
+    return tex
 
 def notesReplacements(tex):
-	"""Search tex file for the keyString "\\apinotes{" and its matching
-	parenthesis. All text between will be processed such that there are no
-	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
-	have all the macros replaced and put back into its corresponding place
-	in the text file. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of the processed text, respectively, for differenti-
-	ation between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """Search tex file for the keyString "\\apinotes{" and its matching
+    parenthesis. All text between will be processed such that there are no
+    consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+    have all the macros replaced and put back into its corresponding place
+    in the text file. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of the processed text, respectively, for differenti-
+    ation between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	startOfText = tex.find("\\apinotes{")
-	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
-	sectionText = cleanText(tex[startOfText:endOfText])
-	tex = tex[:startOfText] + \
-			"./ sectionStart\n" + "\n.SS API Notes\n" + \
-			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
-	tex = tex.replace("\\apinotes{", "")
-	return tex
+    startOfText = tex.find("\\apinotes{")
+    endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+    sectionText = cleanText(tex[startOfText:endOfText])
+    tex = tex[:startOfText] + \
+        "./ sectionStart\n" + "\n.SS API Notes\n" + \
+        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+    tex = tex.replace("\\apinotes{", "")
+    return tex
 
 def impnotesReplacements(tex):
-	"""Search tex file for the keyString "\\apiimpnotes{" and its matching
-	parenthesis. All text between will be processed such that there are no
-	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
-	have all the macros replaced and put back into its corresponding place
-	in the text file. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of the processed text, respectively, for differenti-
-	ation between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """Search tex file for the keyString "\\apiimpnotes{" and its matching
+    parenthesis. All text between will be processed such that there are no
+    consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+    have all the macros replaced and put back into its corresponding place
+    in the text file. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of the processed text, respectively, for differenti-
+    ation between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	startOfText = tex.find("\\apiimpnotes{")
-	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
-	sectionText = cleanText(tex[startOfText:endOfText])
-	tex = tex[:startOfText] + \
-			"./ sectionStart\n" + "\n.SS API Notes\n" + \
-			sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
-	tex = tex.replace("\\apiimpnotes{", "")
-	return tex
+    startOfText = tex.find("\\apiimpnotes{")
+    endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+    sectionText = cleanText(tex[startOfText:endOfText])
+    tex = tex[:startOfText] + \
+        "./ sectionStart\n" + "\n.SS API Notes\n" + \
+        sectionText + "\n./ sectionEnd\n" + tex[endOfText + 1:]
+    tex = tex.replace("\\apiimpnotes{", "")
+    return tex
 
 def sumReplacements(tex, functionName):
-	"""Search tex file for the keyString "\\apisummary{" and its matching
-	parenthesis. All text between will be processed such that there are no
-	consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
-	have all the macros replaced and put back into its corresponding place
-	in the text file. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of the processed text, respectively, for differenti-
-	ation between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """Search tex file for the keyString "\\apisummary{" and its matching
+    parenthesis. All text between will be processed such that there are no
+    consecutive spaces, no tabs, and unnecessary "\\n". The text will then 
+    have all the macros replaced and put back into its corresponding place
+    in the text file. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of the processed text, respectively, for differenti-
+    ation between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """    
 
-	startOfText = tex.find("\\apisummary{")
-	endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
-	sectionText = cleanText(tex[startOfText:endOfText])
-	tex = tex[:startOfText] + \
-			"./ sectionStart\n" + \
-			".SH NAME\n" + functionName + " \- " \
-			+ sectionText + "\n" + \
-			"./ sectionEnd\n" + tex[endOfText+1:]
-	tex = tex.replace("\\apisummary{", "")
-	return tex
+    startOfText = tex.find("\\apisummary{")
+    endOfText = findMatchingBrace(tex, tex.find("{", startOfText))
+    sectionText = cleanText(tex[startOfText:endOfText])
+    tex = tex[:startOfText] + \
+        "./ sectionStart\n" + \
+        ".SH NAME\n" + functionName + " \- " \
+        + sectionText + "\n" + \
+        "./ sectionEnd\n" + tex[endOfText+1:]
+    tex = tex.replace("\\apisummary{", "")
+    return tex
 
 def exampleCodeReplace(sectionText, in_directory, keyString):
-	"""Searches throught the given text and replaces the files of code with
-	the actual code in the file. 
-	
-	All examples in the Latex file follows the following pattern:
-		\keyString{<pre-text>}{<directory to code>}{<post-text>}
-	-- The <pre-text> and <post-text> should have already been processed 
-	prior to this function call and will be concatenated to the return
-	string.
-	-- The pattern ".nf\\n ... .fi\\n" will have the text in between ".nf"
-	and "fi" be presented without formatting. """
+    """Searches throught the given text and replaces the files of code with
+    the actual code in the file. 
+    
+    All examples in the Latex file follows the following pattern:
+        \keyString{<pre-text>}{<directory to code>}{<post-text>}
+    -- The <pre-text> and <post-text> should have already been processed 
+    prior to this function call and will be concatenated to the return
+    string.
+    -- The pattern ".nf\\n ... .fi\\n" will have the text in between ".nf"
+    and "fi" be presented without formatting. """
 
-	while(sectionText.find(keyString) != -1):
-		startOfText = sectionText.find(keyString)
-		firstStartBrace = sectionText.find("{", startOfText)
-		firstEndBrace = sectionText.find("}", firstStartBrace)
-		secStartBrace = sectionText.find("{", firstEndBrace)
-		secEndBrace = sectionText.find("}", secStartBrace)
-		thirdStartBrace = sectionText.find("{", secEndBrace)
-		thirdEndBrace = sectionText.find("}", thirdStartBrace)
-		path = sectionText[secStartBrace+1:secEndBrace].strip()
-		code = open(in_directory + "/../" + path, "r").read()
-		sectionText = sectionText[:startOfText] + "\n" + \
-					sectionText[firstStartBrace+1:firstEndBrace] + "\n\n" + \
-					".nf\n" + \
-					code + \
-					".fi\n" + \
-					sectionText[thirdStartBrace+1:thirdEndBrace] + \
-					sectionText[thirdEndBrace + 1:]
-	return sectionText
+    while(sectionText.find(keyString) != -1):
+        startOfText = sectionText.find(keyString)
+        firstStartBrace = sectionText.find("{", startOfText)
+        firstEndBrace = sectionText.find("}", firstStartBrace)
+        secStartBrace = sectionText.find("{", firstEndBrace)
+        secEndBrace = sectionText.find("}", secStartBrace)
+        thirdStartBrace = sectionText.find("{", secEndBrace)
+        thirdEndBrace = sectionText.find("}", thirdStartBrace)
+        path = sectionText[secStartBrace+1:secEndBrace].strip()
+        code = open(in_directory + "/../" + path, "r").read()
+        sectionText = sectionText[:startOfText] + "\n" + \
+                    sectionText[firstStartBrace+1:firstEndBrace] + "\n\n" + \
+                    ".nf\n" + \
+                    code + \
+                    ".fi\n" + \
+                    sectionText[thirdStartBrace+1:thirdEndBrace] + \
+                    sectionText[thirdEndBrace + 1:]
+    return sectionText
 
 def exampleReplacements(tex, in_directory):
-	"""Search tex file for the keyString "\\begin{apiexamples}" and its matching
-	"\\end{apiexamples}". All text between will be processed such that there 
-	are no consecutive spaces, no tabs, and unnecessary "\\n". The text will 
-	then have all the macros replaced and put back into its corresponding 
-	placein the text file. 
-	The string "./ sectionStart" is appended at the beginning of the pro-
-	cessed text, for differentiation between the text with sections and 
-	"dangling text". These strings will not appear in the manpage as any 
-	line that begins with a period will be treated as a comment. 
-	NOTE: There is no corresponding "./ sectionEnd" in this section because
-	the example section of the manpage is always the last section. 
-	Dangling text is identified as the text between a "./ sectionEnd" and
-	./sectionStart. Since there will be no text following this section, the
-	"./ sectionEnd" flag is no necessary. """
+    """Search tex file for the keyString "\\begin{apiexamples}" and its matching
+    "\\end{apiexamples}". All text between will be processed such that there 
+    are no consecutive spaces, no tabs, and unnecessary "\\n". The text will 
+    then have all the macros replaced and put back into its corresponding 
+    placein the text file. 
+    The string "./ sectionStart" is appended at the beginning of the pro-
+    cessed text, for differentiation between the text with sections and 
+    "dangling text". These strings will not appear in the manpage as any 
+    line that begins with a period will be treated as a comment. 
+    NOTE: There is no corresponding "./ sectionEnd" in this section because
+    the example section of the manpage is always the last section. 
+    Dangling text is identified as the text between a "./ sectionEnd" and
+    ./sectionStart. Since there will be no text following this section, the
+    "./ sectionEnd" flag is no necessary. """
 
-	startOfText = tex.find("\\begin{apiexamples}")
-	endOfText = tex.find("\\end{apiexamples}")
-	text = tex[startOfText + len("\\begin{apiexamples}"):endOfText]
-	sectionText = cleanText(text)
+    startOfText = tex.find("\\begin{apiexamples}")
+    endOfText = tex.find("\\end{apiexamples}")
+    text = tex[startOfText + len("\\begin{apiexamples}"):endOfText]
+    sectionText = cleanText(text)
 
-	sectionText = exampleCodeReplace(sectionText, in_directory, 
-					"\\apicexample")
-	sectionText = exampleCodeReplace(sectionText, in_directory,
-					"\\apifexample")
+    sectionText = exampleCodeReplace(sectionText, in_directory, 
+                "\\apicexample")
+    sectionText = exampleCodeReplace(sectionText, in_directory,
+                "\\apifexample")
 
-	tex = tex[:startOfText] + "\n" \
-			"./ sectionStart" + "\n.SS Examples\n" + \
-			sectionText + \
-			tex[endOfText + len("\\end{apiexamples}"):]
-	return tex
+    tex = tex[:startOfText] + "\n" \
+        "./ sectionStart" + "\n.SS Examples\n" + \
+        sectionText + \
+        tex[endOfText + len("\\end{apiexamples}"):]
+    return tex
 
 def argReplacements(tex):
-	"""All elements within the section defined between "\\begin{apiarguments}"
-	and "\end{apiarguments}" will follow the following pattern:
-			\\apiargument{<STATUS>}{<name>}{<description>}
-	The following code will convert the above text such that STATUS will be
-	bolded, <name> will be underlined/italicized, and <description> will be
-	regular. 
-	In the special case that there are no arguments, the macro will be of 
-	the form:
-			\\apiargument{"None."}{}{}
-	in which case, the code will conver the macro above to have "None." as
-	bolded. """
+    """All elements within the section defined between "\\begin{apiarguments}"
+    and "\end{apiarguments}" will follow the following pattern:
+            \\apiargument{<STATUS>}{<name>}{<description>}
+    The following code will convert the above text such that STATUS will be
+    bolded, <name> will be underlined/italicized, and <description> will be
+    regular. 
+    In the special case that there are no arguments, the macro will be of 
+    the form:
+            \\apiargument{"None."}{}{}
+    in which case, the code will conver the macro above to have "None." as
+    bolded. """
 
-	startOfText = tex.find("\\apiargument")
-	endOfText = tex.find("\\end{apiarguments}")
-	sectionText = tex[startOfText + len("\\apiargument"):endOfText].strip()
-	argList = sectionText.split("\\apiargument")
-	cleanArgList = []
-	for arg in argList:
-		firstStartBrace = arg.find("{")
-		firstEndBrace = findMatchingBrace(arg, firstStartBrace)
-		secStartBrace = arg.find("{", firstEndBrace)
-		secEndBrace = findMatchingBrace(arg, secStartBrace)
-		thirdStartBrace = arg.find("{", secEndBrace)
-		thirdEndBrace = findMatchingBrace(arg, thirdStartBrace)
+    startOfText = tex.find("\\apiargument")
+    endOfText = tex.find("\\end{apiarguments}")
+    sectionText = tex[startOfText + len("\\apiargument"):endOfText].strip()
+    argList = sectionText.split("\\apiargument")
+    cleanArgList = []
+    for arg in argList:
+        firstStartBrace = arg.find("{")
+        firstEndBrace = findMatchingBrace(arg, firstStartBrace)
+        secStartBrace = arg.find("{", firstEndBrace)
+        secEndBrace = findMatchingBrace(arg, secStartBrace)
+        thirdStartBrace = arg.find("{", secEndBrace)
+        thirdEndBrace = findMatchingBrace(arg, thirdStartBrace)
 
-		status = cleanText(arg[firstStartBrace+1:firstEndBrace])
-		name = cleanText(arg[secStartBrace+1:secEndBrace])
-		text = cleanText(arg[thirdStartBrace+1:thirdEndBrace])
-		if (arg[firstStartBrace+1:firstEndBrace] == "None."):
-			cleanArgList.append(".B None.")
-		else:
-			cleanArgList.append(".BR \"" + status + \
-						" \" -" + "\n.I " + name + \
-						"\n- " + text + \
-						arg[thirdEndBrace+1:])
-	sectionText = "\n\n".join(cleanArgList)
-	tex = tex[:startOfText] + "\n" + \
-			"./ sectionStart\n" + "\n" + \
-			".SH DESCRIPTION\n.SS Arguments\n" + \
-			sectionText + "\n./ sectionEnd\n" + tex[endOfText:]
-	tex = tex.replace("\\begin{apiarguments}", "")
-	tex = tex.replace("\\end{apiarguments}", "")
-	return tex
+        status = cleanText(arg[firstStartBrace+1:firstEndBrace])
+        name = cleanText(arg[secStartBrace+1:secEndBrace])
+        text = cleanText(arg[thirdStartBrace+1:thirdEndBrace])
+        if (arg[firstStartBrace+1:firstEndBrace] == "None."):
+            cleanArgList.append(".B None.")
+        else:
+            cleanArgList.append(".BR \"" + status + \
+                    " \" -" + "\n.I " + name + \
+                    "\n- " + text + \
+                    arg[thirdEndBrace+1:])
+    sectionText = "\n\n".join(cleanArgList)
+    tex = tex[:startOfText] + "\n" + \
+        "./ sectionStart\n" + "\n" + \
+        ".SH DESCRIPTION\n.SS Arguments\n" + \
+        sectionText + "\n./ sectionEnd\n" + tex[endOfText:]
+    tex = tex.replace("\\begin{apiarguments}", "")
+    tex = tex.replace("\\end{apiarguments}", "")
+    return tex
 
 ##########################################################################
-##							TABLE REPLACEMENTS	 						##
+##                        TABLE REPLACEMENTS                            ##
 ##########################################################################
 
 def descTReplacements(tex):
-	"""All elements within the tex file defined to begin with "\\apidesctable{"
-	will follow the following pattern:
-			\\apidesctable{{<desc>}{<firstColHead>}{<secondColHead>}
-	The following code will convert the above text to display such that 
-	<desc> will display as regular text, <firstColHead> and <secondColHead>
-	will follow the tabular header.
-	
-	The tabular header is:
-					.TP <number>
-					<firstCol>
-					<secondCol>
-	where <number> is the number of spaces between the start of firstCol
-	and the start of secondCol. 
-	Displays as:
-					<firstCol>					 <secondCol>
-					<----------<number>---------->
-	If the length of <firstCol> surpasses <number>, it will display as:
-					<----------<number>---------->
-					<firstCol>					 
-												 <secondCol>
-	
-	Every row of the table must include the ".TP" or the text will be
-	processed with default formatting. 
-	If there there is no <number>, the script will default to 1, or the
-	lastest definition of <number> in the current table
-	NOTE: Typically manpages ignores "\\n" within the text and displays
-	the text as if there is no "\\n". Under the ".TP" header, the flag
-	for when the second column begins is the next "\\n" 
-	
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of every row processed, respectively, for differenti-
-	ating between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """All elements within the tex file defined to begin with "\\apidesctable{"
+    will follow the following pattern:
+            \\apidesctable{{<desc>}{<firstColHead>}{<secondColHead>}
+    The following code will convert the above text to display such that 
+    <desc> will display as regular text, <firstColHead> and <secondColHead>
+    will follow the tabular header.
+    
+    The tabular header is:
+                    .TP <number>
+                    <firstCol>
+                    <secondCol>
+    where <number> is the number of spaces between the start of firstCol
+    and the start of secondCol. 
+    Displays as:
+                    <firstCol>                   <secondCol>
+                    <----------<number>---------->
+    If the length of <firstCol> surpasses <number>, it will display as:
+                    <----------<number>---------->
+                    <firstCol>                     
+                                                 <secondCol>
+    
+    Every row of the table must include the ".TP" or the text will be
+    processed with default formatting. 
+    If there there is no <number>, the script will default to 1, or the
+    lastest definition of <number> in the current table
+    NOTE: Typically manpages ignores "\\n" within the text and displays
+    the text as if there is no "\\n". Under the ".TP" header, the flag
+    for when the second column begins is the next "\\n" 
+    
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of every row processed, respectively, for differenti-
+    ating between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	index = tex.find("\\apidesctable{")
-	firstStartBrace = tex.find("{", index)
-	firstEndBrace = findMatchingBrace(tex, firstStartBrace)
-	secStartBrace = tex.find("{", firstEndBrace)
-	secEndBrace = findMatchingBrace(tex, secStartBrace)
-	thirdStartBrace = tex.find("{", secEndBrace)
-	thirdEndBrace = findMatchingBrace(tex, thirdStartBrace)
+    index = tex.find("\\apidesctable{")
+    firstStartBrace = tex.find("{", index)
+    firstEndBrace = findMatchingBrace(tex, firstStartBrace)
+    secStartBrace = tex.find("{", firstEndBrace)
+    secEndBrace = findMatchingBrace(tex, secStartBrace)
+    thirdStartBrace = tex.find("{", secEndBrace)
+    thirdEndBrace = findMatchingBrace(tex, thirdStartBrace)
 
-	desc = cleanText(tex[firstStartBrace + 1: firstEndBrace])
-	firstColHead = cleanText(tex[secStartBrace + 1: secEndBrace])
-	secondColHead = cleanText(tex[thirdStartBrace + 1: thirdEndBrace])
+    desc = cleanText(tex[firstStartBrace + 1: firstEndBrace])
+    firstColHead = cleanText(tex[secStartBrace + 1: secEndBrace])
+    secondColHead = cleanText(tex[thirdStartBrace + 1: thirdEndBrace])
 
-	tex = tex[:index] + "\n./ sectionStart\n" + desc + \
-			"\n.TP 25\n" + firstColHead + "\n" + \
-			secondColHead + "\n./ sectionEnd\n" + tex[thirdEndBrace+1:]
-	return tex
+    tex = tex[:index] + "\n./ sectionStart\n" + desc + \
+            "\n.TP 25\n" + firstColHead + "\n" + \
+            secondColHead + "\n./ sectionEnd\n" + tex[thirdEndBrace+1:]
+    return tex
 
 def tablerowReplacements(tex):
-	"""All elements within the tex file defined to begin with "\\apitablerow"
-	will follow the following pattern:
-			\\apitablerow{<firstCol>}{<secondCol>}
-	The following code will convert the above text to display in tabular 
-	form. 
-	
-	The tabular header is:
-					.TP <number>
-					<firstCol>
-					<secondCol>
-	where <number> is the number of spaces between the start of firstCol
-	and the start of secondCol. 
-	Displays as:
-					<firstCol>					 <secondCol>
-					<----------<number>---------->
-	If the length of <firstCol> surpasses <number>, it will display as:
-					<----------<number>---------->
-					<firstCol>					 
-												 <secondCol>
-	
-	Every row of the table must include the ".TP" or the text will be
-	processed with default formatting. 
-	If there there is no <number>, the script will default to 1, or the
-	lastest definition of <number> in the current table
-	NOTE: Typically manpages ignores "\\n" within the text and displays
-	the text as if there is no "\\n". Under the ".TP" header, the flag
-	for when the second column begins is the next "\\n" 
-	
-	In the special case that there is no text in the first column (a 
-	method to get the proper indentation in the Latex), continue the 
-	text in <secondCol> from the previous row's <secondCol> text will
-	have the same behavior from Latex. 
-	The strings "./ sectionStart" and "./ sectionEnd" are appending at the
-	beginning and end of every row processed, respectively, for differenti-
-	ating between the text with sections and "dangling text".
-	These strings will not appear in the manpage as any line that begins 
-	with a period will be treated as a comment. """
+    """All elements within the tex file defined to begin with "\\apitablerow"
+    will follow the following pattern:
+            \\apitablerow{<firstCol>}{<secondCol>}
+    The following code will convert the above text to display in tabular 
+    form. 
+    
+    The tabular header is:
+                    .TP <number>
+                    <firstCol>
+                    <secondCol>
+    where <number> is the number of spaces between the start of firstCol
+    and the start of secondCol. 
+    Displays as:
+                    <firstCol>                   <secondCol>
+                    <----------<number>---------->
+    If the length of <firstCol> surpasses <number>, it will display as:
+                    <----------<number>---------->
+                    <firstCol>                     
+                                                 <secondCol>
+    
+    Every row of the table must include the ".TP" or the text will be
+    processed with default formatting. 
+    If there there is no <number>, the script will default to 1, or the
+    lastest definition of <number> in the current table
+    NOTE: Typically manpages ignores "\\n" within the text and displays
+    the text as if there is no "\\n". Under the ".TP" header, the flag
+    for when the second column begins is the next "\\n" 
+    
+    In the special case that there is no text in the first column (a 
+    method to get the proper indentation in the Latex), continue the 
+    text in <secondCol> from the previous row's <secondCol> text will
+    have the same behavior from Latex. 
+    The strings "./ sectionStart" and "./ sectionEnd" are appending at the
+    beginning and end of every row processed, respectively, for differenti-
+    ating between the text with sections and "dangling text".
+    These strings will not appear in the manpage as any line that begins 
+    with a period will be treated as a comment. """
 
-	while(tex.find("\\apitablerow") != -1):
-		startOfText = tex.find("\\apitablerow")
-		firstStartBrace = tex.find("{", startOfText)
-		firstEndBrace = findMatchingBrace(tex, firstStartBrace)
-		secStartBrace = tex.find("{", firstEndBrace)
-		secEndBrace = findMatchingBrace(tex, secStartBrace)
+    while(tex.find("\\apitablerow") != -1):
+        startOfText = tex.find("\\apitablerow")
+        firstStartBrace = tex.find("{", startOfText)
+        firstEndBrace = findMatchingBrace(tex, firstStartBrace)
+        secStartBrace = tex.find("{", firstEndBrace)
+        secEndBrace = findMatchingBrace(tex, secStartBrace)
 
-		firstCol = tex[firstStartBrace + 1:firstEndBrace]
-		firstCol = firstCol.replace("\n", " ")
-		firstCol = macroReplacements(firstCol)
+        firstCol = tex[firstStartBrace + 1:firstEndBrace]
+        firstCol = firstCol.replace("\n", " ")
+        firstCol = macroReplacements(firstCol)
 
-		secondCol = tex[secStartBrace + 1: secEndBrace]
-		secondCol = secondCol.replace("\n", " ")
-		secondCol = cleanText(secondCol)
+        secondCol = tex[secStartBrace + 1: secEndBrace]
+        secondCol = secondCol.replace("\n", " ")
+        secondCol = cleanText(secondCol)
 
-		if (firstCol != ""):
-			tex = tex[:startOfText] + "\n" + \
-				"./ sectionStart\n.TP 25\n" + firstCol + "\n" + \
-				secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
-		else:
-			tex = tex[:startOfText] + "\n" + "\n./ sectionStart" + \
-				"\n" + secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
-	return tex
+        if (firstCol != ""):
+            tex = tex[:startOfText] + "\n" + \
+                "./ sectionStart\n.TP 25\n" + firstCol + "\n" + \
+                secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
+        else:
+            tex = tex[:startOfText] + "\n" + "\n./ sectionStart" + \
+                "\n" + secondCol + "\n./ sectionEnd\n" + tex[secEndBrace+1:]
+    return tex
 
 
 ##########################################################################
-##					REFERENCES AND REF TABLE REPLACEMENTS	 			##
+##                    REFERENCES AND REF TABLE REPLACEMENTS                 ##
 ##########################################################################
 
 def refTextReplacements(tex):
-	"""Searches through the tex file and processes "dangling text", or text that
-	does not belong to a designated section. It finds these strings by search-
-	ing for text in between any two consecutive "./ sectionStart" and 
-	"./ sectionEnd" These text will sometimes have references to tables, iden-
-	tifiable by the argument in the "\\ref{<argument>}" macro. Each table will
-	have a unique integer that it can be identified with, consistent with the
-	Latex file.
-	The function will return the processed string with an indication array of 
-	which tables are to be appended to the end of the man page. """
+    """Searches through the tex file and processes "dangling text", or text that
+    does not belong to a designated section. It finds these strings by search-
+    ing for text in between any two consecutive "./ sectionStart" and 
+    "./ sectionEnd" These text will sometimes have references to tables, iden-
+    tifiable by the argument in the "\\ref{<argument>}" macro. Each table will
+    have a unique integer that it can be identified with, consistent with the
+    Latex file.
+    The function will return the processed string with an indication array of 
+    which tables are to be appended to the end of the man page. """
 
-	tables = [0, 0, 0, 0, 0]
-	last = 0
-	while(tex.find("./ sectionEnd", last) > 0):
-		firstEnd = tex.find("./ sectionEnd", last)
-		secStart = tex.find("./ sectionStart", firstEnd)
-		last = secStart
-		if(tex[firstEnd + len("./ sectionEnd"):secStart].strip() != ""):
-			sectionText = tex[firstEnd + len("./ sectionEnd"):secStart].strip()
-			sectionText = cleanText(sectionText)
+    tables = [0, 0, 0, 0, 0]
+    last = 0
+    while(tex.find("./ sectionEnd", last) > 0):
+        firstEnd = tex.find("./ sectionEnd", last)
+        secStart = tex.find("./ sectionStart", firstEnd)
+        last = secStart
+        if(tex[firstEnd + len("./ sectionEnd"):secStart].strip() != ""):
+            sectionText = tex[firstEnd + len("./ sectionEnd"):secStart].strip()
+            sectionText = cleanText(sectionText)
 
-			if (tex.find("\\ref{stdrmatypes}") != -1):
-				sectionText = sectionText.replace("\\ref{stdrmatypes}", "1")
-				tables[0] = 1
-			if (tex.find("\\ref{stdamotypes}") != -1):
-				sectionText = sectionText.replace("\\ref{stdamotypes}", "2")
-				tables[1] = 1
-			if (tex.find("\\ref{extamotypes}") != -1):
-				sectionText = sectionText.replace("\\ref{extamotypes}", "3")
-				tables[2] = 1
-			if (tex.find("\\ref{bitamotypes}") != -1):
-				sectionText = sectionText.replace("\\ref{bitamotypes}", "4")
-				tables[3] = 1
-			if (tex.find("\\ref{p2psynctypes}") != -1):
-				sectionText = sectionText.replace("\\ref{p2psynctypes}", "5")
-				tables[4] = 1
+            if (tex.find("\\ref{stdrmatypes}") != -1):
+                sectionText = sectionText.replace("\\ref{stdrmatypes}", "1")
+                tables[0] = 1
+            if (tex.find("\\ref{stdamotypes}") != -1):
+                sectionText = sectionText.replace("\\ref{stdamotypes}", "2")
+                tables[1] = 1
+            if (tex.find("\\ref{extamotypes}") != -1):
+                sectionText = sectionText.replace("\\ref{extamotypes}", "3")
+                tables[2] = 1
+            if (tex.find("\\ref{bitamotypes}") != -1):
+                sectionText = sectionText.replace("\\ref{bitamotypes}", "4")
+                tables[3] = 1
+            if (tex.find("\\ref{p2psynctypes}") != -1):
+                sectionText = sectionText.replace("\\ref{p2psynctypes}", "5")
+                tables[4] = 1
 
-			sectionText = sectionText.replace("~", " ")
-			tex = tex[:firstEnd + len("./ sectionEnd\n")] + "\n\n" + \
-					sectionText + "\n" + tex[secStart:]
-	return (tex, tables)
+            sectionText = sectionText.replace("~", " ")
+            tex = tex[:firstEnd + len("./ sectionEnd\n")] + "\n\n" + \
+                    sectionText + "\n" + tex[secStart:]
+    return (tex, tables)
 
 def refMEMReplacements(tex):
-	""" Searches through the tex for any reference that specifically points to 
-	the memory modelled and replaces that sentence with a hard-coded string.
-	Processing the section that was in the original text is not an option
-	because the reference the Latex file does not apply to the man pages. """
+    """ Searches through the tex for any reference that specifically points to 
+    the memory modelled and replaces that sentence with a hard-coded string.
+    Processing the section that was in the original text is not an option
+    because the reference the Latex file does not apply to the man pages. """
 
-	if (tex.find("\\ref{subsec:memory_model}") != -1):
-		while(tex.find("\\ref{subsec:memory_model}") != -1):
-			index = tex.find("\\ref{subsec:memory_model}")
-			enter = 0
-			last = 0
-			while (enter < index):
-				last = enter
-				enter = tex.find("\n", enter + 1)
-			period = tex.find(".", index)
-			sentence = tex[last + 1: period + 1]
-			tex = tex[:last + 1] + \
-				"Please refer to the subsection on the Memory Model for the" + \
-				" definition of the term \"remotely accessible\"." + \
-				tex[period + 1:]
-	return tex
+    if (tex.find("\\ref{subsec:memory_model}") != -1):
+        while(tex.find("\\ref{subsec:memory_model}") != -1):
+            index = tex.find("\\ref{subsec:memory_model}")
+            enter = 0
+            last = 0
+            while (enter < index):
+                last = enter
+                enter = tex.find("\n", enter + 1)
+            period = tex.find(".", index)
+            sentence = tex[last + 1: period + 1]
+            tex = tex[:last + 1] + \
+                "Please refer to the subsection on the Memory Model for the" + \
+                " definition of the term \"remotely accessible\"." + \
+                tex[period + 1:]
+    return tex
 
 def parseRefTables(tableTex):
-	""" The function takes in a tex file that contains a type table as input
-	and returns the processed table in tabular form.
-	All elements within the tex file that is desired will follow the 
-	following pattern:
-	
-			<firstCol>	&	<secondCol> \\\\ \hline
-	
-	The following code will convert the above text to display in tabular 
-	form. 
-	In the special case of the first row that follows the pattern above,
-	the code will bold the strings of <firstCol> and <secondCol> for this
-	row only, for these are the column headers 
-	
-	The tabular header is:
-					.TP <number>
-					<firstCol>
-					<secondCol>
-	where <number> is the number of spaces between the start of firstCol
-	and the start of secondCol. 
-	Displays as:
-					<firstCol>					 <secondCol>
-					<----------<number>---------->
-	If the length of <firstCol> surpasses <number>, it will display as:
-					<----------<number>---------->
-					<firstCol>					 
-												 <secondCol>
-	
-	Every row of the table must include the ".TP" or the text will be
-	processed with default formatting. 
-	If there there is no <number>, the script will default to 1, or the
-	lastest definition of <number> in the current table
-	NOTE: Typically manpages ignores "\\n" within the text and displays
-	the text as if there is no "\\n". Under the ".TP" header, the flag
-	for when the second column begins is the next "\\n" 
-	
-	.B at the start of a line will underline/italicize all text until
-	the next "\\n" """
+    """ The function takes in a tex file that contains a type table as input
+    and returns the processed table in tabular form.
+    All elements within the tex file that is desired will follow the 
+    following pattern:
+    
+            <firstCol>    &    <secondCol> \\\\ \hline
+    
+    The following code will convert the above text to display in tabular 
+    form. 
+    In the special case of the first row that follows the pattern above,
+    the code will bold the strings of <firstCol> and <secondCol> for this
+    row only, for these are the column headers 
+    
+    The tabular header is:
+                    .TP <number>
+                    <firstCol>
+                    <secondCol>
+    where <number> is the number of spaces between the start of firstCol
+    and the start of secondCol. 
+    Displays as:
+                    <firstCol>                     <secondCol>
+                    <----------<number>---------->
+    If the length of <firstCol> surpasses <number>, it will display as:
+                    <----------<number>---------->
+                    <firstCol>                     
+                                                 <secondCol>
+    
+    Every row of the table must include the ".TP" or the text will be
+    processed with default formatting. 
+    If there there is no <number>, the script will default to 1, or the
+    lastest definition of <number> in the current table
+    NOTE: Typically manpages ignores "\\n" within the text and displays
+    the text as if there is no "\\n". Under the ".TP" header, the flag
+    for when the second column begins is the next "\\n" 
+    
+    .B at the start of a line will underline/italicize all text until
+    the next "\\n" """
 
-	startIdx = tableTex.find("\\hline")
-	endIdx = tableTex.find("\\end{tabular}")
-	table = cleanText(tableTex[startIdx + len("\\hline"):endIdx])
-	text = ""
-	count = 0
-	while(table.find("\\hline") >= 0):
-		line = table[:table.find("\\hline")]
-		firstCol = line[:line.find("&")].strip()
-		secondCol = line[line.find("&")+1:line.find("\\\\")].strip()
-		if (count == 0):
-			text += ".TP 25\n" + ".B " + firstCol + "\n" + \
-					".B " + secondCol + "\n"
-		else:
-			text += ".TP\n" + firstCol + "\n" + secondCol + "\n"
-		table = table[table.find("\\hline") + len("\\hline"):]
-		count += 1
-	return text
+    startIdx = tableTex.find("\\hline")
+    endIdx = tableTex.find("\\end{tabular}")
+    table = cleanText(tableTex[startIdx + len("\\hline"):endIdx])
+    text = ""
+    count = 0
+    while(table.find("\\hline") >= 0):
+        line = table[:table.find("\\hline")]
+        firstCol = line[:line.find("&")].strip()
+        secondCol = line[line.find("&")+1:line.find("\\\\")].strip()
+        if (count == 0):
+            text += ".TP 25\n" + ".B " + firstCol + "\n" + \
+                    ".B " + secondCol + "\n"
+        else:
+            text += ".TP\n" + firstCol + "\n" + secondCol + "\n"
+        table = table[table.find("\\hline") + len("\\hline"):]
+        count += 1
+    return text
 
 def addRefTable(tableID, directory):
-	""" This function maps the tableID given to each reference table to its
-	corresponding to tex file that contains the table. It then calls a
-	helper function to parse the table and returns the subsection text, 
-	containing the subsection header, the caption for the table, and the
-	table. """
+    """ This function maps the tableID given to each reference table to its
+    corresponding to tex file that contains the table. It then calls a
+    helper function to parse the table and returns the subsection text, 
+    containing the subsection header, the caption for the table, and the
+    table. """
 
-	if tableID == 1:
-		tableTex = open(directory + "/stdrmatypes.tex", "r").read()
-	elif tableID == 2: 
-		tableTex = open(directory + "/stdamotypes.tex", "r").read()
-	elif tableID == 3:
-		tableTex = open(directory + "/extamotypes.tex", "r").read()
-	elif tableID == 4:
-		tableTex = open(directory + "/bitamotypes.tex", "r").read()
-	else:
-		tableTex = open(directory + "/p2psynctypes.tex", "r").read()
-	captionIdx = tableTex.find("\\caption")
-	startBrace = captionIdx + len("\\caption")
-	endBrace = findMatchingBrace(tableTex, startBrace)
+    if tableID == 1:
+        tableTex = open(directory + "/stdrmatypes.tex", "r").read()
+    elif tableID == 2: 
+        tableTex = open(directory + "/stdamotypes.tex", "r").read()
+    elif tableID == 3:
+        tableTex = open(directory + "/extamotypes.tex", "r").read()
+    elif tableID == 4:
+        tableTex = open(directory + "/bitamotypes.tex", "r").read()
+    else:
+        tableTex = open(directory + "/p2psynctypes.tex", "r").read()
+    captionIdx = tableTex.find("\\caption")
+    startBrace = captionIdx + len("\\caption")
+    endBrace = findMatchingBrace(tableTex, startBrace)
 
-	caption = generalReplacements(tableTex[startBrace+1:endBrace])
-	text = ".SS Table " + str(tableID) + ":\n" + caption + "\n" + \
-			parseRefTables(tableTex)
-	return text
+    caption = generalReplacements(tableTex[startBrace+1:endBrace])
+    text = ".SS Table " + str(tableID) + ":\n" + caption + "\n" + \
+            parseRefTables(tableTex)
+    return text
 
 ##########################################################################
-##							CODE REPLACEMENTS	 						##
+##                            CODE REPLACEMENTS                             ##
 ##########################################################################
 
 def synCReplacements(tex, keyString):
-	""" Replaces the code identified between "\\begin{<keyString>}" and 
-	"\end{<keyString>}" to have C keywords (defined as a global variable) 
-	bolded and the argument variables underlined. 
-	
-	.B at the start of a line will bold all text until
-	the next "\\n"
-	.I at the start of a line will underline/italicize all text until
-	the next "\\n"
-	.IB will alternate between bold and underline/italicize font. For 
-	example:
-	
-	.IB "A" "B" "C"
-	
-	will have "A" and "C" as italicized and "B" will be bolded. """
+    """ Replaces the code identified between "\\begin{<keyString>}" and 
+    "\end{<keyString>}" to have C keywords (defined as a global variable) 
+    bolded and the argument variables underlined. 
+    
+    .B at the start of a line will bold all text until
+    the next "\\n"
+    .I at the start of a line will underline/italicize all text until
+    the next "\\n"
+    .IB will alternate between bold and underline/italicize font. For 
+    example:
+    
+    .IB "A" "B" "C"
+    
+    will have "A" and "C" as italicized and "B" will be bolded. """
 
-	while (tex.find("\\begin{" + keyString + "}") != -1):
-		startOfText = tex.find("\\begin{" + keyString + "}")
-		endOfText = tex.find("\\end{" + keyString + "}")
-		text = tex[startOfText + len("\\begin{" + keyString + "}"):endOfText]
-		codeList = text.split(";")
-		formattedCode = [];
+    while (tex.find("\\begin{" + keyString + "}") != -1):
+        startOfText = tex.find("\\begin{" + keyString + "}")
+        endOfText = tex.find("\\end{" + keyString + "}")
+        text = tex[startOfText + len("\\begin{" + keyString + "}"):endOfText]
+        codeList = text.split(";")
+        formattedCode = [];
 
-		for line in codeList:
-			line = line.strip()
-			wordList = line.split()
-			for i in xrange(len(wordList)):
-				if(i < 2):
-					wordList[i] = "\n.B " + wordList[i]
-				else:
-					if (wordList[i] in boldWordsC):
-						wordList[i] = "\n.B " + wordList[i]
-					else:
-						if (wordList[i].find(")") != -1):
-							wordList[i] = "\n.I " + \
-								wordList[i][: wordList[i].find(")")] + \
-								"\n.B );\n"
-						elif (wordList[i].find(",") != -1):
-							wordList[i] = "\n.IB \"" + \
-								wordList[i][: wordList[i].find(",")] \
-								+ "\" ,"
-						else:
-							wordList[i] = "\n.I " + wordList[i]
-			line = "".join(wordList)
-			formattedCode.append(line)
+        for line in codeList:
+            line = line.strip()
+            wordList = line.split()
+            for i in xrange(len(wordList)):
+                if(i < 2):
+                    wordList[i] = "\n.B " + wordList[i]
+                else:
+                    if (wordList[i] in boldWordsC):
+                        wordList[i] = "\n.B " + wordList[i]
+                    else:
+                        if (wordList[i].find(")") != -1):
+                            wordList[i] = "\n.I " + \
+                                wordList[i][: wordList[i].find(")")] + \
+                                "\n.B );\n"
+                        elif (wordList[i].find(",") != -1):
+                            wordList[i] = "\n.IB \"" + \
+                                wordList[i][: wordList[i].find(",")] \
+                                + "\" ,"
+                        else:
+                            wordList[i] = "\n.I " + wordList[i]
+            line = "".join(wordList)
+            formattedCode.append(line)
 
-		formattedCode = "\n\n".join(formattedCode)
-		if (keyString == "C11synopsis"):
-			header = ".SS C11:\n"
-		elif (keyString == "Csynopsis"):
-			header = ".SS C/C++:\n"
-		else:
-			header = ""
+        formattedCode = "\n\n".join(formattedCode)
+        if (keyString == "C11synopsis"):
+            header = ".SS C11:\n"
+        elif (keyString == "Csynopsis"):
+            header = ".SS C/C++:\n"
+        else:
+            header = ""
 
-		tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
-				header + formattedCode  + "\n" + \
-				"./ sectionEnd\n" + \
-				tex[endOfText + len("\\end{" + keyString + "}"):]
-	return tex
+        tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
+                header + formattedCode  + "\n" + \
+                "./ sectionEnd\n" + \
+                tex[endOfText + len("\\end{" + keyString + "}"):]
+    return tex
 
 def synFReplacements(tex):
-	""" Replaces the code identified between "\\begin{Fsynopsis}" and 
-	"\end{Fsynopsis}" to have Fortran keywords (defined as a global 
-	variable) bolded. 
-	
-	.B at the start of a line will bold all text untilthe next "\\n"
+    """ Replaces the code identified between "\\begin{Fsynopsis}" and 
+    "\end{Fsynopsis}" to have Fortran keywords (defined as a global 
+    variable) bolded. 
+    
+    .B at the start of a line will bold all text untilthe next "\\n"
 
-	.BR will alternate between bold and regular font. For example:
-	
-	.BR "A" "B" "C"
-	
-	will have "A" and "C" as bolded and "B" will be regular. """
+    .BR will alternate between bold and regular font. For example:
+    
+    .BR "A" "B" "C"
+    
+    will have "A" and "C" as bolded and "B" will be regular. """
 
-	while (tex.find("\\begin{Fsynopsis}") != -1):
-		startOfText = tex.find("\\begin{Fsynopsis}")
-		endOfText = tex.find("\\end{Fsynopsis}")
-		text = tex[startOfText + len("\\begin{Fsynopsis}\n"):endOfText]
-		text = "\n" + text.replace("\n", ";\n")
-		last = 0;
-		while(text.find(";") != -1):
-			s = text.find("\n", last) + len("\n")
-			e = text.find(";", s) + len(";")
-			line = text[s:e]
-			line = line.replace(";", "")
-			wordList = line.split()
-			if(wordList[0] in boldWordsF):
-				line = ".BR \"" + wordList[0] + " \" \"" + \
-						" ".join(wordList[1:]) + "\""
-			text = text[:s] + line + text[e:]
-			last = s
-		tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
-				".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
-				 "\n./ sectionEnd"  + "\n" + \
-				 tex[endOfText + len("\\end{Fsynopsis}"):]
-	return tex
+    while (tex.find("\\begin{Fsynopsis}") != -1):
+        startOfText = tex.find("\\begin{Fsynopsis}")
+        endOfText = tex.find("\\end{Fsynopsis}")
+        text = tex[startOfText + len("\\begin{Fsynopsis}\n"):endOfText]
+        text = "\n" + text.replace("\n", ";\n")
+        last = 0;
+        while(text.find(";") != -1):
+            s = text.find("\n", last) + len("\n")
+            e = text.find(";", s) + len(";")
+            line = text[s:e]
+            line = line.replace(";", "")
+            wordList = line.split()
+            if(wordList[0] in boldWordsF):
+                line = ".BR \"" + wordList[0] + " \" \"" + \
+                        " ".join(wordList[1:]) + "\""
+            text = text[:s] + line + text[e:]
+            last = s
+        tex = tex[:startOfText] + "\n./ sectionStart" + "\n" + \
+                ".SS Fortran:\n" + "\n.nf\n" + text + "\n.fi\n" + \
+                 "\n./ sectionEnd"  + "\n" + \
+                 tex[endOfText + len("\\end{Fsynopsis}"):]
+    return tex
 
 def codeReplace(tex):
-	tex = synCReplacements(tex, "C11synopsis")
-	tex = synCReplacements(tex, "Csynopsis")
-	tex = synCReplacements(tex, "CsynopsisCol")
-	tex = synFReplacements(tex)
-	return tex
+    tex = synCReplacements(tex, "C11synopsis")
+    tex = synCReplacements(tex, "Csynopsis")
+    tex = synCReplacements(tex, "CsynopsisCol")
+    tex = synFReplacements(tex)
+    return tex
 
 ##########################################################################
-##							HELPER FUNCTIONS	 						##
+##                            HELPER FUNCTIONS                             ##
 ##########################################################################
 
 def cleanText(text):
-	""" Gets rid of consecutive spaces and tabs in the given text but maintains
-	any "\\n\\n" which is the indicator of a new paragraph. For every para-
-	graph, the code will replace all macros and rejoin the paragraphs as 
-	the final return string.
-	NOTE: Typically manpages ignores "\\n" within the text and displays
-	the text as if there is no "\\n". "\\n\\n" will parsed as the beginning
-	of a new paragraph. """
-	text = text.replace("\t", "")
-	while(text.find("  ") != -1):
-		text = text.replace("  ", " ")
-	text = text.replace("\n ", "\n")
-	paragraphList = text.split("\n\n")
+    """ Gets rid of consecutive spaces and tabs in the given text but maintains
+    any "\\n\\n" which is the indicator of a new paragraph. For every para-
+    graph, the code will replace all macros and rejoin the paragraphs as 
+    the final return string.
+    NOTE: Typically manpages ignores "\\n" within the text and displays
+    the text as if there is no "\\n". "\\n\\n" will parsed as the beginning
+    of a new paragraph. """
+    text = text.replace("\t", "")
+    while(text.find("  ") != -1):
+        text = text.replace("  ", " ")
+    text = text.replace("\n ", "\n")
+    paragraphList = text.split("\n\n")
 
-	cleanParagraphList = []
-	for paragraph in paragraphList:
-		paragraph = macroReplacements(paragraph)
-		while (paragraph.find("\n\n") != -1):
-			paragraph = paragraph.replace("\n\n", "\n")
-		cleanParagraphList.append(paragraph)
-	sectionText = "\n\n".join(cleanParagraphList)
-	return sectionText
+    cleanParagraphList = []
+    for paragraph in paragraphList:
+        paragraph = macroReplacements(paragraph)
+        while (paragraph.find("\n\n") != -1):
+            paragraph = paragraph.replace("\n\n", "\n")
+        cleanParagraphList.append(paragraph)
+    sectionText = "\n\n".join(cleanParagraphList)
+    return sectionText
 
 def macroReplacements(paragraph):
-	paragraph = variableReplacements(paragraph)
-	paragraph = generalReplacements(paragraph)
-	paragraph = constReplacements(paragraph)
-	paragraph = oprReplacements(paragraph)
-	paragraph = funcReplacements(paragraph)
-	paragraph = italReplacements(paragraph)
-	paragraph = paragraph.replace("\n ", "\n")
-	return paragraph
+    paragraph = variableReplacements(paragraph)
+    paragraph = generalReplacements(paragraph)
+    paragraph = constReplacements(paragraph)
+    paragraph = oprReplacements(paragraph)
+    paragraph = funcReplacements(paragraph)
+    paragraph = italReplacements(paragraph)
+    paragraph = paragraph.replace("\n ", "\n")
+    return paragraph
 
 def generateRoutineList(TOC):
-	""" Takes the Table of Contents and compiles a list of all function names
-	that needs to be parsed to manpages. The code assumes that every function
-	entry will be preceded by the macro, "\\subsubsection{\\textbf" """
+    """ Takes the Table of Contents and compiles a list of all function names
+    that needs to be parsed to manpages. The code assumes that every function
+    entry will be preceded by the macro, "\\subsubsection{\\textbf" """
 
-	count = 0;
-	routineList = []
-	while(TOC.find("\\subsubsection{\\textbf", count) > 0):
-		currIdx = TOC.find("\\subsubsection{\\textbf", count)
-		startBrace = TOC.find("\\textbf", currIdx) + len("\\textbf")
-		endBrace = TOC.find("}", startBrace)
-		func = TOC[startBrace+1:endBrace]
-		if (func.find(",") != -1):
-			func = func[:func.find(",")]
-		name = func.lower().replace("\\", "")
-		routineList.append(name)
-		count = currIdx + len("\\subsubsection{\\textbf")
-	return routineList
+    count = 0;
+    routineList = []
+    while(TOC.find("\\subsubsection{\\textbf", count) > 0):
+        currIdx = TOC.find("\\subsubsection{\\textbf", count)
+        startBrace = TOC.find("\\textbf", currIdx) + len("\\textbf")
+        endBrace = TOC.find("}", startBrace)
+        func = TOC[startBrace+1:endBrace]
+        if (func.find(",") != -1):
+            func = func[:func.find(",")]
+        name = func.lower().replace("\\", "")
+        routineList.append(name)
+        count = currIdx + len("\\subsubsection{\\textbf")
+    return routineList
 
 def findMatchingBrace(tex, ind):
-	""" Takes in the tex string and the index of the open brace to which we 
-	need to find the matching brace. 
-	Function returns the index of the matching brace """
-	count = 0
-	if (tex[ind] == "{"):
-		count += 1
-		ptr = ind + 1
-	while(count != 0):
-		if(tex[ptr] == "{"):
-			count = count + 1
-		if(tex[ptr] == "}"):
-			count = count - 1
-		ptr += 1
-	return ptr - 1
+    """ Takes in the tex string and the index of the open brace to which we 
+    need to find the matching brace. 
+    Function returns the index of the matching brace """
+    count = 0
+    if (tex[ind] == "{"):
+        count += 1
+        ptr = ind + 1
+    while(count != 0):
+        if(tex[ptr] == "{"):
+            count = count + 1
+        if(tex[ptr] == "}"):
+            count = count - 1
+        ptr += 1
+    return ptr - 1
 
 ##########################################################################
-##							MAIN FUNCTIONS		 						##
+##                            MAIN FUNCTIONS                                 ##
 ##########################################################################
 
 def convertFile(functionName, directory, gen_dir):
-	filename = directory + '/' + functionName + ".tex"
-	texFile = open(filename, "r")
-	if not os.path.exists(gen_dir):
-	    os.makedirs(gen_dir)
-	manFile = open(gen_dir + '/' + functionName + ".3", "w")
-	titleHeader = writePageHeader(functionName)
-	manFile.write(titleHeader)
+    filename = directory + '/' + functionName + ".tex"
+    texFile = open(filename, "r")
+    if not os.path.exists(gen_dir):
+        os.makedirs(gen_dir)
+    manFile = open(gen_dir + '/' + functionName + ".3", "w")
+    titleHeader = writePageHeader(functionName)
+    manFile.write(titleHeader)
 
-	tex = texFile.read()
-	tex = tex.replace("\\begin{DeprecateBlock}", "")
-	tex = tex.replace("\\end{DeprecateBlock}", "")
-	tex = tex.replace("\\begin{apidefinition}\n", 
-				"./ sectionStart\n.SH   SYNOPSIS\n./ sectionEnd")
-	tex = sumReplacements(tex, functionName)
-	tex = mBoxReplacements(tex)
-	tex = argReplacements(tex)
-	tex = descrReplacements(tex)
-	tex = notesReplacements(tex)
-	tex = retReplacements(tex)
-	tex = boldReplacements(tex)
-	tex = codeReplace(tex)
-	if (tex.find("\\apiimpnotes{") != -1):
-		tex = impnotesReplacements(tex)
-	while(tex.find("\\apidesctable{") != -1):
-		tex = descTReplacements(tex)
-	tex = tablerowReplacements(tex)
-	tex = refMEMReplacements(tex)
-	if (tex.find("\\begin{apiexamples}") != -1):
-		tex = exampleReplacements(tex, directory)
-	(tex, tables) = refTextReplacements(tex)
-	if (tables[0]):
-		tex = tex + addRefTable(1, directory)
-	if (tables[1]):
-		tex = tex + addRefTable(2, directory)
-	if (tables[2]):
-		tex = tex + addRefTable(3, directory)
-	if (tables[3]):
-		tex = tex + addRefTable(4, directory)
-	if (tables[4]):
-		tex = tex + addRefTable(5, directory)
-	tex = tex.replace("\\begin{apidefinition}", "")
-	tex = tex.replace("\\end{apidefinition}", "")
-	text = tex[:tex.find(".SS Examples")]
-	while(text.find("\n ") != -1):
-		text = text.replace("\n ", "\n")
-	text = text.replace("\\\\", "\n")
-	text = text.replace("$", "")
-	tex = text + tex[tex.find(".SS Examples"):]
-	tex = tex.replace("\n ", "\n")
-	manFile.write(tex.replace("\\n", "\\\\" + "n"))
-	print("Finished converting " + functionName + ".tex")
-	manFile.close()
-	texFile.close()
+    tex = texFile.read()
+    tex = tex.replace("\\begin{DeprecateBlock}", "")
+    tex = tex.replace("\\end{DeprecateBlock}", "")
+    tex = tex.replace("\\begin{apidefinition}\n", 
+                "./ sectionStart\n.SH   SYNOPSIS\n./ sectionEnd")
+    tex = sumReplacements(tex, functionName)
+    tex = mBoxReplacements(tex)
+    tex = argReplacements(tex)
+    tex = descrReplacements(tex)
+    tex = notesReplacements(tex)
+    tex = retReplacements(tex)
+    tex = boldReplacements(tex)
+    tex = codeReplace(tex)
+    if (tex.find("\\apiimpnotes{") != -1):
+        tex = impnotesReplacements(tex)
+    while(tex.find("\\apidesctable{") != -1):
+        tex = descTReplacements(tex)
+    tex = tablerowReplacements(tex)
+    tex = refMEMReplacements(tex)
+    if (tex.find("\\begin{apiexamples}") != -1):
+        tex = exampleReplacements(tex, directory)
+    (tex, tables) = refTextReplacements(tex)
+    if (tables[0]):
+        tex = tex + addRefTable(1, directory)
+    if (tables[1]):
+        tex = tex + addRefTable(2, directory)
+    if (tables[2]):
+        tex = tex + addRefTable(3, directory)
+    if (tables[3]):
+        tex = tex + addRefTable(4, directory)
+    if (tables[4]):
+        tex = tex + addRefTable(5, directory)
+    tex = tex.replace("\\begin{apidefinition}", "")
+    tex = tex.replace("\\end{apidefinition}", "")
+    text = tex[:tex.find(".SS Examples")]
+    while(text.find("\n ") != -1):
+        text = text.replace("\n ", "\n")
+    text = text.replace("\\\\", "\n")
+    text = text.replace("$", "")
+    tex = text + tex[tex.find(".SS Examples"):]
+    tex = tex.replace("\n ", "\n")
+    manFile.write(tex.replace("\\n", "\\\\" + "n"))
+    print("Finished converting " + functionName + ".tex")
+    manFile.close()
+    texFile.close()
 
 def main():
-	parser = argparse.ArgumentParser(description='Generate OpenSHMEM manpages')
-	parser.add_argument('-d', '--directory', type=str, required=False,
+    parser = argparse.ArgumentParser(description='Generate OpenSHMEM manpages')
+    parser.add_argument('-d', '--directory', type=str, required=False,
                         help='OpenSHMEM specification LaTeX directory path')
-	parser.add_argument('-o', '--output-directory', type=str, required=False, default="./man",
+    parser.add_argument('-o', '--output-directory', type=str, required=False, default="./man",
                         help='Output directory for generated manpages')
-	parser.add_argument('-f', '--filename', type=str, required=False,
+    parser.add_argument('-f', '--filename', type=str, required=False,
                         help='LaTeX file path for an OpenSHMEM routine')
-	args = parser.parse_args()
+    args = parser.parse_args()
 
-	if (args.directory == None) and (args.filename == None):
-		parser.print_usage()
-		exit(1)
+    if (args.directory == None) and (args.filename == None):
+        parser.print_usage()
+        exit(1)
 
-	if args.directory != None:
-		if not os.path.realpath(args.directory):
-			print("Error: input directory, " + args.directory + ", does not appear to exist")
-			exit(1)
-		else:
-			print("Dir found")
+    if args.directory != None:
+        if not os.path.realpath(args.directory):
+            print("Error: input directory, " + args.directory + ", does not appear to exist")
+            exit(1)
+        else:
+            print("Dir found")
             
-			if not os.path.isfile(args.directory + "/../main_spec.tex"):
-				print("Error: main_spec.tex is not found in the parent of the given directory.")
-				exit(1)
+            if not os.path.isfile(args.directory + "/../main_spec.tex"):
+                print("Error: main_spec.tex is not found in the parent of the given directory.")
+                exit(1)
 
-			TOC = open(args.directory + "/../main_spec.tex").read()
-			routineList = generateRoutineList(TOC)
-			for routine in routineList:
-				if routine + ".tex" not in os.listdir(args.directory):
-					print("Error: " + routine + ".tex is not in the given directory")
-					exit(1)
-				else:
-					convertFile(routine, args.directory, args.output_directory)
-	else:
-		if not os.path.isfile(args.filename):
-			print("Error: input file, " + args.filename + ", does not appear to exist.")
-			exit(1)
-		else:
-			per = args.filename.find(".tex")
-			last = 0;
-			while (args.filename.find("/", last) >= 0):
-				last = args.filename.find("/", last) + 1
+            TOC = open(args.directory + "/../main_spec.tex").read()
+            routineList = generateRoutineList(TOC)
+            for routine in routineList:
+                if routine + ".tex" not in os.listdir(args.directory):
+                    print("Error: " + routine + ".tex is not in the given directory")
+                    exit(1)
+                else:
+                    convertFile(routine, args.directory, args.output_directory)
+    else:
+        if not os.path.isfile(args.filename):
+            print("Error: input file, " + args.filename + ", does not appear to exist.")
+            exit(1)
+        else:
+            per = args.filename.find(".tex")
+            last = 0;
+            while (args.filename.find("/", last) >= 0):
+                last = args.filename.find("/", last) + 1
 
-			functionName = args.filename[last:per]
-			convertFile(functionName, args.filename[:last], args.output_directory)
+            functionName = args.filename[last:per]
+            convertFile(functionName, args.filename[:last], args.output_directory)
 
 if __name__== "__main__":
     main()


### PR DESCRIPTION
- Changed autogen.sh and configure.ac to incorporate manpage installation
- Added "man" directory containing generated man pages
- Added Python script to "scripts" directory that can take in individual files or a folder containing LaTex files from the OpenSHMEM specification and converts them to manpages.
- Designed to link with the content folder of the openshmem-org/specification directory

Signed-off-by: angelali4096 <qingyanl@andrew.cmu.edu>
