### PR TITLE
Ignore deprecated decls for now in Travis (AMO's)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ compiler:
 env:
     global:
         - TRAVIS_PAR_MAKE="-j 4"
-        - SOS_GLOBAL_BUILD_OPTS="--enable-picky --enable-pmi-simple FCFLAGS=-fcray-pointer"
+        - SOS_GLOBAL_BUILD_OPTS="--enable-picky --enable-pmi-simple FCFLAGS=-fcray-pointer CFLAGS=-Wno-deprecated-declarations CXXFLAGS=-Wno-deprecated-declarations"
         - PTL_IFACE_NAME=venet0
         - FI_LOG_LEVEL=warn
         - SHMEM_OFI_USE_PROVIDER=sockets


### PR DESCRIPTION
To reduce the large # of unit test warnings in Travis...