### PR TITLE
Fix memory leak in target_put

### DIFF
--- a/test/performance/shmem_perf_suite/target_put.h
+++ b/test/performance/shmem_perf_suite/target_put.h
@@ -97,8 +97,8 @@ void static inline target_data_uni_bw(int len, perf_metrics_t metric_info)
             shmem_int_inc(&completion_signal, my_PE_partners[i]);
         }
         end = perf_shmemx_wtime();
-        free(my_PE_partners);
     }
+    free(my_PE_partners);
 
     shmem_barrier_all();
     completion_signal = 0;


### PR DESCRIPTION
Coverity reported this leak, which can be fixed by moving the free()
into the same scope as the assignment.