### PR TITLE
Fix missing manpages from RPM build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-EXTRA_DIST = README NEWS LICENSE sandia-openshmem.spec pmi-simple
+EXTRA_DIST = README NEWS LICENSE sandia-openshmem.spec pmi-simple man
 
 SUBDIRS = man mpp pmi-simple src test
 

--- a/sandia-openshmem.spec.in
+++ b/sandia-openshmem.spec.in
@@ -62,6 +62,7 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+%{_bindir}/oshrun
 %{_libdir}/lib*.so.*
 %doc LICENSE README NEWS
 
@@ -71,6 +72,7 @@ rm -rf %{buildroot}
 %{_libdir}/lib*.so
 %{_libdir}/*.a
 %{_includedir}/*
+%{_mandir}/man[1-3]/*.[1-3]
 
 %files tests
 %defattr(-,root,root)


### PR DESCRIPTION
Adds the man pages directory to EXTRA_DIST so that "make dist" includes
them in the packages tarball.  Also adds the manpage files to the
"devel" RPM build and "oshrun" to the standard RPM.

Signed-off-by: David Ozog <david.m.ozog@intel.com>