### PR TITLE
Duplicate C11 AMO unitests to cover some of shmem_atomic_* interface

### DIFF
--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -308,6 +308,12 @@ define(`SHMEM_C11_GEN_ADD', `               $2*: shmem_$1_add')dnl
 SHMEM_BIND_C11_AMO(`SHMEM_C11_GEN_ADD', `, \') \
             )(dest, value, pe)
 
+define(`SHMEM_C11_GEN_ATOMIC_ADD', `         $2*: shmem_$1_atomic_add')dnl
+#define shmem_atomic_add(dest, value, pe) \
+    _Generic(&*(dest), \
+SHMEM_BIND_C11_AMO(`SHMEM_C11_GEN_ATOMIC_ADD', `, \') \
+            )(dest, value, pe)
+
 define(`SHMEM_C11_GEN_CSWAP', `               $2*: shmem_$1_cswap')dnl
 #define shmem_cswap(dest, cond, value, pe) \
     _Generic(&*(dest), \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -65,13 +65,17 @@ check_PROGRAMS = \
 	alltoall \
 	alltoalls \
 	c11_test_shmem_add \
+	c11_test_shmem_atomic_add \
 	c11_test_shmem_fetch \
+	c11_test_shmem_atomic_fetch \
 	c11_test_shmem_g \
 	c11_test_shmem_get \
 	c11_test_shmem_inc \
+	c11_test_shmem_atomic_inc \
 	c11_test_shmem_p \
 	c11_test_shmem_put \
 	c11_test_shmem_set \
+	c11_test_shmem_atomic_set \
 	get_nbi \
 	put_nbi \
 	rma_coverage \

--- a/test/unit/c11_test_shmem_atomic_add.c
+++ b/test/unit/c11_test_shmem_atomic_add.c
@@ -1,0 +1,81 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+
+#define TEST_SHMEM_ADD(TYPE)                                            \
+  do {                                                                  \
+    static TYPE remote = (TYPE)0;                                       \
+    const int mype = shmem_my_pe();                                     \
+    const int npes = shmem_n_pes();                                     \
+    for (int i = 0; i < npes; i++)                                      \
+      shmem_atomic_add(&remote, (TYPE)(mype + 1), i);                   \
+    shmem_barrier_all();                                                \
+    if (remote != (TYPE)(npes * (npes + 1) / 2)) {                      \
+      fprintf(stderr,                                                   \
+              "PE %i observed error with shmem_atomic_add(%s, ...)\n",  \
+              mype, #TYPE);                                             \
+      rc = EXIT_FAILURE;                                                \
+    }                                                                   \
+  } while (false)
+
+#else
+#define TEST_SHMEM_ADD(TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_ADD(int);
+  TEST_SHMEM_ADD(long);
+  TEST_SHMEM_ADD(long long);
+  TEST_SHMEM_ADD(unsigned int);
+  TEST_SHMEM_ADD(unsigned long);
+  TEST_SHMEM_ADD(unsigned long long);
+  TEST_SHMEM_ADD(int32_t);
+  TEST_SHMEM_ADD(int64_t);
+  TEST_SHMEM_ADD(uint32_t);
+  TEST_SHMEM_ADD(uint64_t);
+  TEST_SHMEM_ADD(size_t);
+  TEST_SHMEM_ADD(ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/unit/c11_test_shmem_atomic_fetch.c
+++ b/test/unit/c11_test_shmem_atomic_fetch.c
@@ -1,0 +1,83 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+
+#define TEST_SHMEM_FETCH(TYPE)                                  \
+  do {                                                          \
+    static TYPE remote;                                         \
+    const int mype = shmem_my_pe();                             \
+    const int npes = shmem_n_pes();                             \
+    remote = (TYPE)mype;                                        \
+    shmem_barrier_all();                                        \
+    TYPE val = shmem_atomic_fetch(&remote, (mype + 1) % npes);  \
+    if (val != (TYPE)((mype + 1) % npes)) {                     \
+      fprintf(stderr,                                           \
+              "PE %i received incorrect value "                 \
+              "for shmem_atomic_fetch(%s, ...)\n", mype, #TYPE);\
+      rc = EXIT_FAILURE;                                        \
+    }                                                           \
+  } while (false)
+
+#else
+#define TEST_SHMEM_FETCH(TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_FETCH(float);
+  TEST_SHMEM_FETCH(double);
+  TEST_SHMEM_FETCH(int);
+  TEST_SHMEM_FETCH(long);
+  TEST_SHMEM_FETCH(long long);
+  TEST_SHMEM_FETCH(unsigned int);
+  TEST_SHMEM_FETCH(unsigned long);
+  TEST_SHMEM_FETCH(unsigned long long);
+  TEST_SHMEM_FETCH(int32_t);
+  TEST_SHMEM_FETCH(int64_t);
+  TEST_SHMEM_FETCH(uint32_t);
+  TEST_SHMEM_FETCH(uint64_t);
+  TEST_SHMEM_FETCH(size_t);
+  TEST_SHMEM_FETCH(ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/unit/c11_test_shmem_atomic_inc.c
+++ b/test/unit/c11_test_shmem_atomic_inc.c
@@ -1,0 +1,81 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+
+#define TEST_SHMEM_INC(TYPE)                                            \
+  do {                                                                  \
+    static TYPE remote = (TYPE)0;                                       \
+    const int mype = shmem_my_pe();                                     \
+    const int npes = shmem_n_pes();                                     \
+    for (int i = 0; i < npes; i++)                                      \
+      shmem_atomic_inc(&remote, i);                                     \
+    shmem_barrier_all();                                                \
+    if (remote != (TYPE)npes) {                                         \
+      fprintf(stderr,                                                   \
+              "PE %i observed error with shmem_atomic_inc(%s, ...)\n",  \
+              mype, #TYPE);                                             \
+      rc = EXIT_FAILURE;                                                \
+    }                                                                   \
+  } while (false)
+
+#else
+#define TEST_SHMEM_INC(TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_INC(int);
+  TEST_SHMEM_INC(long);
+  TEST_SHMEM_INC(long long);
+  TEST_SHMEM_INC(unsigned int);
+  TEST_SHMEM_INC(unsigned long);
+  TEST_SHMEM_INC(unsigned long long);
+  TEST_SHMEM_INC(int32_t);
+  TEST_SHMEM_INC(int64_t);
+  TEST_SHMEM_INC(uint32_t);
+  TEST_SHMEM_INC(uint64_t);
+  TEST_SHMEM_INC(size_t);
+  TEST_SHMEM_INC(ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}

--- a/test/unit/c11_test_shmem_atomic_set.c
+++ b/test/unit/c11_test_shmem_atomic_set.c
@@ -1,0 +1,82 @@
+/*
+ *  This test program is derived from a unit test created by Nick Park.
+ *  The original unit test is a work of the U.S. Government and is not subject
+ *  to copyright protection in the United States.  Foreign copyrights may
+ *  apply.
+ *
+ *  Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <shmem.h>
+
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
+
+#define TEST_SHMEM_SET(TYPE)                                   \
+  do {                                                         \
+    static TYPE remote;                                        \
+    const int mype = shmem_my_pe();                            \
+    const int npes = shmem_n_pes();                            \
+    shmem_atomic_set(&remote, (TYPE)mype, (mype + 1) % npes);  \
+    shmem_barrier_all();                                       \
+    if (remote != (TYPE)((mype + npes - 1) % npes)) {          \
+      fprintf(stderr,                                          \
+              "PE %i received incorrect value "                \
+              "for shmem_atomic_set(%s, ...)\n", mype, #TYPE); \
+      rc = EXIT_FAILURE;                                       \
+    }                                                          \
+  } while (false)
+
+#else
+#define TEST_SHMEM_SET(TYPE)
+
+#endif
+
+int main(int argc, char* argv[]) {
+  shmem_init();
+
+  int rc = EXIT_SUCCESS;
+  TEST_SHMEM_SET(float);
+  TEST_SHMEM_SET(double);
+  TEST_SHMEM_SET(int);
+  TEST_SHMEM_SET(long);
+  TEST_SHMEM_SET(long long);
+  TEST_SHMEM_SET(unsigned int);
+  TEST_SHMEM_SET(unsigned long);
+  TEST_SHMEM_SET(unsigned long long);
+  TEST_SHMEM_SET(int32_t);
+  TEST_SHMEM_SET(int64_t);
+  TEST_SHMEM_SET(uint32_t);
+  TEST_SHMEM_SET(uint64_t);
+  TEST_SHMEM_SET(size_t);
+  TEST_SHMEM_SET(ptrdiff_t);
+
+  shmem_finalize();
+  return rc;
+}


### PR DESCRIPTION
Note that adding these tests revealed that shmem_atomic_add was mistakenly omitted from the new C11 atomics routines :/