### PR TITLE
 Add m4/macros for _ctx_ routines to C bindings

### DIFF
--- a/mpp/shmem_c_func.m4
+++ b/mpp/shmem_c_func.m4
@@ -22,6 +22,10 @@ dnl
 #   endif
 #endif
 
+/* Temporary placeholder to avoid undefined warnings: */
+#define SHMEM_CTX_DEFAULT 0
+typedef int shmem_ctx_t;
+
 /* Library Setup, Exit, and Query Routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_init(void);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_finalize(void);
@@ -48,15 +52,28 @@ define(`SHMEM_C_P',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_p($2 *addr, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_P')
 
+define(`SHMEM_C_CTX_P',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_p(shmem_ctx_t ctx, $2 *addr, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_P')
+
 /* RMA: Contiguous Data Put Routines */
 define(`SHMEM_C_PUT',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_put($2 *target, const $2 *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_PUT')
 
+define(`SHMEM_C_CTX_PUT',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_put(shmem_ctx_t ctx, $2 *target, const $2 *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_PUT')
+
 define(`SHMEM_C_PUT_N',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_put$1(void* target, const void *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_PUT_N')
 SHMEM_C_PUT_N(mem,1);
+
+define(`SHMEM_C_CTX_PUT_N',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_put$1(shmem_ctx_t ctx, void* target, const void *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_PUT_N')
+SHMEM_C_CTX_PUT_N(mem,1);
 
 /* RMA: Strided Put Routines */
 define(`SHMEM_C_IPUT',
@@ -65,26 +82,51 @@ SH_PAD(`$1')                 ptrdiff_t tst, ptrdiff_t sst,
 SH_PAD(`$1')                 size_t len, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_IPUT')
 
+define(`SHMEM_C_CTX_IPUT',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_iput(shmem_ctx_t ctx, $2 *target, const $2 *source,
+SH_PAD(`$1')                 ptrdiff_t tst, ptrdiff_t sst,
+SH_PAD(`$1')                 size_t len, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_IPUT')
+
 define(`SHMEM_C_IPUT_N',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_iput$1(void *target, const void *source,
 SH_PAD(`$1')                ptrdiff_t tst, ptrdiff_t sst, size_t len,
 SH_PAD(`$1')                int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_IPUT_N')
 
+define(`SHMEM_C_CTX_IPUT_N',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_iput$1(shmem_ctx_t ctx, void *target, const void *source,
+SH_PAD(`$1')                ptrdiff_t tst, ptrdiff_t sst, size_t len,
+SH_PAD(`$1')                int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_IPUT_N')
+
 /* RMA: Elemental Data Get Routines */
 define(`SHMEM_C_G',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_g(const $2 *addr, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_G')
+
+define(`SHMEM_C_CTX_G',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_g(shmem_ctx_t ctx, const $2 *addr, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_G')
 
 /* RMA: Contiguous Data Get Routines */
 define(`SHMEM_C_GET',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_get($2 *target, const $2 *source, size_t nelems,int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_GET')
 
+define(`SHMEM_C_CTX_GET',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_get(shmem_ctx_t ctx, $2 *target, const $2 *source, size_t nelems,int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_GET')
+
 define(`SHMEM_C_GET_N',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_get$1(void* target, const void *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_GET_N')
 SHMEM_C_GET_N(mem,1);
+
+define(`SHMEM_C_CTX_GET_N',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_get$1(shmem_ctx_t ctx, void* target, const void *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_GET_N')
+SHMEM_C_CTX_GET_N(mem,1);
 
 /* RMA: Strided Get Routines */
 define(`SHMEM_C_IGET',
@@ -93,40 +135,78 @@ SH_PAD(`$1')                 ptrdiff_t tst, ptrdiff_t sst,
 SH_PAD(`$1')                 size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_IGET')
 
+define(`SHMEM_C_CTX_IGET',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_iget(shmem_ctx_t ctx, $2 *target, const $2 *source,
+SH_PAD(`$1')                 ptrdiff_t tst, ptrdiff_t sst,
+SH_PAD(`$1')                 size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_IGET')
+
 define(`SHMEM_C_IGET_N',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_iget$1(void* target, const void *source,
 SH_PAD(`$1')                ptrdiff_t tst, ptrdiff_t sst,
 SH_PAD(`$1')                size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_IGET_N')
 
+define(`SHMEM_C_CTX_IGET_N',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_iget$1(shmem_ctx_t ctx, void* target, const void *source,
+SH_PAD(`$1')                ptrdiff_t tst, ptrdiff_t sst,
+SH_PAD(`$1')                size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_IGET_N')
+
 /* RMA: Nonblocking Contiguous Data Put Routines */
 define(`SHMEM_C_PUT_NBI',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_put_nbi($2 *target, const $2 *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_PUT_NBI')
+
+define(`SHMEM_C_CTX_PUT_NBI',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_put_nbi(shmem_ctx_t ctx, $2 *target, const $2 *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_PUT_NBI')
 
 define(`SHMEM_C_PUT_N_NBI',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_put$1_nbi(void* target, const void *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_PUT_N_NBI')
 SHMEM_C_PUT_N_NBI(mem,1);
 
+define(`SHMEM_C_CTX_PUT_N_NBI',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_put$1_nbi(shmem_ctx_t ctx, void* target, const void *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_PUT_N_NBI')
+SHMEM_C_CTX_PUT_N_NBI(mem,1);
+
 /* RMA: Nonblocking Contiguous Data Get Routines */
 define(`SHMEM_C_GET_NBI',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_get_nbi($2 *target, const $2 *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_RMA(`SHMEM_C_GET_NBI')
+
+define(`SHMEM_C_CTX_GET_NBI',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_get_nbi(shmem_ctx_t ctx, $2 *target, const $2 *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_RMA(`SHMEM_C_CTX_GET_NBI')
 
 define(`SHMEM_C_GET_N_NBI',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_get$1_nbi(void* target, const void *source, size_t nelems, int pe)')dnl
 SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_GET_N_NBI')
 SHMEM_C_GET_N_NBI(mem,1);
 
+define(`SHMEM_C_CTX_GET_N_NBI',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_get$1_nbi(shmem_ctx_t ctx, void* target, const void *source, size_t nelems, int pe)')dnl
+SHMEM_DECLARE_FOR_SIZES(`SHMEM_C_CTX_GET_N_NBI')
+SHMEM_C_CTX_GET_N_NBI(mem,1);
+
 /* AMO: Atomic Swap Routines */
 define(`SHMEM_C_SWAP',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_swap($2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_SWAP')
 
+define(`SHMEM_C_CTX_SWAP',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_swap(shmem_ctx_t ctx, $2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_SWAP')
+
 define(`SHMEM_C_ATOMIC_SWAP',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_swap($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_ATOMIC_SWAP')
+
+define(`SHMEM_C_CTX_ATOMIC_SWAP',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_swap(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_ATOMIC_SWAP')
 
 /* Special case, only enabled when C++ and C11 bindings are disabled */
 #if !defined(__cplusplus) && \
@@ -139,89 +219,169 @@ define(`SHMEM_C_CSWAP',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_cswap($2 *target, $2 cond, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CSWAP')
 
+define(`SHMEM_C_CTX_CSWAP',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_cswap(shmem_ctx_t ctx, $2 *target, $2 cond, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_CSWAP')
+
 define(`SHMEM_C_ATOMIC_COMPARE_SWAP',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_compare_swap($2 *target, $2 cond, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ATOMIC_COMPARE_SWAP')
+
+define(`SHMEM_C_CTX_ATOMIC_COMPARE_SWAP',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_compare_swap(shmem_ctx_t ctx, $2 *target, $2 cond, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ATOMIC_COMPARE_SWAP')
 
 /* AMO: Atomic Fetch-and-Add Routines */
 define(`SHMEM_C_FADD',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_fadd($2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_FADD')
 
+define(`SHMEM_C_CTX_FADD',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_fadd(shmem_ctx_t ctx, $2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_FADD')
+
 define(`SHMEM_C_ATOMIC_FETCH_ADD',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch_add($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ATOMIC_FETCH_ADD')
+
+define(`SHMEM_C_CTX_ATOMIC_FETCH_ADD',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch_add(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ATOMIC_FETCH_ADD')
 
 /* AMO: Atomic Fetch-and-Increment Routines */
 define(`SHMEM_C_FINC',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_finc($2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_FINC')
 
+define(`SHMEM_C_CTX_FINC',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_finc(shmem_ctx_t ctx, $2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_FINC')
+
 define(`SHMEM_C_ATOMIC_FETCH_INC',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch_inc($2 *target, int pe)')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ATOMIC_FETCH_INC')
+
+define(`SHMEM_C_CTX_ATOMIC_FETCH_INC',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch_inc(shmem_ctx_t ctx, $2 *target, int pe)')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ATOMIC_FETCH_INC')
 
 /* AMO: Atomic Add Routines */
 define(`SHMEM_C_ADD',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_add($2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ADD')
 
+define(`SHMEM_C_CTX_ADD',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_add(shmem_ctx_t ctx, $2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ADD')
+
 define(`SHMEM_C_ATOMIC_ADD',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_add($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ATOMIC_ADD')
+
+define(`SHMEM_C_CTX_ATOMIC_ADD',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_add(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ATOMIC_ADD')
 
 /* AMO: Atomic Increment Routines */
 define(`SHMEM_C_INC',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_inc($2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_INC')
 
+define(`SHMEM_C_CTX_INC',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_inc(shmem_ctx_t ctx, $2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_INC')
+
 define(`SHMEM_C_ATOMIC_INC',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_inc($2 *target, int pe)')dnl
 SHMEM_DECLARE_FOR_AMO(`SHMEM_C_ATOMIC_INC')
+
+define(`SHMEM_C_CTX_ATOMIC_INC',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_inc(shmem_ctx_t ctx, $2 *target, int pe)')dnl
+SHMEM_DECLARE_FOR_AMO(`SHMEM_C_CTX_ATOMIC_INC')
 
 /* AMO: Atomic Fetch Routines */
 define(`SHMEM_C_FETCH',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_fetch(const $2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_FETCH')
 
+define(`SHMEM_C_CTX_FETCH',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_fetch(shmem_ctx_t ctx, const $2 *target, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_FETCH')
+
 define(`SHMEM_C_ATOMIC_FETCH',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch(const $2 *target, int pe)')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_ATOMIC_FETCH')
+
+define(`SHMEM_C_CTX_ATOMIC_FETCH',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch(shmem_ctx_t ctx, const $2 *target, int pe)')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_ATOMIC_FETCH')
 
 /* AMO: Atomic Set Routines */
 define(`SHMEM_C_SET',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_set($2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_SET')
 
+define(`SHMEM_C_CTX_SET',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_set(shmem_ctx_t ctx, $2 *target, $2 value, int pe) SHMEM_ATTRIBUTE_DEPRECATED')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_SET')
+
 /* AMO: Atomic Bitwise Routines */
 define(`SHMEM_C_XOR',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_xor($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_XOR')
 
+define(`SHMEM_C_CTX_XOR',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_xor(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_XOR')
+
 define(`SHMEM_C_AND',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_and($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_AND')
 
+define(`SHMEM_C_CTX_AND',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_and(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_AND')
+
 define(`SHMEM_C_OR',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_or($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_OR')
+
+define(`SHMEM_C_CTX_OR',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_or(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_OR')
 
 /* AMO: Fetching atomic Bitwise Routines */
 define(`SHMEM_C_FETCH_XOR',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch_xor($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_FETCH_XOR')
 
+define(`SHMEM_C_CTX_FETCH_XOR',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch_xor(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_XOR')
+
 define(`SHMEM_C_FETCH_AND',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch_and($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_FETCH_AND')
+
+define(`SHMEM_C_CTX_FETCH_AND',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch_and(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_AND')
 
 define(`SHMEM_C_FETCH_OR',
 `SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_$1_atomic_fetch_or($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_FETCH_OR')
 
+define(`SHMEM_C_CTX_FETCH_OR',
+`SHMEM_FUNCTION_ATTRIBUTES $2 SHPRE()shmem_ctx_$1_atomic_fetch_or(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_OR')
+
 define(`SHMEM_C_ATOMIC_SET',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_atomic_set($2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_ATOMIC_SET')
+
+define(`SHMEM_C_CTX_ATOMIC_SET',
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_set(shmem_ctx_t ctx, $2 *target, $2 value, int pe)')dnl
+SHMEM_DECLARE_FOR_EXTENDED_AMO(`SHMEM_C_CTX_ATOMIC_SET')
 
 /* COLL: Barrier Synchronization Routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync);

--- a/src/atomic_c.c4
+++ b/src/atomic_c.c4
@@ -37,10 +37,20 @@ define(`SHMEM_PROF_DEF_SWAP',
 #define shmem_$1_swap pshmem_$1_swap')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_SWAP')
 
+define(`SHMEM_PROF_DEF_CTX_SWAP',
+`#pragma weak shmem_ctx_$1_swap = pshmem_ctx_$1_swap
+#define shmem_ctx_$1_swap pshmem_ctx_$1_swap')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_SWAP')
+
 define(`SHMEM_PROF_DEF_ATOMIC_SWAP',
 `#pragma weak shmem_$1_atomic_swap = pshmem_$1_atomic_swap
 #define shmem_$1_atomic_swap pshmem_$1_atomic_swap')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_ATOMIC_SWAP')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_SWAP',
+`#pragma weak shmem_ctx_$1_atomic_swap = pshmem_ctx_$1_atomic_swap
+#define shmem_ctx_$1_atomic_swap pshmem_ctx_$1_atomic_swap')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_SWAP')
 
 #if !defined(__cplusplus) && \
     !(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
@@ -54,107 +64,212 @@ define(`SHMEM_PROF_DEF_CSWAP',
 #define shmem_$1_cswap pshmem_$1_cswap')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CSWAP')
 
+define(`SHMEM_PROF_DEF_CTX_CSWAP',
+`#pragma weak shmem_ctx_$1_cswap = pshmem_ctx_$1_cswap
+#define shmem_ctx_$1_cswap pshmem_ctx_$1_cswap')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_CSWAP')
+
 define(`SHMEM_PROF_DEF_ATOMIC_COMPARE_SWAP',
 `#pragma weak shmem_$1_atomic_compare_swap = pshmem_$1_atomic_compare_swap
 #define shmem_$1_atomic_compare_swap pshmem_$1_atomic_compare_swap')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ATOMIC_COMPARE_SWAP')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_COMPARE_SWAP',
+`#pragma weak shmem_ctx_$1_atomic_compare_swap = pshmem_ctx_$1_atomic_compare_swap
+#define shmem_ctx_$1_atomic_compare_swap pshmem_ctx_$1_atomic_compare_swap')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_COMPARE_SWAP')
 
 define(`SHMEM_PROF_DEF_INC',
 `#pragma weak shmem_$1_inc = pshmem_$1_inc
 #define shmem_$1_inc pshmem_$1_inc')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_INC')
 
+define(`SHMEM_PROF_DEF_CTX_INC',
+`#pragma weak shmem_ctx_$1_inc = pshmem_ctx_$1_inc
+#define shmem_ctx_$1_inc pshmem_ctx_$1_inc')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_INC')
+
 define(`SHMEM_PROF_DEF_ATOMIC_INC',
 `#pragma weak shmem_$1_atomic_inc = pshmem_$1_atomic_inc
 #define shmem_$1_atomic_inc pshmem_$1_atomic_inc')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ATOMIC_INC')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_INC',
+`#pragma weak shmem_ctx_$1_atomic_inc = pshmem_ctx_$1_atomic_inc
+#define shmem_ctx_$1_atomic_inc pshmem_ctx_$1_atomic_inc')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_INC')
 
 define(`SHMEM_PROF_DEF_FINC',
 `#pragma weak shmem_$1_finc = pshmem_$1_finc
 #define shmem_$1_finc pshmem_$1_finc')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_FINC')
 
+define(`SHMEM_PROF_DEF_CTX_FINC',
+`#pragma weak shmem_ctx_$1_finc = pshmem_ctx_$1_finc
+#define shmem_ctx_$1_finc pshmem_ctx_$1_finc')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_FINC')
+
 define(`SHMEM_PROF_DEF_ATOMIC_FETCH_INC',
 `#pragma weak shmem_$1_atomic_fetch_inc = pshmem_$1_atomic_fetch_inc
 #define shmem_$1_atomic_fetch_inc pshmem_$1_atomic_fetch_inc')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ATOMIC_FETCH_INC')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_INC',
+`#pragma weak shmem_ctx_$1_atomic_fetch_inc = pshmem_ctx_$1_atomic_fetch_inc
+#define shmem_ctx_$1_atomic_fetch_inc pshmem_ctx_$1_atomic_fetch_inc')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_INC')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_INC',
+`#pragma weak shmem_ctx_$1_atomic_fetch_inc = pshmem_ctx_$1_atomic_fetch_inc
+#define shmem_ctx_$1_atomic_fetch_inc pshmem_ctx_$1_atomic_fetch_inc')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_INC')
 
 define(`SHMEM_PROF_DEF_ADD',
 `#pragma weak shmem_$1_add = pshmem_$1_add
 #define shmem_$1_add pshmem_$1_add')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ADD')
 
+define(`SHMEM_PROF_DEF_CTX_ADD',
+`#pragma weak shmem_ctx_$1_add = pshmem_ctx_$1_add
+#define shmem_ctx_$1_add pshmem_ctx_$1_add')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ADD')
+
 define(`SHMEM_PROF_DEF_ATOMIC_ADD',
 `#pragma weak shmem_$1_atomic_add = pshmem_$1_atomic_add
 #define shmem_$1_atomic_add pshmem_$1_atomic_add')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ATOMIC_ADD')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_ADD',
+`#pragma weak shmem_ctx_$1_atomic_add = pshmem_ctx_$1_atomic_add
+#define shmem_ctx_$1_atomic_add pshmem_ctx_$1_atomic_add')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_ADD')
 
 define(`SHMEM_PROF_DEF_FADD',
 `#pragma weak shmem_$1_fadd = pshmem_$1_fadd
 #define shmem_$1_fadd pshmem_$1_fadd')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_FADD')
 
+define(`SHMEM_PROF_DEF_CTX_FADD',
+`#pragma weak shmem_ctx_$1_fadd = pshmem_ctx_$1_fadd
+#define shmem_ctx_$1_fadd pshmem_ctx_$1_fadd')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_FADD')
+
 define(`SHMEM_PROF_DEF_ATOMIC_FETCH_ADD',
 `#pragma weak shmem_$1_atomic_fetch_add = pshmem_$1_atomic_fetch_add
 #define shmem_$1_atomic_fetch_add pshmem_$1_atomic_fetch_add')dnl
 SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_ATOMIC_FETCH_ADD')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_ADD',
+`#pragma weak shmem_ctx_$1_atomic_fetch_add = pshmem_ctx_$1_atomic_fetch_add
+#define shmem_ctx_$1_atomic_fetch_add pshmem_ctx_$1_atomic_fetch_add')dnl
+SHMEM_DEFINE_FOR_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH_ADD')
 
 define(`SHMEM_PROF_DEF_FETCH',
 `#pragma weak shmem_$1_fetch = pshmem_$1_fetch
 #define shmem_$1_fetch pshmem_$1_fetch')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_FETCH')
 
+define(`SHMEM_PROF_DEF_CTX_FETCH',
+`#pragma weak shmem_ctx_$1_fetch = pshmem_ctx_$1_fetch
+#define shmem_ctx_$1_fetch pshmem_ctx_$1_fetch')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_FETCH')
+
 define(`SHMEM_PROF_DEF_ATOMIC_FETCH',
 `#pragma weak shmem_$1_atomic_fetch = pshmem_$1_atomic_fetch
 #define shmem_$1_atomic_fetch pshmem_$1_atomic_fetch')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_ATOMIC_FETCH')
+
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH',
+`#pragma weak shmem_ctx_$1_atomic_fetch = pshmem_ctx_$1_atomic_fetch
+#define shmem_ctx_$1_atomic_fetch pshmem_ctx_$1_atomic_fetch')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_FETCH')
 
 define(`SHMEM_PROF_DEF_SET',
 `#pragma weak shmem_$1_set = pshmem_$1_set
 #define shmem_$1_set pshmem_$1_set')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_SET')
 
+define(`SHMEM_PROF_DEF_CTX_SET',
+`#pragma weak shmem_ctx_$1_set = pshmem_ctx_$1_set
+#define shmem_ctx_$1_set pshmem_ctx_$1_set')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_SET')
+
 define(`SHMEM_PROF_DEF_AND',
 `#pragma weak shmem_$1_atomic_and = pshmem_$1_atomic_and
 #define shmem_$1_atomic_and pshmem_$1_atomic_and')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_AND')
+
+define(`SHMEM_PROF_DEF_CTX_AND',
+`#pragma weak shmem_ctx_$1_atomic_and = pshmem_ctx_$1_atomic_and
+#define shmem_ctx_$1_atomic_and pshmem_ctx_$1_atomic_and')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_AND')
 
 define(`SHMEM_PROF_DEF_FETCH_AND',
 `#pragma weak shmem_$1_atomic_fetch_and = pshmem_$1_atomic_fetch_and
 #define shmem_$1_atomic_fetch_and pshmem_$1_atomic_fetch_and ')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_FETCH_AND')
 
+define(`SHMEM_PROF_DEF_CTX_FETCH_AND',
+`#pragma weak shmem_ctx_$1_atomic_fetch_and = pshmem_ctx_$1_atomic_fetch_and
+#define shmem_ctx_$1_atomic_fetch_and pshmem_ctx_$1_atomic_fetch_and ')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_AND')
+
 define(`SHMEM_PROF_DEF_OR',
 `#pragma weak shmem_$1_atomic_or = pshmem_$1_atomic_or
 #define shmem_$1_atomic_or pshmem_$1_atomic_or')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_OR')
+
+define(`SHMEM_PROF_DEF_CTX_OR',
+`#pragma weak shmem_ctx_$1_atomic_or = pshmem_ctx_$1_atomic_or
+#define shmem_ctx_$1_atomic_or pshmem_ctx_$1_atomic_or')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_OR')
 
 define(`SHMEM_PROF_DEF_FETCH_OR',
 `#pragma weak shmem_$1_atomic_fetch_or = pshmem_$1_atomic_fetch_or
 #define shmem_$1_atomic_fetch_or pshmem_$1_atomic_fetch_or')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_FETCH_OR')
 
+define(`SHMEM_PROF_DEF_CTX_FETCH_OR',
+`#pragma weak shmem_ctx_$1_atomic_fetch_or = pshmem_ctx_$1_atomic_fetch_or
+#define shmem_ctx_$1_atomic_fetch_or pshmem_ctx_$1_atomic_fetch_or')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_OR')
+
 define(`SHMEM_PROF_DEF_XOR',
 `#pragma weak shmem_$1_atomic_xor = pshmem_$1_atomic_xor
 #define shmem_$1_atomic_xor pshmem_$1_atomic_xor')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_XOR')
+
+define(`SHMEM_PROF_DEF_CTX_XOR',
+`#pragma weak shmem_ctx_$1_atomic_xor = pshmem_ctx_$1_atomic_xor
+#define shmem_ctx_$1_atomic_xor pshmem_ctx_$1_atomic_xor')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_XOR')
 
 define(`SHMEM_PROF_DEF_FETCH_XOR',
 `#pragma weak shmem_$1_atomic_fetch_xor = pshmem_$1_atomic_fetch_xor
 #define shmem_$1_atomic_fetch_xor pshmem_$1_atomic_fetch_xor')dnl
 SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_FETCH_XOR')
 
+define(`SHMEM_PROF_DEF_CTX_FETCH_XOR',
+`#pragma weak shmem_ctx_$1_atomic_fetch_xor = pshmem_ctx_$1_atomic_fetch_xor
+#define shmem_ctx_$1_atomic_fetch_xor pshmem_ctx_$1_atomic_fetch_xor')dnl
+SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR')
+
 define(`SHMEM_PROF_DEF_ATOMIC_SET',
 `#pragma weak shmem_$1_atomic_set = pshmem_$1_atomic_set
 #define shmem_$1_atomic_set pshmem_$1_atomic_set')dnl
 SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_ATOMIC_SET')
 
+define(`SHMEM_PROF_DEF_CTX_ATOMIC_SET',
+`#pragma weak shmem_ctx_$1_atomic_set = pshmem_ctx_$1_atomic_set
+#define shmem_ctx_$1_atomic_set pshmem_ctx_$1_atomic_set')dnl
+SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_SET')
+
 #endif /* ENABLE_PROFILING */
+
 
 #define SHMEM_DEF_SWAP(STYPE,TYPE,ITYPE)                        \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                              \
-    shmem_##STYPE##_swap(TYPE *target, TYPE value, int pe)      \
-    {                                                           \
+    FUNC_PROTOTYPE(STYPE##_swap, TYPE *target, TYPE value, int pe)      \
         TYPE newval;                                            \
         SHMEM_ERR_CHECK_INITIALIZED();                          \
         SHMEM_ERR_CHECK_PE(pe);                                 \
@@ -165,12 +280,10 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_ATOMIC_SET')
         return newval;                                          \
     }
 
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SWAP)
 
 #define SHMEM_DEF_ATOMIC_SWAP(STYPE,TYPE,ITYPE)                 \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                              \
-    shmem_##STYPE##_atomic_swap(TYPE *target, TYPE value, int pe)\
-    {                                                           \
+    FUNC_PROTOTYPE(STYPE##_atomic_swap, TYPE *target, TYPE value, int pe)\
         TYPE newval;                                            \
         SHMEM_ERR_CHECK_INITIALIZED();                          \
         SHMEM_ERR_CHECK_PE(pe);                                 \
@@ -180,8 +293,6 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SWAP)
         shmem_internal_get_wait();                              \
         return newval;                                          \
     }
-
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SWAP)
 
 
 #if !defined(__cplusplus) && \
@@ -205,9 +316,8 @@ shmem_swap(long *target, long value, int pe)
 
 #define SHMEM_DEF_CSWAP(STYPE,TYPE,ITYPE)                               \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_cswap(TYPE *target, TYPE cond, TYPE value,          \
+    FUNC_PROTOTYPE(STYPE##_cswap, TYPE *target, TYPE cond, TYPE value,          \
                                int pe)                                  \
-    {                                                                   \
         TYPE newval;                                                    \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -218,13 +328,11 @@ shmem_swap(long *target, long value, int pe)
         return newval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_CSWAP)
 
 #define SHMEM_DEF_ATOMIC_COMPARE_SWAP(STYPE,TYPE,ITYPE)                 \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_compare_swap(TYPE *target, TYPE cond, TYPE value, \
+    FUNC_PROTOTYPE(STYPE##_atomic_compare_swap, TYPE *target, TYPE cond, TYPE value, \
                                int pe)                                  \
-    {                                                                   \
         TYPE newval;                                                    \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -235,12 +343,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_CSWAP)
         return newval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_COMPARE_SWAP)
 
 #define SHMEM_DEF_INC(STYPE,TYPE,ITYPE)                                 \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_inc(TYPE *target, int pe)                           \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_inc, TYPE *target, int pe)                           \
         TYPE tmp = 1;                                                   \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -249,12 +355,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_COMPARE_SWAP)
                                     SHM_INTERNAL_SUM, ITYPE);           \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_INC)
 
 #define SHMEM_DEF_ATOMIC_INC(STYPE,TYPE,ITYPE)                          \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_inc(TYPE *target, int pe)                    \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_inc, TYPE *target, int pe)                    \
         TYPE tmp = 1;                                                   \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -263,12 +367,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_INC)
                                     SHM_INTERNAL_SUM, ITYPE);           \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_INC)
 
 #define SHMEM_DEF_FINC(STYPE,TYPE,ITYPE)                                \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_finc(TYPE *target, int pe)                          \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_finc, TYPE *target, int pe)                          \
         TYPE oldval, tmp = 1;                                           \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -279,12 +381,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_INC)
         return oldval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FINC)
 
 #define SHMEM_DEF_ATOMIC_FETCH_INC(STYPE,TYPE,ITYPE)                    \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_fetch_inc(TYPE *target, int pe)              \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch_inc, TYPE *target, int pe)              \
         TYPE oldval, tmp = 1;                                           \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -295,12 +395,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FINC)
         return oldval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_INC)
 
 #define SHMEM_DEF_ADD(STYPE,TYPE,ITYPE)                                 \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_add(TYPE *target, TYPE value, int pe)               \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_add, TYPE *target, TYPE value, int pe)               \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
