### PR TITLE
Update SMA_SYMMETRIC_SIZE for ISx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -255,12 +255,12 @@ script:
     ###
     - export PATH=$TRAVIS_INSTALL/sandia-shmem-ofi/bin:$TRAVIS_INSTALL/hydra/bin:$BASE_PATH
     - export OSHRUN_LAUNCHER="mpiexec.hydra"
-    - export SMA_SYMMETRIC_SIZE='4G'
     - cd $TRAVIS_SRC/ISx/SHMEM
     - make CC=oshcc LDLIBS=-lm
-    - oshrun -np 4 ./bin/isx.strong 134217728 output_strong
-    - oshrun -np 4 ./bin/isx.weak 33554432 output_weak
-    - oshrun -np 4 ./bin/isx.weak_iso 33554432 output_weak_iso
+    # Note: This SMA_SYMMETRIC_SIZE setting may exceed the memory available in the CI testing environment
+    - oshrun -np 4 -env SMA_SYMMETRIC_SIZE '4G' ./bin/isx.strong 134217728 output_strong
+    - oshrun -np 4 -env SMA_SYMMETRIC_SIZE '4G' ./bin/isx.weak 33554432 output_weak
+    - oshrun -np 4 -env SMA_SYMMETRIC_SIZE '4G' ./bin/isx.weak_iso 33554432 output_weak_iso
     - make clean
     ###
     ### Run PRK (Portals)


### PR DESCRIPTION
Move the SMA_SYMMETRIC_SIZE env var adjustment to an oshrun argument to avoid changing the environment variable setting (which may be set elsewhere in the future and would be used by all other tests).