### PR TITLE
Add PMIx experimental feature w/ Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: c
 compiler:
     #- clang
@@ -126,7 +127,26 @@ before_install:
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
     - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
-
+    ## Build Libevent
+    - cd $TRAVIS_SRC
+    - wget https://github.com/libevent/libevent/releases/download/release-2.0.22-stable/libevent-2.0.22-stable.tar.gz
+    - tar -xzvf libevent-2.0.22-stable.tar.gz
+    - cd libevent-2.0.22-stable
+    - ./autogen.sh
+    - ./configure --prefix=$PWD/install
+    - make clean all install
+    ## Build PMIx
+    - cd $TRAVIS_SRC
+    - git clone --depth 10 --single-branch -b v2.0 https://github.com/pmix/pmix pmix
+    - cd pmix
+    - ./autogen.pl
+    - ./configure --prefix=$PWD/install --with-libevent=$TRAVIS_SRC/libevent-2.0.22-stable/install --with-devel-headers --disable-visibility && make clean all install
+    ## Build Open MPI
+    - cd $TRAVIS_SRC
+    - git clone --depth 10 --single-branch -b v3.0.x https://github.com/open-mpi/ompi.git ompi
+    - cd ompi
+    - ./autogen.pl
+    - ./configure --prefix=$PWD/install --with-libevent=$TRAVIS_SRC/libevent-2.0.22-stable/install --with-pmix=$TRAVIS_SRC/pmix/install && make clean all install
 install:
     - cd $SOS_SRC
     - ./autogen.sh
@@ -178,6 +198,17 @@ script:
     - make $TRAVIS_PAR_MAKE
     - make $TRAVIS_PAR_MAKE check TESTS=
     - make VERBOSE=1 TEST_RUNNER="mpiexec.hydra -np 2" check
+    - make install
+    ###
+    ### Build and check with ORTE (Open MPI's launcher)
+    ###
+    - cd $SOS_SRC
+    - mkdir ompi-build
+    - cd ompi-build
+    - export PATH=$TRAVIS_SRC/ompi/install/bin:$BASE_PATH
+    - ../configure --prefix=$PWD/install --with-ofi=$TRAVIS_INSTALL/libfabric --with-pmix=$TRAVIS_SRC/pmix/install
+    - make $TRAVIS_PAR_MAKE
+    - make $TRAVIS_PAR_MAKE check TESTS=
     - make install
     ###
     ### Run the UH test suite (Portals)

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,12 +141,16 @@ before_install:
     - cd pmix
     - ./autogen.pl
     - ./configure --prefix=$PWD/install --with-libevent=$TRAVIS_SRC/libevent-2.0.22-stable/install --with-devel-headers --disable-visibility && make clean all install
-    ## Build Open MPI
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 --single-branch -b v3.0.x https://github.com/open-mpi/ompi.git ompi
-    - cd ompi
-    - ./autogen.pl
-    - ./configure --prefix=$PWD/install --with-libevent=$TRAVIS_SRC/libevent-2.0.22-stable/install --with-pmix=$TRAVIS_SRC/pmix/install && make clean all install
+    ## Build OMPI from source (takes too long, so removed in favor of RPM install below)
+    #- cd $TRAVIS_SRC
+    #- git clone --depth 10 --single-branch -b v3.0.x https://github.com/open-mpi/ompi.git ompi
+    #- cd ompi
+    #- ./autogen.pl
+    #- ./configure --prefix=$PWD/install --with-libevent=$TRAVIS_SRC/libevent-2.0.22-stable/install --with-pmix=$TRAVIS_SRC/pmix/install && make clean all install
+    ## Download and install OpenMPI RPM 
+    - cd $TRAVIS_INSTALL
+    - wget http://gdurl.com/P5og -O openmpi-v3.0.x.deb
+    - sudo dpkg -i openmpi-v3.0.x.deb
 install:
     - cd $SOS_SRC
     - ./autogen.sh