@@ -310,12 +408,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_INC)
     }
 
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ADD)
 
 #define SHMEM_DEF_ATOMIC_ADD(STYPE,TYPE,ITYPE)                          \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_add(TYPE *target, TYPE value, int pe)        \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_add, TYPE *target, TYPE value, int pe)        \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
@@ -325,12 +421,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ADD)
     }
 
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_ADD)
 
 #define SHMEM_DEF_FADD(STYPE,TYPE,ITYPE)                                \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_fadd(TYPE *target, TYPE value, int pe)              \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_fadd, TYPE *target, TYPE value, int pe)              \
         TYPE oldval;                                                    \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -342,12 +436,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_ADD)
         return oldval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FADD)
 
 #define SHMEM_DEF_ATOMIC_FETCH_ADD(STYPE,TYPE,ITYPE)                    \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_fetch_add(TYPE *target, TYPE value, int pe)  \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch_add, TYPE *target, TYPE value, int pe)  \
         TYPE oldval;                                                    \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
@@ -359,12 +451,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FADD)
         return oldval;                                                  \
     }
 
-SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_ADD)
 
 #define SHMEM_DEF_FETCH(STYPE,TYPE,ITYPE)                               \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_fetch(const TYPE *source, int pe)                   \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_fetch, const TYPE *source, int pe)                   \
         TYPE val;                                                       \
                                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
