### PR TITLE
Changed mt_a2a.c such that the test works.

### DIFF
--- a/test/unit/mt_a2a.c
+++ b/test/unit/mt_a2a.c
@@ -78,6 +78,7 @@ static void * thread_main(void *arg) {
         pthread_mutex_unlock(&mutex);
     }
 
+    pthread_barrier_wait(&fencebar);
     if (0 == tid) shmem_barrier_all();
     pthread_barrier_wait(&fencebar);
 


### PR DESCRIPTION
File was missing a pthread barrier and was causing unspecified execution.

Signed-off-by: = <=alex@mckpals.com>