### PR TITLE
Fixes shrealloc and ipgm test errors with 1 PE

### DIFF
--- a/test/unit/ipgm.c
+++ b/test/unit/ipgm.c
@@ -94,7 +94,7 @@ usage (void)
             "    -v == Verbose output\n"
             "    -h == help.\n");
     }
-    exit (1);
+    shmem_global_exit(1);
 }
 
 int
@@ -174,6 +174,12 @@ main(int argc, char **argv)
     nProcs = shmem_n_pes();
     workers = nProcs - 1;
 
+    if (nProcs <= 1) {
+        fprintf(stderr, "ERR - Requires > 1 PEs\n");
+        shmem_finalize();
+        return 0;
+    }
+
     while ((c = getopt (argc, argv, "hmrvdD")) != -1)
         switch (c)
         {
@@ -241,7 +247,7 @@ main(int argc, char **argv)
         if (!results)
         {
             perror ("Failed results memory allocation");
-            exit (1);
+            shmem_global_exit(1);
         }
         prev_sz = rc;
 
@@ -266,7 +272,7 @@ main(int argc, char **argv)
 
         if (! source) {
             perror ("Failed source memory allocation");
-            exit (1);
+            shmem_global_exit(1);
         }
         if (Debug > 3)
             printf("shmem_malloc() source %p (%d bytes)\n",(void*)source,rc);
@@ -285,7 +291,7 @@ main(int argc, char **argv)
 
         if ( ! target ) {
             perror ("Failed target memory allocation");
-            exit (1);
+            shmem_global_exit(1);
         }
         memset(target, 0, rc);
         if (Debug > 3)

--- a/test/unit/shrealloc.c
+++ b/test/unit/shrealloc.c
@@ -73,9 +73,9 @@ static int source_sz;
 static int target_sz;
 static int result_sz;
 
-static int prev_source_idx;
-static int prev_target_idx;
-static int prev_result_idx;
+static int prev_source_idx = 0;
+static int prev_target_idx = 0;
+static int prev_result_idx = 0;
 
 static char *pgm;
 
@@ -147,6 +147,12 @@ main(int argc, char **argv)
     shmem_init();
     me = shmem_my_pe();
     nProcs = shmem_n_pes();
+
+    if (nProcs <= 1) {
+        fprintf(stderr, "ERR - Requires > 1 PEs\n");
+        shmem_finalize();
+        return 0;
+    }
 
     while ((c = getopt (argc, argv, "hpv")) != -1)
         switch (c)


### PR DESCRIPTION
These tests are invalid when run with 1 PE, so require 2 or more PE's.  Also change exit() to shmem_global_exit() where necessary and address a small initialization issue.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>