@@ -377,12 +467,10 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_ADD)
         return val;                                                     \
     }
 
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_FETCH)
 
 #define SHMEM_DEF_ATOMIC_FETCH(STYPE,TYPE,ITYPE)                        \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_fetch(const TYPE *source, int pe)            \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch, const TYPE *source, int pe)            \
         TYPE val;                                                       \
                                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
@@ -394,14 +482,11 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_FETCH)
         shmem_internal_get_wait();                                      \
         return val;                                                     \
     }
-
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_FETCH)
 
 
 #define SHMEM_DEF_SET(STYPE,TYPE,ITYPE)                                 \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_set(TYPE *dest, TYPE value, int pe)                 \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_set, TYPE *dest, TYPE value, int pe)                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE));                  \
@@ -410,12 +495,10 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_FETCH)
                                   pe, ITYPE);                           \
     }
 
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SET)
 
 #define SHMEM_DEF_ATOMIC_SET(STYPE,TYPE,ITYPE)                          \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_set(TYPE *dest, TYPE value, int pe)          \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_set, TYPE *dest, TYPE value, int pe)          \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE));                  \
@@ -424,12 +507,10 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SET)
                                   pe, ITYPE);                           \
     }
 
-SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SET)
 
 #define SHMEM_DEF_XOR(STYPE,TYPE,ITYPE)                                 \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_xor(TYPE *target, TYPE value, int pe)        \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_xor, TYPE *target, TYPE value, int pe)        \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