@@ -205,10 +209,11 @@ script:
     - cd $SOS_SRC
     - mkdir ompi-build
     - cd ompi-build
-    - export PATH=$TRAVIS_SRC/ompi/install/bin:$BASE_PATH
+    - export PATH=/opt/openmpi/gitclone/bin:$BASE_PATH
     - ../configure --prefix=$PWD/install --with-ofi=$TRAVIS_INSTALL/libfabric --with-pmix=$TRAVIS_SRC/pmix/install
     - make $TRAVIS_PAR_MAKE
-    - make $TRAVIS_PAR_MAKE check TESTS=
+    - echo "localhost slots=4" > /tmp/hostfile.txt
+    - make VERBOSE=1 TEST_RUNNER="mpiexec --hostfile /tmp/hostfile.txt -np 4" check
     - make install
     ###
     ### Run the UH test suite (Portals)

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -256,3 +256,107 @@ dnl check to see if we have crazy cray PMI (no pmi2 but PMI2_init works)
     AC_SUBST(TEST_RUNNER)
     OPAL_VAR_SCOPE_POP
 ])
+
+AC_DEFUN([OPAL_CHECK_PMIX],[
+
+    OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
+
+    AC_ARG_WITH([pmix],
+                [AC_HELP_STRING([--with-pmix(=DIR)],
+                                [Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
+
+    AS_IF([test "$with_pmix" = "no"],
+          [AC_MSG_WARN([Open MPI requires PMIx support. It can be built])
+           AC_MSG_WARN([with either its own internal copy of PMIx, or with])
+           AC_MSG_WARN([an external copy that you supply.])
+           AC_MSG_ERROR([Cannot continue])])
+
+    AC_MSG_CHECKING([if user requested external PMIx support($with_pmix)])
+    AS_IF([test -z "$with_pmix" || test "$with_pmix" = "yes" || test "$with_pmix" = "internal"],
+          [AC_MSG_RESULT([no])
+           opal_external_pmix_happy=no],
+
+          [AC_MSG_RESULT([yes])
+           # check for external pmix lib */
+           AS_IF([test "$with_pmix" = "external"],
+                 [pmix_ext_install_dir=/usr],
+                 [pmix_ext_install_dir=$with_pmix])
+
+           # Make sure we have the headers and libs in the correct location
+           OPAL_CHECK_WITHDIR([external-pmix], [$pmix_ext_install_dir/include], [pmix.h])
+           OPAL_CHECK_WITHDIR([external-libpmix], [$pmix_ext_install_dir/lib], [libpmix.*])
+           # check the version
+           opal_external_pmix_save_CPPFLAGS=$CPPFLAGS
+           opal_external_pmix_save_LDFLAGS=$LDFLAGS
+           opal_external_pmix_save_LIBS=$LIBS
+
+           # if the pmix_version.h file does not exist, then
+           # this must be from a pre-1.1.5 version
+           AC_MSG_CHECKING([PMIx version])
+           CPPFLAGS="-I$pmix_ext_install_dir/include $CPPFLAGS"
+           AS_IF([test "x`ls $pmix_ext_install_dir/include/pmix_version.h 2> /dev/null`" = "x"],
+                 [AC_MSG_RESULT([version file not found - assuming v1.1.4])
+                  opal_external_pmix_version_found=1
+                  opal_external_pmix_version=114],
+                 [AC_MSG_RESULT([version file found])
+                  opal_external_pmix_version_found=0])
+
+           # if it does exist, then we need to parse it to find
+           # the actual release series
+           AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 3x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 3L)
+                                                      #error "not version 3"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=3x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+
+           AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 2x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 2L)
+                                                      #error "not version 2"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=2x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+     
+	  AS_IF([test "$opal_external_pmix_version_found" = "0"],
+                 [AC_MSG_CHECKING([version 1x])
+                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([
+                                                      #include <pmix_version.h>
+                                                      #if (PMIX_VERSION_MAJOR != 1L)
+                                                      #error "not version 1"
+                                                      #endif
+                                                      ], [])],
+                                    [AC_MSG_RESULT([found])
+                                     opal_external_pmix_version=1x
+                                     opal_external_pmix_version_found=1],
+                                    [AC_MSG_RESULT([not found])])])
+
+           AS_IF([test "x$opal_external_pmix_version" = "x"],
+                 [AC_MSG_WARN([External PMIx support requested, but version])
+                  AC_MSG_WARN([information of the external lib could not])
+                  AC_MSG_WARN([be detected])
+                  AC_MSG_ERROR([cannot continue])])
+
+           CPPFLAGS=$opal_external_pmix_save_CPPFLAGS
+           LDFLAGS=$opal_external_pmix_save_LDFLAGS
+           LIBS=$opal_external_pmix_save_LIBS
+
+           opal_external_pmix_CPPFLAGS="-I$pmix_ext_install_dir/include"
+           opal_external_pmix_LDFLAGS=-L$pmix_ext_install_dir/lib
+           opal_external_pmix_LIBS=-lpmix
+           opal_external_pmix_happy=yes])
+
+    OPAL_VAR_SCOPE_POP
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ AC_CANONICAL_HOST
 
 OPAL_CHECK_ATTRIBUTES
 
+OPAL_CHECK_PMIX
+
 AC_ARG_ENABLE([picky],
     [AC_HELP_STRING([--enable-picky],
                     [Enable developer-level compiler pickyness when building (default: disabled)])])
@@ -316,6 +318,7 @@ AS_IF([test "$enable_pmi_simple" = "yes"],
      [OPAL_CHECK_PMI(pmi_type)])
 AM_CONDITIONAL([USE_PMI_SIMPLE], [test "$enable_pmi_simple" = "yes"])
 AM_CONDITIONAL([USE_PMI2], [test "$pmi_type" = "pmi2"])
+AM_CONDITIONAL([USE_PMIX], [test "$opal_external_pmix_version_found" = 1])
 
 dnl check for header files
 AC_CHECK_HEADERS([fnmatch.h])
@@ -563,11 +566,11 @@ if test "$transport_xpmem" = "yes" ; then
     WRAPPER_COMPILER_EXTRA_LIBS="$XPMEM_LIBS"
 fi
 
-CPPFLAGS="$CPPFLAGS $pmi_CPPFLAGS"
-LDFLAGS="$LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
-LIBS="$LIBS $pmi_LIBS"
-WRAPPER_COMPILER_EXTRA_LDFLAGS="$WRAPPER_COMPILER_EXTRA_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
-WRAPPER_COMPILER_EXTRA_LIBS="$WRAPPER_COMPILER_LIBS $pmi_LIBS"
+CPPFLAGS="$CPPFLAGS $pmi_CPPFLAGS $opal_external_pmix_CPPFLAGS"
+LDFLAGS="$LDFLAGS $pmi_LDFLAGS $opal_external_pmix_LDFLAGS $aslr_LDFLAGS"
+LIBS="$LIBS $pmi_LIBS $opal_external_pmix_LIBS"
+WRAPPER_COMPILER_EXTRA_LDFLAGS="$WRAPPER_COMPILER_EXTRA_LDFLAGS $pmi_LDFLAGS $opal_external_pmix_LDFLAGS $aslr_LDFLAGS"
+WRAPPER_COMPILER_EXTRA_LIBS="$WRAPPER_COMPILER_LIBS $pmi_LIBS $opal_external_pmix_LIBS"
 
 # Need the libtool binary before setting up rpath
 LT_OUTPUT
@@ -608,7 +611,7 @@ fi
 
 AC_OUTPUT
 
-AS_IF([test "$enable_pmi_simple" != "yes" -a "$ompi_check_pmi_happy" != "yes" -a -z "$pmi_type"],
+AS_IF([test "$enable_pmi_simple" != "yes" -a "$opal_external_pmix_version_found" != 1 -a "$ompi_check_pmi_happy" != "yes" -a -z "$pmi_type"],
          [AC_MSG_WARN([No PMI found, if build fails consider --enable-pmi-simple or --with-pmi])])
 
 AS_IF([test "$transport_portals4" != "yes" -a "$transport_xpmem" != "yes" -a "$transport_cma" != "yes" -a "$transport_ofi" != "yes"],

--- a/configure.ac
+++ b/configure.ac
@@ -617,6 +617,10 @@ AS_IF([test "$enable_pmi_simple" != "yes" -a "$opal_external_pmix_version_found"
 AS_IF([test "$transport_portals4" != "yes" -a "$transport_xpmem" != "yes" -a "$transport_cma" != "yes" -a "$transport_ofi" != "yes"],
       [AC_MSG_WARN([No transport found])])
 
+#Note: The --with-pmix flag is not currently marked as experimental in
+#      --help, because the AC_HELP string is set in upstream OMPI.
+AS_IF([test "$opal_external_pmix_happy" = "yes"],
+      [AC_MSG_WARN([PMIx is an experimental feature in Sandia OpenSHMEM])])
 
 FORT="$FC"
 if test "$FORT" = "" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -316,6 +316,10 @@ AC_ARG_ENABLE([pmi-simple], [AC_HELP_STRING([--enable-pmi-simple],
 AS_IF([test "$enable_pmi_simple" = "yes"],
      [TEST_RUNNER='$(abs_top_builddir)/src/oshrun -n $(NPROCS)'],
      [OPAL_CHECK_PMI(pmi_type)])
+AS_IF([test "$opal_external_pmix_version_found" = 1],
+     [pmi_CPPFLAGS="$opal_external_pmix_CPPFLAGS"
+      pmi_LDFLAGS="$opal_external_pmix_LDFLAGS"
+      pmi_LIBS="$opal_external_pmix_LIBS"])
 AM_CONDITIONAL([USE_PMI_SIMPLE], [test "$enable_pmi_simple" = "yes"])
 AM_CONDITIONAL([USE_PMI2], [test "$pmi_type" = "pmi2"])
 AM_CONDITIONAL([USE_PMIX], [test "$opal_external_pmix_version_found" = 1])
@@ -566,11 +570,11 @@ if test "$transport_xpmem" = "yes" ; then
     WRAPPER_COMPILER_EXTRA_LIBS="$XPMEM_LIBS"
 fi
 
-CPPFLAGS="$CPPFLAGS $pmi_CPPFLAGS $opal_external_pmix_CPPFLAGS"
-LDFLAGS="$LDFLAGS $pmi_LDFLAGS $opal_external_pmix_LDFLAGS $aslr_LDFLAGS"
-LIBS="$LIBS $pmi_LIBS $opal_external_pmix_LIBS"
-WRAPPER_COMPILER_EXTRA_LDFLAGS="$WRAPPER_COMPILER_EXTRA_LDFLAGS $pmi_LDFLAGS $opal_external_pmix_LDFLAGS $aslr_LDFLAGS"
-WRAPPER_COMPILER_EXTRA_LIBS="$WRAPPER_COMPILER_LIBS $pmi_LIBS $opal_external_pmix_LIBS"
+CPPFLAGS="$CPPFLAGS $pmi_CPPFLAGS"
+LDFLAGS="$LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
+LIBS="$LIBS $pmi_LIBS"
+WRAPPER_COMPILER_EXTRA_LDFLAGS="$WRAPPER_COMPILER_EXTRA_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
+WRAPPER_COMPILER_EXTRA_LIBS="$WRAPPER_COMPILER_LIBS $pmi_LIBS"
 
 # Need the libtool binary before setting up rpath
 LT_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,14 +112,18 @@ endif
 
 if USE_PMI_SIMPLE
 AM_CPPFLAGS += -I$(top_srcdir)/pmi-simple
+libsma_la_SOURCES += \
+	runtime-pmi.c
 endif
 
 if USE_PMI2
 libsma_la_SOURCES += \
 	runtime-pmi2.c
-else
+endif
+
+if USE_PMIX
 libsma_la_SOURCES += \
-	runtime-pmi.c
+	runtime-pmix.c
 endif
 
 

--- a/src/init.c
+++ b/src/init.c
@@ -301,7 +301,9 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     }
 
     /* finish up */
+#ifndef USE_PMIX
     shmem_runtime_barrier();
+#endif
     return;
 
  cleanup:

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -47,8 +47,7 @@ shmem_runtime_init(void)
 
     if (!initialized) {
         if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
-
-            fprintf(stderr, "PMIx_Init failed\n");
+            RETURN_ERROR_MSG_PREINIT("PMIx_Init failed (%d)\n", rc);
             return rc;
         }
     }
@@ -61,8 +60,7 @@ shmem_runtime_init(void)
         PMIX_VALUE_RELEASE(val);
     }
     else {
-        fprintf(stderr, "Size is not properly initiated\n");
-
+        RETURN_ERROR_MSG_PREINIT("Size is not properly initiated (%d)\n", rc);
         return rc;
     }
 
@@ -76,8 +74,7 @@ shmem_runtime_fini(void)
     pmix_status_t rc;
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "PMIx_Finalize failed\n");
-
+        RETURN_ERROR_MSG_PREINIT("PMIx_Finalize failed (%d)\n", rc);
         return rc;
     }
 
@@ -97,7 +94,7 @@ shmem_runtime_abort(int exit_code, const char msg[])
     pmix_status_t rc;
 
     if (PMIX_SUCCESS != (rc = PMIx_Abort(exit_code, msg, NULL, 0))) {
-        fprintf(stderr, "PMIx_Abort failed");
+        RETURN_ERROR_STR("PMIx_Abort failed");
     }
 
     /* PMI_Abort should not return */
@@ -138,7 +135,7 @@ shmem_runtime_exchange(void)
 
     /* commit any values we "put" */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        fprintf(stderr, "PMIx_Commit failed\n");
+        RETURN_ERROR_MSG("PMIx_Commit failed (%d)\n", rc);
         return rc;
     }
 
@@ -150,10 +147,10 @@ shmem_runtime_exchange(void)
     // ing capabilities. The commented out call function above, the commented
     // variable "bool active," and the PMIx_Fence_nb if-statement are here for
     // when that is ready. Current implementations will cause the test to hang.
-    
+
     // if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, &info, 1, opcbfunc, &active))) {
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
-        fprintf(stderr, "PMIx_Fence failed");
+        RETURN_ERROR_MSG("PMIx_Fence failed (%d)\n", rc);
     }
     PMIX_INFO_DESTRUCT(&info);
 

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -1,0 +1,232 @@
+/* -*- C -*-
+ *
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
+ * retains certain rights in this software.
+ *
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+/*
+ * Wrappers to interface with PMI runtime
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#if defined(PMI_PORTALS4)
+#include <portals4/pmi.h>
+#else
+#include <pmix.h>
+#endif
+
+#include "runtime.h"
+#include "shmem_internal.h"
+#include "uthash.h"
+
+static pmix_proc_t myproc;
+static size_t size;
+
+int
+shmem_runtime_init(void)
+{
+    printf("HELLO FROM PMIX\n");
+
+    pmix_status_t rc;
+    pmix_proc_t proc;
+    proc.rank = PMIX_RANK_WILDCARD;
+    pmix_value_t *val;
+
+    int initialized = PMIx_Initialized();
+
+    if (!initialized) {
+        if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+
+            fprintf(stderr, "PMIx_Init failed\n");
+            return rc;
+        }
+        // else {
+        //     pmix_output_verbose(stderr, pmix_globals.debug_output,
+        //     "PMIx_Init executed successfully");
+        // }
+    }
+
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        size = val->data.uint32;
+        PMIX_VALUE_RELEASE(val);
+    }
+    else {
+        fprintf(stderr, "Size is not properly initiated\n");
+
+        return rc;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+int
+shmem_runtime_fini(void)
+{
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "PMIx_Finalize failed\n");
+
+        return rc;
+    }
+    // else{
+    //     pmix_output_verbose(stderr, pmix_globals.debug_output,
+    //         "PMIx_Finalize executed successfully");
+    // }
+
+    return PMIX_SUCCESS;
+}
+
+
+void
+shmem_runtime_abort(int exit_code, const char msg[])
+{
+
+#ifdef HAVE___BUILTIN_TRAP
+    if (shmem_internal_trap_on_abort)
+        __builtin_trap();
+#endif
+
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Abort(exit_code, msg, NULL, 0))) {
+        fprintf(stderr, "PMIx_Abort failed");
+    }
+    // else{
+    //     pmix_output_verbose(stderr, pmix_globals.debug_output,
+    //         "PMIx_Abort executed successfully");
+    // }
+
+    /* PMI_Abort should not return */
+    abort();
+
+}
+
+
+
+int
+shmem_runtime_get_rank(void)
+{
+    return myproc.rank;
+}
+
+
+int
+shmem_runtime_get_size(void)
+{
+    return size;
+}
+
+// static void opcbfunc(pmix_status_t status, void *cbdata)
+// {
+//     bool *active = (bool*)cbdata;
+
+//     fprintf(stderr, "%s:%d completed fence_nb", myproc.nspace, myproc.rank);
+//     *active = false;
+// }
+
+int
+shmem_runtime_exchange(void)
+{
+    pmix_status_t rc;
+    pmix_info_t info;
+    bool wantit=true;
+    pmix_proc_t proc;
+    bool active = true;
+
+    /* commit any values we "put" */
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "PMIx_Commit failed\n");
+        return rc;
+    }
+
+    /* execute a fence, directing that all info be exchanged */
+    PMIX_INFO_CONSTRUCT(&info);
+    PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &wantit, PMIX_BOOL);
+
+    // Future optimization for when 
+    // if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, &info, 1, opcbfunc, &active))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
+        fprintf(stderr, "PMIx_Fence failed");
+    }
+    PMIX_INFO_DESTRUCT(&info);
+
+    return rc;
+}
+
+
+int
+shmem_runtime_put(char *key, void *value, size_t valuelen)
+{
+    pmix_value_t val;
+    pmix_status_t rc;
+
+    PMIX_VALUE_CONSTRUCT(&val);
+    val.type = PMIX_BYTE_OBJECT;
+    val.data.bo.bytes = value;
+    val.data.bo.size = valuelen;
+
+    rc = PMIx_Put(PMIX_GLOBAL, key, &val);
+    val.data.bo.bytes = NULL;  // protect the data
+    val.data.bo.size = 0;
+    PMIX_VALUE_DESTRUCT(&val);
+
+    return rc;
+}
+
+/* I'm assuming you malloc'd a region and are giving me its length */
+int
+shmem_runtime_get(int pe, char *key, void *value, size_t valuelen)
+{
+    pmix_proc_t proc;
+    pmix_value_t *val;
+    pmix_status_t rc;
+
+    /* ensure the region is zero'd out */
+    memset(value, 0, valuelen);
+
+    /* setup the ID of the proc whose info we are getting */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = pe;
+
+    rc = PMIx_Get(&proc, key, NULL, 0, &val);
+
+    if (PMIX_SUCCESS == rc) {
+        if (NULL != val) {
+            /* see if the data fits into the given region */
+            if (valuelen < val->data.bo.size) {
+                PMIX_VALUE_RELEASE(val);
+                return PMIX_ERROR;
+            }
+            /* copy the results across */
+            memcpy(value, val->data.bo.bytes, val->data.bo.size);
+            PMIX_VALUE_RELEASE(val);
+        }
+    }
+
+    return rc;
+}
+
+
+void
+shmem_runtime_barrier(void)
+{
+    PMIx_Fence(NULL, 0, NULL, 0);
+}

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -38,8 +38,6 @@ static size_t size;
 int
 shmem_runtime_init(void)
 {
-    printf("HELLO FROM PMIX\n");
-
     pmix_status_t rc;
     pmix_proc_t proc;
     proc.rank = PMIX_RANK_WILDCARD;
@@ -53,10 +51,6 @@ shmem_runtime_init(void)
             fprintf(stderr, "PMIx_Init failed\n");
             return rc;
         }
