### PR TITLE
Check for null pointers in unit tests

### DIFF
--- a/test/unit/asym_alloc.c
+++ b/test/unit/asym_alloc.c
@@ -61,6 +61,10 @@ int main(int argc, char **argv) {
     /* Write to neighbor's buffer */
     target = (me + 1) % npes;
     buf_in = malloc(sizeof(int) * (target + 1));
+    if (!buf_in) {
+        fprintf(stderr, "ERR - null buf_in pointer\n");
+        shmem_global_exit(1);
+    }
 
     for (i = 0; i < target + 1; i++)
         buf_in[i] = target;

--- a/test/unit/bcast_flood.c
+++ b/test/unit/bcast_flood.c
@@ -119,14 +119,26 @@ main(int argc, char **argv)
 
     ps_cnt *= SHMEM_BCAST_SYNC_SIZE;
     pSync = shmem_malloc( ps_cnt * sizeof(long) );
+    if (!pSync) {
+        fprintf(stderr, "ERR - null pSync pointer\n");
+        shmem_global_exit(1);
+    }
 
     for (i = 0; i < ps_cnt; i++) {
       pSync[i] = SHMEM_SYNC_VALUE;
     }
 
     source = (int *) shmem_malloc( elements * sizeof(*source) );
+    if (!source) {
+        fprintf(stderr, "ERR - null source pointer\n");
+        shmem_global_exit(1);
+    }
 
     target = (int *) shmem_malloc( elements * sizeof(*target) );
+    if (!target) {
+        fprintf(stderr, "ERR - null target pointer\n");
+        shmem_global_exit(1);
+    }
     for (i = 0; i < elements; i += 1) {
         source[i] = i + 1;
         target[i] = -90;

--- a/test/unit/put_nbi.c
+++ b/test/unit/put_nbi.c
@@ -50,11 +50,20 @@ main(int argc, char* argv[])
 
     target = (long*) shmem_malloc(sizeof(long) * 10);
     flag = (int*) shmem_malloc(sizeof(int));
+    if (!flag) {
+        fprintf(stderr, "ERR - null flag pointer\n");
+        shmem_global_exit(1);
+    }
     *flag = 0;
 
     num_pes=shmem_n_pes();
 
-    memset(target, 0, sizeof(long)*10);
+    if (target) {
+        memset(target, 0, sizeof(long)*10);
+    } else {
+        fprintf(stderr, "ERR - null target pointer\n");
+        shmem_global_exit(1);
+    }
 
     shmem_barrier_all();
 


### PR DESCRIPTION
Check that pointers returned by shmem_malloc/malloc are not null before dereferencing them.