@@ -438,12 +519,10 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SET)
                                     SHM_INTERNAL_BXOR, ITYPE);          \
     }
 
-SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_XOR)
 
 #define SHMEM_DEF_AND(STYPE,TYPE,ITYPE)                                 \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_and(TYPE *target, TYPE value, int pe)        \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_and, TYPE *target, TYPE value, int pe)        \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
@@ -452,12 +531,10 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_XOR)
                                     SHM_INTERNAL_BAND, ITYPE);          \
     }
 
-SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_AND)
 
 #define SHMEM_DEF_OR(STYPE,TYPE,ITYPE)                                  \
     void SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_atomic_or(TYPE *target, TYPE value, int pe)         \
-    {                                                                   \
+    FUNC_PROTOTYPE(STYPE##_atomic_or, TYPE *target, TYPE value, int pe)         \
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
@@ -466,12 +543,10 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_AND)
                                     SHM_INTERNAL_BOR, ITYPE);           \
     }
 
-SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_OR)
 
 #define SHMEM_DEF_FETCH_XOR(STYPE,TYPE,ITYPE)                                \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                           \
-    shmem_##STYPE##_atomic_fetch_xor(TYPE *target, TYPE value, int  pe)      \
-    {                                                                        \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch_xor, TYPE *target, TYPE value, int  pe)      \
         TYPE oldval;                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                       \
         SHMEM_ERR_CHECK_PE(pe);                                              \