-        // else {
-        //     pmix_output_verbose(stderr, pmix_globals.debug_output,
-        //     "PMIx_Init executed successfully");
-        // }
     }
 
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
@@ -86,10 +80,6 @@ shmem_runtime_fini(void)
 
         return rc;
     }
-    // else{
-    //     pmix_output_verbose(stderr, pmix_globals.debug_output,
-    //         "PMIx_Finalize executed successfully");
-    // }
 
     return PMIX_SUCCESS;
 }
@@ -100,7 +90,7 @@ shmem_runtime_abort(int exit_code, const char msg[])
 {
 
 #ifdef HAVE___BUILTIN_TRAP
-    if (shmem_internal_trap_on_abort)
+    if (shmem_internal_params.TRAP_ON_ABORT)
         __builtin_trap();
 #endif
 
@@ -109,10 +99,6 @@ shmem_runtime_abort(int exit_code, const char msg[])
     if (PMIX_SUCCESS != (rc = PMIx_Abort(exit_code, msg, NULL, 0))) {
         fprintf(stderr, "PMIx_Abort failed");
     }
-    // else{
-    //     pmix_output_verbose(stderr, pmix_globals.debug_output,
-    //         "PMIx_Abort executed successfully");
-    // }
 
     /* PMI_Abort should not return */
     abort();
@@ -148,8 +134,7 @@ shmem_runtime_exchange(void)
     pmix_status_t rc;
     pmix_info_t info;
     bool wantit=true;
-    pmix_proc_t proc;
-    bool active = true;
+    //bool active = true;
 
     /* commit any values we "put" */
     if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
@@ -161,7 +146,11 @@ shmem_runtime_exchange(void)
     PMIX_INFO_CONSTRUCT(&info);
     PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &wantit, PMIX_BOOL);
 
