### PR TITLE
Fix handling of zero-length put/get operations

### DIFF
--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -52,6 +52,8 @@ shmem_internal_put_small(void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
 
+    shmem_internal_assert(len > 0);
+
     if (-1 != (node_rank = SHMEM_GET_RANK_SAME_NODE(pe))) {
 #if USE_XPMEM
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
@@ -72,6 +74,8 @@ shmem_internal_put_nb(void *target, const void *source, size_t len, int pe,
                       long *completion)
 {
     int node_rank;
+
+    if (len == 0) return;
 
     if (-1 != (node_rank = SHMEM_GET_RANK_SAME_NODE(pe))) {
 #if USE_XPMEM
@@ -95,6 +99,8 @@ void
 shmem_internal_put_nbi(void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
+
+    if (len == 0) return;
 
     if (-1 != (node_rank = SHMEM_GET_RANK_SAME_NODE(pe))) {
 #if USE_XPMEM
@@ -140,6 +146,8 @@ shmem_internal_get(void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
 
+    if (len == 0) return;
+
     if (-1 != (node_rank = SHMEM_GET_RANK_SAME_NODE(pe))) {
 #if USE_XPMEM
         shmem_transport_xpmem_get(target, source, len, pe, node_rank);
@@ -181,6 +189,8 @@ void
 shmem_internal_swap(void *target, void *source, void *dest, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
+    if (len == 0) return;
+
     shmem_transport_swap(target, source, dest, len, pe, datatype);
 }
 
@@ -190,6 +200,8 @@ void
 shmem_internal_cswap(void *target, void *source, void *dest, void *operand, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
+    if (len == 0) return;
+
     shmem_transport_cswap(target, source, dest, operand, len, pe, datatype);
 }
 
@@ -199,6 +211,8 @@ void
 shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
+    if (len == 0) return;
+
     shmem_transport_mswap(target, source, dest, mask, len, pe, datatype);
 }
 
@@ -209,6 +223,8 @@ shmem_internal_atomic_small(void *target, const void *source, size_t len,
                             int pe, shm_internal_op_t op,
                             shm_internal_datatype_t datatype)
 {
+    shmem_internal_assert(len > 0);
+
     shmem_transport_atomic_small(target, source, len, pe, op, datatype);
 }
 
@@ -218,6 +234,8 @@ void
 shmem_internal_atomic_fetch(void *target, const void *source, size_t len,
                             int pe, shm_internal_datatype_t datatype)
 {
+    shmem_internal_assert(len > 0);
+
     shmem_transport_atomic_fetch(target, source, len, pe, datatype);
 }
 
@@ -227,6 +245,8 @@ void
 shmem_internal_atomic_set(void *target, const void *source, size_t len,
                           int pe, shm_internal_datatype_t datatype)
 {
+    shmem_internal_assert(len > 0);
+
     shmem_transport_atomic_set(target, source, len, pe, datatype);
 }
 
@@ -237,6 +257,8 @@ shmem_internal_atomic_nb(void *target, const void *source, size_t len,
                          int pe, shm_internal_op_t op,
                          shm_internal_datatype_t datatype, long *completion)
 {
+    if (len == 0) return;
+
     shmem_transport_atomic_nb(target, source, len, pe, op, datatype, completion);
 }
 
@@ -248,6 +270,8 @@ shmem_internal_fetch_atomic(void *target, void *source, void *dest, size_t len,
                             int pe, shm_internal_op_t op,
                             shm_internal_datatype_t datatype)
 {
+    if (len == 0) return;
+
     shmem_transport_fetch_atomic(target, source, dest, len, pe, op, datatype);
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -189,7 +189,7 @@ void
 shmem_internal_swap(void *target, void *source, void *dest, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
-    if (len == 0) return;
+    shmem_internal_assert(len > 0);
 
     shmem_transport_swap(target, source, dest, len, pe, datatype);
 }
@@ -200,7 +200,7 @@ void
 shmem_internal_cswap(void *target, void *source, void *dest, void *operand, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
-    if (len == 0) return;
+    shmem_internal_assert(len > 0);
 
     shmem_transport_cswap(target, source, dest, operand, len, pe, datatype);
 }
@@ -211,7 +211,7 @@ void
 shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
-    if (len == 0) return;
+    shmem_internal_assert(len > 0);
 
     shmem_transport_mswap(target, source, dest, mask, len, pe, datatype);
 }
@@ -257,7 +257,7 @@ shmem_internal_atomic_nb(void *target, const void *source, size_t len,
                          int pe, shm_internal_op_t op,
                          shm_internal_datatype_t datatype, long *completion)
 {
-    if (len == 0) return;
+    shmem_internal_assert(len > 0);
 
     shmem_transport_atomic_nb(target, source, len, pe, op, datatype, completion);
 }
@@ -270,7 +270,7 @@ shmem_internal_fetch_atomic(void *target, void *source, void *dest, size_t len,
                             int pe, shm_internal_op_t op,
                             shm_internal_datatype_t datatype)
 {
-    if (len == 0) return;
+    shmem_internal_assert(len > 0);
 
     shmem_transport_fetch_atomic(target, source, dest, len, pe, op, datatype);
 }

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -83,7 +83,8 @@ check_PROGRAMS = \
 	pcontrol \
 	atomic_bitwise \
 	nop_collectives \
-	self_collectives
+	self_collectives \
+	zero_comm
 
 if ENABLE_PROFILING
 check_PROGRAMS += \

--- a/test/unit/zero_comm.c
+++ b/test/unit/zero_comm.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <shmem.h>
+
+int main(void) {
+    shmem_init();
+
+    shmem_putmem(NULL, NULL, 0, 0);
+    shmem_getmem(NULL, NULL, 0, 0);
+
+    shmem_putmem_nbi(NULL, NULL, 0, 0);
+    shmem_getmem_nbi(NULL, NULL, 0, 0);
+
+    shmem_int_iget(NULL, NULL, 1, 1, 0, 0);
+    shmem_int_iput(NULL, NULL, 1, 1, 0, 0);
+
+    shmem_finalize();
+    return 0;
+}


### PR DESCRIPTION
Note that atomics are always length 1, so I added asserts to the corresponding ```atomic/put_small``` routines rather than a length check (the assertions are only included in error checking builds).