@@ -483,12 +558,10 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_OR)
         return oldval;                                                       \
     }
 
-SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_XOR)
 
 #define SHMEM_DEF_FETCH_AND(STYPE,TYPE,ITYPE)                                \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                           \
-    shmem_##STYPE##_atomic_fetch_and(TYPE *target, TYPE value, int  pe)      \
-    {                                                                        \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch_and, TYPE *target, TYPE value, int  pe)      \
         TYPE oldval;                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                       \
         SHMEM_ERR_CHECK_PE(pe);                                              \
@@ -500,12 +573,10 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_XOR)
         return oldval;                                                       \
     }
 
-SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_AND)
 
 #define SHMEM_DEF_FETCH_OR(STYPE,TYPE,ITYPE)                                 \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                           \
-    shmem_##STYPE##_atomic_fetch_or(TYPE *target, TYPE value, int  pe)       \
-    {                                                                        \
+    FUNC_PROTOTYPE(STYPE##_atomic_fetch_or, TYPE *target, TYPE value, int  pe)       \
         TYPE oldval;                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                       \
         SHMEM_ERR_CHECK_PE(pe);                                              \
@@ -517,4 +588,58 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_AND)
         return oldval;                                                       \
     }
 
+#define FUNC_PROTOTYPE(FUNCNAME,  ...)        \
+  shmem_##FUNCNAME(__VA_ARGS__) {            \
+  const shmem_ctx_t ctx = SHMEM_CTX_DEFAULT;
+
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SWAP)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_CSWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_COMPARE_SWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FINC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_ADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_ADD)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_FETCH)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_FETCH)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SET)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SET)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_XOR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_AND)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_OR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_XOR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_AND)
 SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_OR)