-    // Future optimization for when 
+    // Future optimization for when fabrics are ready to support the non-block-
+    // ing capabilities. The commented out call function above, the commented
+    // variable "bool active," and the PMIx_Fence_nb if-statement are here for
+    // when that is ready. Current implementations will cause the test to hang.
+    
     // if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, &info, 1, opcbfunc, &active))) {
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
         fprintf(stderr, "PMIx_Fence failed");

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -119,6 +119,19 @@ extern long shmem_internal_data_length;
     } while (0)
 
 
+#define RETURN_ERROR_MSG_PREINIT(...)                                   \
+    do {                                                                \
+        char str[256];                                                  \
+        size_t off;                                                     \
+        off = snprintf(str, sizeof(str), "[????] ERROR: %s:%d: %s\n",   \
+                       __FILE__, __LINE__, __func__);                   \
+        off+= snprintf(str+off, sizeof(str)-off, RAISE_PE_PREFIX,       \
+                       shmem_internal_my_pe);                           \
+        off+= snprintf(str+off, sizeof(str)-off, __VA_ARGS__);          \
+        fprintf(stderr, "%s", str);                                     \
+    } while (0)
+
+
 #define DEBUG_STR(str)                                                  \
     do {                                                                \
         if(shmem_internal_params.DEBUG) {                               \


### PR DESCRIPTION
This PR adds a new `runtime-pmix.c` file which uses the PMIx interface (courtesy of @rhc54 and @angelali4096).  It also incorporates the upstream (OMPI) m4 script for PMI detection, including the `--with-pmix` flag.  Finally, it includes a build of OpenMPI 3.0.x in Travis CI (via RPM) to execute the SOS unit tests using the OMPI (mpiexec) launcher running on top of PMIx.