+
+#undef FUNC_PROTOTYPE
+
+#define FUNC_PROTOTYPE(FUNCNAME,  ...)        \
+  shmem_ctx_##FUNCNAME(shmem_ctx_t ctx, __VA_ARGS__) {
+
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SWAP)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_CSWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_COMPARE_SWAP)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FINC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_INC)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_ADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_FADD)
+SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_ATOMIC_FETCH_ADD)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_FETCH)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_FETCH)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_SET)
+SHMEM_DEFINE_FOR_EXTENDED_AMO(SHMEM_DEF_ATOMIC_SET)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_XOR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_AND)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_OR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_XOR)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_AND)
+SHMEM_DEFINE_FOR_BITWISE_AMO(SHMEM_DEF_FETCH_OR)
+

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -128,20 +128,16 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
 
 #define SHMEM_DEF_P(STYPE,TYPE)                                \
   void SHMEM_FUNCTION_ATTRIBUTES                               \
-  shmem_##STYPE##_p(TYPE *addr, TYPE value, int pe)            \
-  {                                                            \
+  FUNC_PROTOTYPE(STYPE##_p, TYPE *addr, TYPE value, int pe)    \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(addr, sizeof(TYPE));             \
     shmem_internal_put_small(addr, &value, sizeof(TYPE), pe);  \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_P')
-
 #define SHMEM_DEF_G(STYPE,TYPE)                      \
   TYPE SHMEM_FUNCTION_ATTRIBUTES                     \
-  shmem_##STYPE##_g(const TYPE *addr, int pe)        \
-  {                                                  \
+  FUNC_PROTOTYPE(STYPE##_g, const TYPE *addr, int pe)\
     TYPE tmp;                                        \
     SHMEM_ERR_CHECK_INITIALIZED();                   \
     SHMEM_ERR_CHECK_PE(pe);                          \
@@ -151,13 +147,10 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_P')
     return tmp;                                      \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_G')
-
 #define SHMEM_DEF_PUT(STYPE,TYPE)                                \
   void SHMEM_FUNCTION_ATTRIBUTES                                 \
-  shmem_##STYPE##_put(TYPE *target, const TYPE *source,          \
+  FUNC_PROTOTYPE(STYPE##_put, TYPE *target, const TYPE *source,  \
                            size_t nelems, int pe)                \
-  {                                                              \
     long completion = 0;                                         \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
@@ -168,13 +161,11 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_G')
     shmem_internal_put_wait(&completion);                        \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT')
 
 #define SHMEM_DEF_PUT_N(NAME,SIZE)                             \
   void SHMEM_FUNCTION_ATTRIBUTES                               \
-  shmem_put##NAME(void *target, const void *source,            \
+  FUNC_PROTOTYPE(put##NAME, void *target, const void *source,  \
                        size_t nelems, int pe)                  \
-  {                                                            \
     long completion = 0;                                       \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
@@ -185,14 +176,11 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT')
     shmem_internal_put_wait(&completion);                      \
   }
 
-SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N')
-SHMEM_DEF_PUT_N(`mem', `1')
 
 #define SHMEM_DEF_PUT_NBI(STYPE,TYPE)                            \
   void SHMEM_FUNCTION_ATTRIBUTES                                 \
-  shmem_##STYPE##_put_nbi(TYPE *target, const TYPE *source,      \
+  FUNC_PROTOTYPE(STYPE##_put_nbi, TYPE *target, const TYPE *source, \
                                size_t nelems, int pe)            \
-  {                                                              \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
@@ -201,13 +189,11 @@ SHMEM_DEF_PUT_N(`mem', `1')
         pe);                                                     \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT_NBI')
 
 #define SHMEM_DEF_PUT_N_NBI(NAME,SIZE)                         \
   void SHMEM_FUNCTION_ATTRIBUTES                               \
-  shmem_put##NAME##_nbi(void *target, const void *source,      \
+  FUNC_PROTOTYPE(put##NAME##_nbi, void *target, const void *source, \
                              size_t nelems, int pe)            \
-  {                                                            \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
@@ -215,14 +201,11 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT_NBI')
     shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
   }
 
-SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N_NBI')
-SHMEM_DEF_PUT_N_NBI(`mem', `1')
 
 #define SHMEM_DEF_GET(STYPE,TYPE)                             \
   void SHMEM_FUNCTION_ATTRIBUTES                              \
-  shmem_##STYPE##_get(TYPE *target,const TYPE *source,        \
+  FUNC_PROTOTYPE(STYPE##_get, TYPE *target,const TYPE *source,\
                            size_t nelems, int pe)             \
-  {                                                           \
     SHMEM_ERR_CHECK_INITIALIZED();                            \
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems); \
@@ -232,13 +215,11 @@ SHMEM_DEF_PUT_N_NBI(`mem', `1')
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET')
 
 #define SHMEM_DEF_GET_N(NAME,SIZE)                         \
   void SHMEM_FUNCTION_ATTRIBUTES                           \
-  shmem_get##NAME(void *target, const void *source,        \
+  FUNC_PROTOTYPE(get##NAME, void *target, const void *source, \
                        size_t nelems, int pe)              \
-  {                                                        \
     SHMEM_ERR_CHECK_INITIALIZED();                         \
     SHMEM_ERR_CHECK_PE(pe);                                \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);    \
@@ -247,14 +228,11 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET')
     shmem_internal_get_wait();                             \
   }
 
-SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N')
-SHMEM_DEF_GET_N(`mem', `1')
 
 #define SHMEM_DEF_GET_NBI(STYPE,TYPE)                            \
   void SHMEM_FUNCTION_ATTRIBUTES                                 \
-  shmem_##STYPE##_get_nbi(TYPE *target, const TYPE *source,      \
+  FUNC_PROTOTYPE(STYPE##_get_nbi, TYPE *target, const TYPE *source, \
                               size_t nelems, int pe)             \
-  {                                                              \
     SHMEM_ERR_CHECK_INITIALIZED();                               \
     SHMEM_ERR_CHECK_PE(pe);                                      \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems);    \
@@ -262,13 +240,11 @@ SHMEM_DEF_GET_N(`mem', `1')
     shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET_NBI')
 
 #define SHMEM_DEF_GET_N_NBI(NAME,SIZE)                         \
   void SHMEM_FUNCTION_ATTRIBUTES                               \
-  shmem_get##NAME##_nbi(void *target, const void *source,      \
+  FUNC_PROTOTYPE(get##NAME##_nbi, void *target, const void *source, \
                              size_t nelems, int pe)            \
-  {                                                            \
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);        \
@@ -276,15 +252,11 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET_NBI')
     shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
   }
 
-SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N_NBI')
-SHMEM_DEF_GET_N_NBI(`mem', `1')
-
 #define SHMEM_DEF_IPUT(STYPE,TYPE)                            \
   void SHMEM_FUNCTION_ATTRIBUTES                              \
-  shmem_##STYPE##_iput(TYPE *target, const TYPE *source,      \
+  FUNC_PROTOTYPE(STYPE##_iput, TYPE *target, const TYPE *source, \
                             ptrdiff_t tst, ptrdiff_t sst,     \
                             size_t nelems, int pe)            \
-  {                                                           \
     SHMEM_ERR_CHECK_INITIALIZED();                            \
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_POSITIVE(tst);                            \
@@ -299,14 +271,12 @@ SHMEM_DEF_GET_N_NBI(`mem', `1')
     }                                                         \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IPUT')
 
 #define SHMEM_DEF_IPUT_N(NAME,SIZE)                          \
   void SHMEM_FUNCTION_ATTRIBUTES                             \
-  shmem_iput##NAME(void *target, const void *source,         \
+  FUNC_PROTOTYPE(iput##NAME, void *target, const void *source, \
                         ptrdiff_t tst, ptrdiff_t sst,        \
                         size_t nelems, int pe)               \
-  {                                                          \
     SHMEM_ERR_CHECK_INITIALIZED();                           \
     SHMEM_ERR_CHECK_PE(pe);                                  \
     SHMEM_ERR_CHECK_POSITIVE(tst);                           \
@@ -320,14 +290,12 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IPUT')
     }                                                        \
   }
 
-SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IPUT_N')
 
 #define SHMEM_DEF_IGET(STYPE,TYPE)                            \
   void SHMEM_FUNCTION_ATTRIBUTES                              \
-  shmem_##STYPE##_iget(TYPE *target, const TYPE *source,      \
+  FUNC_PROTOTYPE(STYPE##_iget, TYPE *target, const TYPE *source, \
                             ptrdiff_t tst, ptrdiff_t sst,     \
                             size_t nelems, int pe)            \
-  {                                                           \
     SHMEM_ERR_CHECK_INITIALIZED();                            \
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_POSITIVE(tst);                            \
@@ -342,14 +310,11 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IPUT_N')
     shmem_internal_get_wait();                                \
   }
 
-SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IGET')
-
 #define SHMEM_DEF_IGET_N(NAME,SIZE)                       \
   void SHMEM_FUNCTION_ATTRIBUTES                          \
-  shmem_iget##NAME(void *target, const void *source,      \
+  FUNC_PROTOTYPE(iget##NAME, void *target, const void *source, \
                         ptrdiff_t tst, ptrdiff_t sst,     \
                         size_t nelems, int pe)            \
-  {                                                       \
     SHMEM_ERR_CHECK_INITIALIZED();                        \
     SHMEM_ERR_CHECK_PE(pe);                               \
     SHMEM_ERR_CHECK_POSITIVE(tst);                        \
@@ -364,6 +329,51 @@ SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IGET')
     shmem_internal_get_wait();                            \
   }
 
+#define FUNC_PROTOTYPE(FUNCNAME,  ...)        \
+  shmem_##FUNCNAME(__VA_ARGS__) {            \
+  const shmem_ctx_t ctx = SHMEM_CTX_DEFAULT;
+
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_P')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_G')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N')
+SHMEM_DEF_PUT_N(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT_NBI')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N_NBI')
+SHMEM_DEF_PUT_N_NBI(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N')
+SHMEM_DEF_GET_N(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET_NBI')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N_NBI')
+SHMEM_DEF_GET_N_NBI(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IPUT')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IPUT_N')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IGET')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IGET_N')
+
+#undef FUNC_PROTOTYPE
+
+#define FUNC_PROTOTYPE(FUNCNAME,  ...)        \
+  shmem_ctx_##FUNCNAME(shmem_ctx_t ctx, __VA_ARGS__) {
+
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_P')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_G')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N')
+SHMEM_DEF_PUT_N(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_PUT_NBI')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_PUT_N_NBI')
+SHMEM_DEF_PUT_N_NBI(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N')
+SHMEM_DEF_GET_N(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_GET_NBI')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_GET_N_NBI')
+SHMEM_DEF_GET_N_NBI(`mem', `1')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IPUT')
+SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IPUT_N')
+SHMEM_DEFINE_FOR_RMA(`SHMEM_DEF_IGET')
 SHMEM_DEFINE_FOR_SIZES(`SHMEM_DEF_IGET_N')
 
 void SHMEM_FUNCTION_ATTRIBUTES


### PR DESCRIPTION
Adds preliminary C bindings for contexts with dummy definitions for `SHMEM_CTX_DEFAULT` and `shmem_ctx_t`.