### PR TITLE
v1.3 manpage cleanup

### DIFF
--- a/man/_num_pes.3
+++ b/man/_num_pes.3
@@ -1,1 +1,1 @@
-.so shmem_n_pes
+.so shmem_n_pes.3

--- a/man/oshcc.1
+++ b/man/oshcc.1
@@ -24,4 +24,3 @@ usage: oshcc [oshcc_options] [compiler_arguments]
 .TP
 .B -c
 - Compile and assemble. Disable link
-

--- a/man/oshfort.1
+++ b/man/oshfort.1
@@ -24,4 +24,3 @@ usage: oshfort [oshfort_options] [compiler_arguments]
 .TP
 .B -c
 - Compile and assemble. Disable link
-

--- a/man/shfree.3
+++ b/man/shfree.3
@@ -1,1 +1,1 @@
-.so shmem_malloc.3
+.so shmem_free.3

--- a/man/shmem_addr_accessible.3
+++ b/man/shmem_addr_accessible.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ADDR_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ADDR_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_addr_accessible \- 
 Determines whether an address is accessible via OpenSHMEM data transfer
 routines from the specified remote PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B int
 .B shmem_addr_accessible(const
 .B void
@@ -22,58 +17,35 @@ routines from the specified remote PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "LOGICAL " "LOG, SHMEM_ADDR_ACCESSIBLE"
 .BR "INTEGER " "pe"
 LOG = SHMEM_ADDR_ACCESSIBLE(addr, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I addr
 - Data object on the local PE.
-
-
 .BR "IN " -
 .I pe
 - Integer id of a remote PE.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_addr\_accessible
 is a query routine that indicates whether a local
 address is accessible via OpenSHMEM routines from the specified remote PE. 
-
 This routine verifies that the data object is symmetric and accessible with
 respect to a remote PE via OpenSHMEM data transfer routines. The
 specified address 
 .I addr
 is a data object on the local PE. 
-
 This routine may be particularly useful for hybrid programming with other
 communication libraries (such as MPI) or parallel languages. For
 example, in SGI Altix series systems, for multiple executable MPI programs that
@@ -87,37 +59,22 @@ or
 .B shpalloc
 ) is symmetric across the
 same or different executable files.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 C/C++: The return value is 1 if 
 .I addr
 is a symmetric data object
 and accessible via OpenSHMEM routines from the specified remote PE;
 otherwise, it is 0.
-
 Fortran: The return value is .TRUE. if 
 .I addr
 is a symmetric data
 object and accessible via OpenSHMEM routines from the specified remote PE;
 otherwise, it is .FALSE..
-
 ./ sectionEnd
-
 		
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_alltoall.3
+++ b/man/shmem_alltoall.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ALLTOALL 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ALLTOALL 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_alltoall \- 
 shmem\_alltoall is a collective routine where each PE exchanges a fixed amount of data with all other PEs in the
 .IR "Active set" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_alltoall32(void
 .IB "*dest" ,
@@ -32,9 +27,6 @@ shmem\_alltoall is a collective routine where each PE exchanges a fixed amount o
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_alltoall64(void
 .IB "*dest" ,
@@ -52,33 +44,17 @@ shmem\_alltoall is a collective routine where each PE exchanges a fixed amount o
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pSync(SHMEM_ALLTOALL_SYNC_SIZE)"
 .BR "INTEGER " "PE_start, logPE_stride, PE_size, nelems"
 .BR "CALL " "SHMEM_ALLTOALL32(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_ALLTOALL64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -88,9 +64,6 @@ the combined total of
 .I nelems
 elements from each PE in the
 .IR "Active set" .
-
-
-
 .BR "IN " -
 .I source
 - A symmetric data object that contains 
@@ -99,16 +72,12 @@ elements of data for each PE in the
 .I "Active set"
 , ordered according to
 destination PE.
-
-
 .BR "IN " -
 .I nelems
 - The number of elements to exchange for each PE.
 .I nelems
 must be of type size\_t for  C/C++. If you are using
 Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_start
 - The lowest PE number of the 
@@ -118,8 +87,6 @@ PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran,
 it must be a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 - The log (base 2) of the stride between
@@ -128,8 +95,6 @@ consecutive PE numbers in the
 .I logPE\_stride
 must be of
 type integer. If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 - The number of PEs in the 
@@ -137,8 +102,6 @@ type integer. If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must
 be a default integer value.
-
-
 .BR "IN " -
 .I pSync
 - A symmetric work array. In  C/C++, 
@@ -153,12 +116,8 @@ the value SHMEM\_SYNC\_VALUE before any of the PEs in the
 .I "Active set"
 enter the routine.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_alltoall
 routines are collective routines. Each PE
@@ -215,7 +174,6 @@ the
 object of PE 
 .IR "j" .
 .
-
 As with all OpenSHMEM collective routines, this routine assumes
 that only PEs in the 
 .I "Active set"
@@ -224,7 +182,6 @@ in the
 .I "Active set"
 calls an OpenSHMEM collective routine, undefined
 behavior results.
-
 The values of arguments 
 .I nelems
 , 
@@ -245,8 +202,6 @@ data objects, and the same
 work
 array must be passed to all PEs in the 
 .IR "Active set" .
-
-
 Before any PE calls a 
 .B shmem\_alltoall
 routine, the following
@@ -265,7 +220,6 @@ all PEs in the
 is ready to accept the
 .B shmem\_alltoall
 data.
-
 Upon return from a 
 .B shmem\_alltoall
 routine, the following is true for
@@ -278,58 +232,37 @@ data object.
 The values in the 
 .I pSync
 array are restored to the original values.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to certain typing
 constraints, which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_alltoall64
 64 bits aligned.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_alltoall32
 32 bits aligned.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 This routine restores 
 .I pSync
 to its original contents. Multiple calls
@@ -370,40 +303,28 @@ routine call that used the same
 .I pSync
 array. In general, this can be
 ensured only by doing some type of synchronization.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This example shows a 
 .B shmem\_alltoall64
 on two long elements among all
 PEs.
-
 .nf
 #include <stdio.h>
 #include <inttypes.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
   for (int i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
      pSync[i] = SHMEM_SYNC_VALUE;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   const int count = 2;
   int64_t* dest = (int64_t*) shmem_malloc(count * npes * sizeof(int64_t));
   int64_t* source = (int64_t*) shmem_malloc(count * npes * sizeof(int64_t));
-
   /* assign source values */
   for (int pe = 0; pe < npes; pe++) {
      for (int i = 0; i < count; i++) {
@@ -413,10 +334,8 @@ int main(void)
   }
   /* wait for all PEs to update source/dest */
   shmem_barrier_all();
-
   /* alltoall on all PES */
   shmem_alltoall64(dest, source, count, 0, 0, npes, pSync);
-
   /* verify results */
   for (int pe = 0; pe < npes; pe++) {
      for (int i = 0; i < count; i++) {
@@ -426,16 +345,9 @@ int main(void)
           }
       }
   }
-
   shmem_free(dest);
   shmem_free(source);
   shmem_finalize();
   return 0;
 }
 .fi
-
-
-
-
-
-

--- a/man/shmem_alltoalls.3
+++ b/man/shmem_alltoalls.3
@@ -1,21 +1,16 @@
-.TH SHMEM_ALLTOALLS 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ALLTOALLS 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_alltoalls \- 
 shmem\_alltoalls is a collective routine where each PE exchanges a fixed amount of strided data with all other
 PEs in the 
 .IR "Active set" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_alltoalls32(void
 .IB "*dest" ,
@@ -37,9 +32,6 @@ PEs in the
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_alltoalls64(void
 .IB "*dest" ,
@@ -61,34 +53,18 @@ PEs in the
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pSync(SHMEM_ALLTOALLS_SYNC_SIZE)"
 .BR "INTEGER " "dst, sst, PE_start, logPE_stride, PE_size"
 .BR "INTEGER " "nelems"
 .BR "CALL " "SHMEM_ALLTOALLS32(dest, source, dst, sst, nelems, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_ALLTOALLS64(dest, source, dst, sst, nelems, PE_start, logPE_stride, PE_size, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -98,9 +74,6 @@ the combined total of
 .I nelems
 elements from each PE in the
 .IR "Active set" .
-
-
-
 .BR "IN " -
 .I source
 - A symmetric data object that contains 
@@ -109,8 +82,6 @@ elements of data for each PE in the
 .I "Active set"
 , ordered according to 
 destination PE.
-
-
 .BR "IN " -
 .I dst
 - The stride between consecutive elements of the 
@@ -121,8 +92,6 @@ value of 1 indicates contiguous data.
 must be of type
 ptrdiff\_t. If you are using Fortran, it must be a default integer
 value.
-
-
 .BR "IN " -
 .I sst
 - The stride between consecutive elements of the
@@ -133,16 +102,12 @@ A value of 1 indicates contiguous data.
 must be
 of type ptrdiff\_t. If you are using Fortran, it must be a
 default integer value.
-
-
 .BR "IN " -
 .I nelems
 - The number of elements to exchange for each PE.
 .I nelems
 must be of type size\_t for  C/C++. If you are using
 Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_start
 - The lowest PE number of the 
@@ -152,8 +117,6 @@ PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran,
 it must be a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 - The log (base 2) of the stride between
@@ -162,8 +125,6 @@ consecutive PE numbers in the
 .I logPE\_stride
 must be of
 type integer. If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 - The number of PEs in the 
@@ -171,8 +132,6 @@ type integer. If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must
 be a default integer value.
-
-
 .BR "IN " -
 .I pSync
 - A symmetric work array. In  C/C++, 
@@ -187,12 +146,8 @@ the value SHMEM\_SYNC\_VALUE before any of the PEs in the
 .I "Active set"
 enter the routine.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_alltoalls
 routines are collective routines. Each PE
@@ -240,7 +195,6 @@ data object on
 PE 
 .IR "j" .
 .
-
 As with all OpenSHMEM collective routines, these routines assume
 that only PEs in the 
 .I "Active set"
@@ -249,7 +203,6 @@ in the
 .I "Active set"
 calls an OpenSHMEM collective routine, undefined
 behavior results.
-
 The values of arguments 
 .I dst
 , 
@@ -272,8 +225,6 @@ data objects, and the same
 .I pSync
 work array must be passed to all PEs in the 
 .IR "Active set" .
-
-
 Before any PE calls to a 
 .B shmem\_alltoalls
 routine, the following
@@ -292,7 +243,6 @@ all PEs in the
 is ready to accept the
 .B shmem\_alltoalls
 data.
-
 Upon return from a 
 .B shmem\_alltoalls
 routine, the following is true for
@@ -305,58 +255,37 @@ data object.
 The values in the 
 .I pSync
 array are restored to the original values.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to certain typing
 constraints, which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_alltoalls64
 64 bits aligned.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_alltoalls32
 32 bits aligned.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 This routine restores 
 .I pSync
 to its original contents. Multiple calls
@@ -397,42 +326,30 @@ routine call that used the same
 .I pSync
 array. In general, this can be
 ensured only by doing some type of synchronization. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This example shows a 
 .B shmem\_alltoalls64
 on two long elements among
 all PEs.
-
 .nf
 #include <stdio.h>
 #include <inttypes.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long pSync[SHMEM_ALLTOALLS_SYNC_SIZE];
   for (int i = 0; i < SHMEM_ALLTOALLS_SYNC_SIZE; i++)
      pSync[i] = SHMEM_SYNC_VALUE;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   const int count = 2;
   const ptrdiff_t dst = 2;
   const ptrdiff_t sst = 3;
   int64_t* dest = (int64_t*) shmem_malloc(count * dst * npes * sizeof(int64_t));
   int64_t* source = (int64_t*) shmem_malloc(count * sst * npes * sizeof(int64_t));
-
   /* assign source values */
   for (int pe = 0; pe < npes; pe++) {
      for (int i = 0; i < count; i++) {
@@ -442,10 +359,8 @@ int main(void)
   }
   /* wait for all PEs to update source/dest */
   shmem_barrier_all();
-
   /* alltoalls on all PES */
   shmem_alltoalls64(dest, source, dst, sst, count, 0, 0, npes, pSync);
-
   /* verify results */
   for (int pe = 0; pe < npes; pe++) {
      for (int i = 0; i < count; i++) {
@@ -456,15 +371,9 @@ int main(void)
          }
       }
   }
-
   shmem_free(dest);
   shmem_free(source);
   shmem_finalize();
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_atomic_add.3
+++ b/man/shmem_atomic_add.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_ADD 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_ADD 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_add \- 
 Performs an atomic add operation on a remote symmetric data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_add(TYPE
 .IB "*dest" ,
@@ -22,17 +17,11 @@ Performs an atomic add operation on a remote symmetric data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types specified by
 Table 2.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_add(TYPE
 .IB "*dest" ,
@@ -41,34 +30,20 @@ Table 2.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types and has a corresponding
 TYPENAME specified by Table 2.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "value_i4"
 .BR "CALL " "SHMEM_INT4_ADD(dest, value_i4, pe)"
 .BR "INTEGER*8 " "value_i8"
 .BR "CALL " "SHMEM_INT8_ADD(dest, value_i8, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -77,8 +52,6 @@ TYPENAME specified by Table 2.
 updated on the remote PE. If you are using  C/C++, the type of
 .I "dest"
 should match that implied in the SYNOPSIS section.
-
-
 .BR "IN " -
 .I value
 - The value to be atomically added to 
@@ -90,9 +63,6 @@ should match that implied in
 the SYNOPSIS section. If you are using Fortran, it must be of type
 integer with an element size of 
 .IR "dest" .
-
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number upon which
@@ -100,12 +70,8 @@ integer with an element size of
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_atomic\_add
 routine performs an atomic add operation. It adds
@@ -117,75 +83,44 @@ on PE
 and atomically updates the 
 .I "dest"
 without returning the value.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I dest
 must be of the following type:
-
 .TP 25
 Routine
 Data type of 
 .I dest
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_ADD
 4-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_ADD
 8-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_add
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_add" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
-
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static int dst = 22;
@@ -199,11 +134,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 2:
 Standard AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_and.3
+++ b/man/shmem_atomic_and.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ATOMIC_AND 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_AND 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_and \- 
 Atomically perform a non-fetching bitwise AND operation on a
 remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_and(TYPE
 .IB "*dest" ,
@@ -23,17 +18,11 @@ remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_and(TYPE
 .IB "*dest" ,
@@ -42,41 +31,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise AND operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_and
 atomically performs a non-fetching bitwise AND
 on the remotely accessible data object pointed to by 
@@ -86,30 +61,15 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_compare_swap.3
+++ b/man/shmem_atomic_compare_swap.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_COMPARE_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_COMPARE_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_compare_swap \- 
 Performs an atomic conditional swap on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_compare_swap(TYPE
 .IB "*dest" ,
@@ -24,17 +19,11 @@ Performs an atomic conditional swap on a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types specified by
 Table 2.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_compare_swap(TYPE
 .IB "*dest" ,
@@ -45,42 +34,26 @@ Table 2.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types and has a corresponding
 TYPENAME specified by Table 2.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "SHMEM_INT4_CSWAP, cond_i4, value_i4, ires_i4"
 ires_i4 = SHMEM_INT4_CSWAP(dest, cond_i4, value_i4, pe)
 .BR "INTEGER*8 " "SHMEM_INT8_CSWAP, cond_i8, value_i8, ires_i8"
 ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - The remotely accessible integer data object to be
 updated on the remote PE. 
-
-
 .BR "IN " -
 .I cond
 - 
@@ -107,8 +80,6 @@ must be of the same data
 type as 
 .IR "dest" .
 .
-
-
 .BR "IN " -
 .I value
 - The value to be atomically written to the remote
@@ -117,8 +88,6 @@ PE.
 must be the same data type as 
 .IR "dest" .
 .
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number upon which
@@ -126,99 +95,65 @@ must be the same data type as
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The conditional swap routines conditionally update a 
 .I dest
 data object on
 the specified PE and return the prior contents of the data object in one
 atomic operation.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 The 
 .I dest
 and 
 .I value
 data objects must conform to certain typing
 constraints, which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I value
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_CSWAP
 4-byte integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_CSWAP
 8-byte integer.
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The contents that had been in the 
 .I dest
 data object on the remote
 PE prior to the conditional swap. Data type is the same as the
 .I dest
 data type.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_cswap
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_compare\_swap" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following call ensures that the first PE to execute the
 conditional swap will successfully write its PE number to
 .I race\_winner
 on PE 0.
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static int race_winner = -1;
@@ -230,11 +165,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 2:
 Standard AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch.3
+++ b/man/shmem_atomic_fetch.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_FETCH 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch \- 
 Atomically fetches the value of a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch(const
 .B TYPE
@@ -21,17 +16,11 @@ Atomically fetches the value of a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types specified by
 Table 3.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch(const
 .B TYPE
@@ -39,19 +28,12 @@ Table 3.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types and has a corresponding
 TYPENAME specified by Table 3.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "SHMEM_INT4_FETCH, ires_i4"
 ires_i4 = SHMEM_INT4_FETCH(dest, pe)
@@ -61,75 +43,46 @@ ires_i8 = SHMEM_INT8_FETCH(dest, pe)
 res_r4 = SHMEM_REAL4_FETCH(dest, pe)
 .BR "REAL*8 " "SHMEM_REAL8_FETCH, res_r8"
 res_r8 = SHMEM_REAL8_FETCH(dest, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I dest
 - The remotely accessible data object to be fetched from
 the remote PE.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number from which
 .I dest
 is to be fetched.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_fetch
 performs an atomic fetch operation.
 It returns the contents of the 
 .I dest
 as an atomic operation.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The contents at the 
 .I dest
 address on the remote PE.
 The data type of the return value is the same as the type of
 the remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_fetch
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_fetch" .
-
 ./ sectionEnd
-
-
-
-
 .SS Table 3:
 Extended AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch_add.3
+++ b/man/shmem_atomic_fetch_add.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_FETCH_ADD 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH_ADD 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch_add \- 
 Performs an atomic fetch-and-add operation on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch_add(TYPE
 .IB "*dest" ,
@@ -22,17 +17,11 @@ Performs an atomic fetch-and-add operation on a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types specified by
 Table 2.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch_add(TYPE
 .IB "*dest" ,
@@ -41,35 +30,20 @@ Table 2.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types and has a corresponding
 TYPENAME specified by Table 2.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "SHMEM_INT4_FADD, ires_i4, value_i4"
 ires_i4 = SHMEM_INT4_FADD(dest, value_i4, pe)
 .BR "INTEGER*8 " "SHMEM_INT8_FADD, ires_i8, value_i8"
 ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -79,8 +53,6 @@ the remote PE. The type of
 .I dest
 should match that implied in the
 SYNOPSIS section.
-
-
 .BR "IN " -
 .I value
 - The value to be atomically added to 
@@ -89,8 +61,6 @@ SYNOPSIS section.
 type of 
 .I value
 should match that implied in the SYNOPSIS section.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number on which
@@ -98,12 +68,8 @@ should match that implied in the SYNOPSIS section.
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_fetch\_add
 routines perform an atomic fetch-and-add operation. An
 atomic fetch-and-add operation fetches the old 
@@ -123,47 +89,30 @@ on
 and return the previous contents of
 .I dest
 as an atomic operation.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I dest
 must be of the following type:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_FADD
 4-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_FADD
 8-byte integer
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The contents that had been at the 
 .I dest
 address on the remote PE
@@ -171,39 +120,25 @@ prior to the atomic addition operation. The data type of the return value is
 the same as the 
 .IR "dest" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_fadd
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_fetch\_add" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_atomic\_fetch\_add
 example is for
 C[11] programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   int old = -1;
@@ -218,11 +153,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 2:
 Standard AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch_and.3
+++ b/man/shmem_atomic_fetch_and.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_FETCH_AND 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH_AND 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch_and \- 
 Atomically perform a fetching bitwise AND operation on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch_and(TYPE
 .IB "*dest" ,
@@ -22,17 +17,11 @@ Atomically perform a fetching bitwise AND operation on a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch_and(TYPE
 .IB "*dest" ,
@@ -41,41 +30,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise AND operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_fetch\_and
 atomically performs a fetching bitwise AND
 on the remotely accessible data object pointed to by 
@@ -85,35 +60,20 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The value pointed to by 
 .I dest
 on PE 
 .I pe
 immediately before the
 operation is performed.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch_inc.3
+++ b/man/shmem_atomic_fetch_inc.3
@@ -1,72 +1,45 @@
-.TH SHMEM_ATOMIC_FETCH_INC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH_INC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch_inc \- 
 Performs an atomic fetch-and-increment operation on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch_inc(TYPE
 .IB "*dest" ,
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types specified by
 Table 2.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch_inc(TYPE
 .IB "*dest" ,
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types and has a corresponding
 TYPENAME specified by Table 2.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "SHMEM_INT4_FINC, ires_i4"
 ires_i4 = SHMEM_INT4_FINC(dest, pe)
 .BR "INTEGER*8 " "SHMEM_INT8_FINC, ires_i8"
 ires_i8 = SHMEM_INT8_FINC(dest, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -76,8 +49,6 @@ on the remote PE. The type of
 .I "dest"
 should match that implied in the
 SYNOPSIS section.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number on which
@@ -85,13 +56,8 @@ SYNOPSIS section.
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS API Description
-
 These routines perform a fetch-and-increment operation. The 
 .I "dest"
 on
@@ -101,84 +67,54 @@ is increased by one and the routine returns the previous
 contents of 
 .I "dest"
 as an atomic operation.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I dest
 must be of the following type:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_FINC
 4-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_FINC
 8-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The contents that had been at the 
 .I "dest"
 address on the remote PE prior to
 the increment. The data type of the return value is the same as the 
 .IR "dest" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_finc
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_fetch\_inc" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_atomic\_fetch\_inc
 example is for
 C[11] programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   int old = -1;
@@ -193,11 +129,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 2:
 Standard AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch_or.3
+++ b/man/shmem_atomic_fetch_or.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_FETCH_OR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH_OR 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch_or \- 
 Atomically perform a fetching bitwise OR operation on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch_or(TYPE
 .IB "*dest" ,
@@ -22,17 +17,11 @@ Atomically perform a fetching bitwise OR operation on a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch_or(TYPE
 .IB "*dest" ,
@@ -41,41 +30,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise OR operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_fetch\_or
 atomically performs a fetching bitwise OR
 on the remotely accessible data object pointed to by 
@@ -85,35 +60,20 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The value pointed to by 
 .I dest
 on PE 
 .I pe
 immediately before the
 operation is performed.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_fetch_xor.3
+++ b/man/shmem_atomic_fetch_xor.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ATOMIC_FETCH_XOR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_FETCH_XOR 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_fetch_xor \- 
 Atomically perform a fetching bitwise exclusive OR (XOR) operation on a
 remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_fetch_xor(TYPE
 .IB "*dest" ,
@@ -23,17 +18,11 @@ remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_fetch_xor(TYPE
 .IB "*dest" ,
@@ -42,41 +31,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise XOR operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_fetch\_xor
 atomically performs a fetching bitwise XOR
 on the remotely accessible data object pointed to by 
@@ -86,35 +61,20 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The value pointed to by 
 .I dest
 on PE 
 .I pe
 immediately before the
 operation is performed.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_inc.3
+++ b/man/shmem_atomic_inc.3
@@ -1,69 +1,43 @@
-.TH SHMEM_ATOMIC_INC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_INC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_inc \- 
 Performs an atomic increment operation on a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_inc(TYPE
 .IB "*dest" ,
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types specified by
 Table 2.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_inc(TYPE
 .IB "*dest" ,
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard AMO types and has a corresponding
 TYPENAME specified by Table 2.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "CALL " "SHMEM_INT4_INC(dest, pe)"
 .BR "CALL " "SHMEM_INT8_INC(dest, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -73,8 +47,6 @@ on the remote PE. The type of
 .I "dest"
 should match that implied in the
 SYNOPSIS section.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number on which
@@ -82,91 +54,56 @@ SYNOPSIS section.
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 These routines perform an atomic increment operation on the 
 .I dest
 data
 object on PE.
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I dest
 must be of the following type:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_INC
 4-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_INC
 8-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_inc
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_inc" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_atomic\_inc
 example is for
 C[11] programs: 
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static int dst = 74;
@@ -180,11 +117,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 2:
 Standard AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_or.3
+++ b/man/shmem_atomic_or.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ATOMIC_OR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_OR 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_or \- 
 Atomically perform a non-fetching bitwise OR operation on a
 remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_or(TYPE
 .IB "*dest" ,
@@ -23,17 +18,11 @@ remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_or(TYPE
 .IB "*dest" ,
@@ -42,41 +31,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise OR operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_or
 atomically performs a non-fetching bitwise OR
 on the remotely accessible data object pointed to by 
@@ -86,30 +61,15 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_set.3
+++ b/man/shmem_atomic_set.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_SET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_SET 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_set \- 
 Atomically sets the value of a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_set(TYPE
 .IB "*dest" ,
@@ -22,17 +17,11 @@ Atomically sets the value of a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types specified by
 Table 3.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_set(TYPE
 .IB "*dest" ,
@@ -41,19 +30,12 @@ Table 3.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types and has a corresponding
 TYPENAME specified by Table 3.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "pe"
 .BR "INTEGER*4 " "SHMEM_INT4_SET, value_i4"
 .BR "CALL " "SHMEM_INT4_SET(dest, value_i4, pe)"
@@ -63,42 +45,26 @@ TYPENAME specified by Table 3.
 .BR "CALL " "SHMEM_REAL4_SET(dest, value_r4, pe)"
 .BR "REAL*8 " "SHMEM_REAL8_SET, value_r8"
 .BR "CALL " "SHMEM_REAL8_SET(dest, value_r8, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I dest
 - The remotely accessible data object to be set on
 the remote PE.
-
-
 .BR "IN " -
 .I value
 - The value to be atomically written to the remote PE.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number on which
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_set
 performs an atomic set operation. It writes the
 .I value
@@ -107,35 +73,20 @@ into
 on 
 .I pe
 as an atomic operation.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_set
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_set" .
-
 ./ sectionEnd
-
-
-
-
 .SS Table 3:
 Extended AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_swap.3
+++ b/man/shmem_atomic_swap.3
@@ -1,19 +1,14 @@
-.TH SHMEM_ATOMIC_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_SWAP 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_swap \- 
 Performs an atomic swap to a remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_atomic_swap(TYPE
 .IB "*dest" ,
@@ -22,16 +17,10 @@ Performs an atomic swap to a remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types specified by Table 3.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_atomic_swap(TYPE
 .IB "*dest" ,
@@ -40,18 +29,11 @@ where TYPE is one of the extended AMO types specified by Table 3.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the extended AMO types and has a corresponding TYPENAME specified by Table 3.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "SHMEM_SWAP, value, pe"
 ires = SHMEM_SWAP(dest, value, pe)
 .BR "INTEGER*4 " "SHMEM_INT4_SWAP, value_i4, ires_i4"
@@ -62,16 +44,9 @@ ires_i8 = SHMEM_INT8_SWAP(dest, value_i8, pe)
 res_r4 = SHMEM_REAL4_SWAP(dest, value_r4, pe)
 .BR "REAL*8 " "SHMEM_REAL8_SWAP, value_r8, res_r8"
 res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -80,8 +55,6 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 updated on the remote PE. If you are using  C/C++, the type of
 .I "dest"
 should match that implied in the SYNOPSIS section.
-
-
 .BR "IN " -
 .I value
 - The value to be atomically written to the remote
@@ -89,9 +62,6 @@ PE.
 .I value
 is the same type as 
 .IR "dest" .
-
-
-
 .BR "IN " -
 .I pe
 -  An integer that indicates the PE number on which
@@ -99,12 +69,8 @@ is the same type as
 is to be updated. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_swap
 performs an atomic swap operation.
 It writes 
@@ -115,102 +81,66 @@ on PE and returns the previous
 contents of 
 .I "dest"
 as an atomic operation.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I dest
 must be of the following type:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_SWAP
 Integer of default kind
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT4\_SWAP
 4-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INT8\_SWAP
 8-byte integer
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL4\_SWAP
 4-byte real
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL8\_SWAP
 8-byte real
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The content that had been at the 
 .I "dest"
 address on the remote PE
 prior to the swap is returned.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], 
 .B shmem\_swap
 has been deprecated.
 Its behavior and call signature are identical to the replacement
 interface, 
 .BR "shmem\_atomic\_swap" .
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The example below swaps values between odd numbered PEs and
 their right (modulo) neighbor and outputs the result of swap.
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long dest;
@@ -228,11 +158,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 3:
 Extended AMO Types and Names
 .TP 25

--- a/man/shmem_atomic_xor.3
+++ b/man/shmem_atomic_xor.3
@@ -1,20 +1,15 @@
-.TH SHMEM_ATOMIC_XOR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_ATOMIC_XOR 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_atomic_xor \- 
 Atomically perform a non-fetching bitwise exclusive OR (XOR) operation on a
 remote data object.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_atomic_xor(TYPE
 .IB "*dest" ,
@@ -23,17 +18,11 @@ remote data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types specified by
 Table 4.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_atomic_xor(TYPE
 .IB "*dest" ,
@@ -42,41 +31,27 @@ Table 4.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the bitwise AMO types and has a corresponding
 TYPENAME specified by Table 4.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A pointer to the remotely accessible data object to
 be updated.
-
-
 .BR "IN " -
 .I value
 - The operand to the bitwise XOR operation.
-
-
 .BR "IN " -
 .I pe
 - An integer value for the PE on which 
 .I dest
 is to be updated.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_atomic\_xor
 atomically performs a non-fetching bitwise XOR
 on the remotely accessible data object pointed to by 
@@ -86,30 +61,15 @@ at PE
 with the operand 
 .IR "value" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-
 .SS Table 4:
 Bitwise AMO Types and Names
 .TP 25

--- a/man/shmem_barrier.3
+++ b/man/shmem_barrier.3
@@ -1,4 +1,4 @@
-.TH SHMEM_BARRIER 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_BARRIER 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_barrier \- 
@@ -7,17 +7,12 @@ Performs all operations described in the
 interface
 but with respect to a subset of PEs defined by the 
 .IR "Active set" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_barrier(int
 .IB "PE_start" ,
@@ -28,32 +23,16 @@ but with respect to a subset of PEs defined by the
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "PE_start, logPE_stride, PE_size"
 .BR "INTEGER " "pSync(SHMEM_BARRIER_SYNC_SIZE)"
 .BR "CALL " "SHMEM_BARRIER(PE_start, logPE_stride, PE_size, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -64,8 +43,6 @@ of PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran, it must be
 a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 - The log (base 2) of the stride between consecutive
@@ -74,8 +51,6 @@ PE numbers in the
 .I logPE\_stride
 must be of type integer.
 If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 - The number of PEs in the 
@@ -83,8 +58,6 @@ If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must be a default
 integer value.
-
-
 .BR "IN " -
 .I pSync
 - A symmetric work array. In  C/C++, 
@@ -101,12 +74,8 @@ enter
 .B shmem\_barrier
 the first time.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_barrier
 is a collective synchronization routine over an
 .IR "Active set" .
@@ -123,15 +92,12 @@ the
 .I PE\_size
 ) have called 
 .BR "shmem\_barrier" .
-
-
 As with all OpenSHMEM collective routines, each of these routines assumes that
 only PEs in the 
 .I "Active set"
 call the routine. If a PE not in the
 .I "Active set"
 calls an OpenSHMEM collective routine, undefined behavior results.
-
 The values of arguments 
 .I PE\_start
 , 
@@ -145,38 +111,24 @@ passed in
 .I pSync
 to all PEs in the 
 .IR "Active set" .
-
-
-
 .B shmem\_barrier
 ensures that all previously issued stores and remote
 memory updates, including AMOs and RMA operations, done by any of the
 PEs in the 
 .I "Active set"
 are complete before returning.
-
 The same 
 .I pSync
 array may be reused on consecutive calls to
 .B shmem\_barrier
 if the same active PE set is used.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 If the 
 .I pSync
 array is initialized at run time, be sure to use some type of
@@ -186,7 +138,6 @@ synchronization, for example, a call to
 calling 
 .B shmem\_barrier
 for the first time.
-
 If the 
 .I "Active set"
 does not change, 
@@ -198,39 +149,27 @@ array. No additional synchronization
 beyond that implied by 
 .B shmem\_barrier
 itself is necessary in this case.
-
 The 
 .B shmem\_barrier
 routine can be used to
 portably ensure that memory access operations observe remote updates in the order
 enforced by initiator PEs.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following barrier example is for C11 programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static int x = 10101;
   static long pSync[SHMEM_BARRIER_SYNC_SIZE];
   for (int i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++)
      pSync[i] = SHMEM_SYNC_VALUE;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   if (me % 2 == 0) {
      /* put to next even PE in a circular fashion */
      shmem_p(&x, 4, (me + 2) % npes);
@@ -242,8 +181,3 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_barrier_all.3
+++ b/man/shmem_barrier_all.3
@@ -1,56 +1,32 @@
-.TH SHMEM_BARRIER_ALL 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_BARRIER_ALL 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_barrier_all \- 
 Registers the arrival of a PE at a barrier and suspends PE execution
 until all other PEs arrive at the barrier and all local and remote memory
 updates are completed.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_barrier_all(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_BARRIER_ALL"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_barrier\_all
 routine registers the arrival of a PE at
@@ -61,8 +37,6 @@ have called
 This routine must be used with
 PEs started by 
 .BR "shmem\_init" .
-
-
 Prior to synchronizing with other PEs, 
 .B shmem\_barrier\_all
 ensures completion of all previously issued memory stores and remote memory
@@ -75,57 +49,35 @@ as
 .B shmem\_put\_nbi
 , and 
 .BR "shmem\_get\_nbi" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 The 
 .B shmem\_barrier\_all
 routine can be used to
 portably ensure that memory access operations observe remote updates in the order
 enforced by initiator PEs.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_barrier\_all
 example is for C11 programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static int x = 1010;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   /* put to next  PE in a circular fashion */
   shmem_p(&x, 4, (me + 1) % npes);
-
   /* synchronize all PEs */
   shmem_barrier_all();
   printf("%d: x = %d\\n", me, x);
@@ -133,8 +85,3 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_broadcast.3
+++ b/man/shmem_broadcast.3
@@ -1,20 +1,15 @@
-.TH SHMEM_BROADCAST 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_BROADCAST 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_broadcast \- 
 Broadcasts a block of data from one PE to one or more destination
 PEs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_broadcast32(void
 .IB "*dest" ,
@@ -34,9 +29,6 @@ PEs.
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_broadcast64(void
 .IB "*dest" ,
@@ -56,50 +48,30 @@ PEs.
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "nelems, PE_root, PE_start, logPE_stride, PE_size"
 .BR "INTEGER " "pSync(SHMEM_BCAST_SYNC_SIZE)"
 .BR "CALL " "SHMEM_BROADCAST4(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_BROADCAST8(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_BROADCAST32(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size,pSync)"
 .BR "CALL " "SHMEM_BROADCAST64(dest, source, nelems, PE_root, PE_start, logPE_stride, PE_size,pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - A symmetric data object. 
-
-
 .BR "IN " -
 .I source
 - A symmetric data object that can be of any data type
 that is permissible for the 
 .I "dest"
 argument.
-
-
 .BR "IN " -
 .I nelems
 - The number of elements in 
@@ -113,8 +85,6 @@ and
 .I size\_t
 in C. If you are
 using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_root
 - Zero-based ordinal of the PE, with respect to
@@ -127,8 +97,6 @@ the
 .I PE\_root
 must be of type integer. If you
 are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_start
 - The lowest PE number of the 
@@ -138,8 +106,6 @@ PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran,
 it must be a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 -  The log (base 2) of the stride between
@@ -148,8 +114,6 @@ consecutive PE numbers in the
 .I log\_PE\_stride
 must be of
 type integer. If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 -  The number of PEs in the 
@@ -157,8 +121,6 @@ type integer. If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must be a
 default integer value.
-
-
 .BR "IN " -
 .I pSync
 -  A symmetric work array. In  C/C++, 
@@ -173,14 +135,9 @@ Fortran) before any of the PEs in the
 .I "Active set"
 enter
 .BR "shmem\_broadcast" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 OpenSHMEM broadcast routines are collective routines. They copy data object
 .I "source"
 on the processor specified by 
@@ -197,14 +154,12 @@ on the other PEs specified by the triplet
 .I "dest"
 area
 on the root PE.
-
 As with all OpenSHMEM collective routines, each of these routines assumes that
 only PEs in the 
 .I "Active set"
 call the routine. If a PE not in the
 .I "Active set"
 calls an OpenSHMEM collective routine, undefined behavior results.
-
 The values of arguments 
 .I PE\_root
 , 
@@ -225,8 +180,6 @@ data objects and the same
 work array must be
 passed to all PEs in the 
 .IR "Active set" .
-
-
 Before any PE calls a broadcast routine, you must ensure that the following
 conditions exist (synchronization via a barrier or some other method is often
 needed to ensure this): The 
@@ -239,7 +192,6 @@ array on all PEs in the
 .I "Active set"
 is ready to accept the
 broadcast data.
-
 Upon return from a broadcast routine, the following are true for the local
 PE: If the current PE is not the root PE, the 
 .I "dest"
@@ -250,58 +202,37 @@ data object may be safely reused.
 The values in the 
 .I pSync
 array are restored to the original values.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to certain typing
 constraints, which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_broadcast8, shmem\_broadcast64
 Any noncharacter type that has an element size of 64 bits. No Fortran derived types or  C/C++ structures are allowed.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_broadcast4, shmem\_broadcast32
 Any noncharacter type that has an element size of 32 bits. No Fortran derived types or  C/C++ structures are allowed.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 All OpenSHMEM broadcast routines restore 
 .I pSync
 to its original contents.
@@ -311,7 +242,6 @@ array do not
 require that 
 .I pSync
 be reinitialized after the first call.
-
 You must ensure the that the 
 .I pSync
 array is not being updated by any
@@ -337,16 +267,9 @@ used the same
 .I pSync
 array. In general, this can be ensured only by doing
 some type of synchronization. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 In the following examples, the call to 
 .B shmem\_broadcast64
 copies 
@@ -354,56 +277,36 @@ copies
 on PE 4 to 
 .I "dest"
 on PEs 5, 6, and 7. 
-
 C/C++ example:
-
 .nf
 #include <stdio.h>
 #include <stdlib.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long pSync[SHMEM_BCAST_SYNC_SIZE];
   for (int i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
      pSync[i] = SHMEM_SYNC_VALUE;
   static long source[4], dest[4];
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   if (me == 0)
      for (int i = 0; i < 4; i++)
         source[i] = i;
-
   shmem_broadcast64(dest, source, 4, 0, 0, 0, npes, pSync);
   printf("%d: %ld, %ld, %ld, %ld\\n", me, dest[0], dest[1], dest[2], dest[3]);
   shmem_finalize();
   return 0;
 }
 .fi
-
-
-
 Fortran example:
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_BCAST_SYNC_SIZE)
 INTEGER DEST, SOURCE, NLONG, PE_ROOT, PE_START,
 &   LOGPE_STRIDE, PE_SIZE, PSYNC
 COMMON /COM/ DEST, SOURCE
-
 DATA PSYNC /SHMEM_BCAST_SYNC_SIZE*SHMEM_SYNC_VALUE/
-
 CALL SHMEM_BROADCAST64(DEST, SOURCE, NLONG, 0, 4, 0, 4, PSYNC)
-
-
 .fi
-
-
-
-
-

--- a/man/shmem_cache.3
+++ b/man/shmem_cache.3
@@ -1,81 +1,56 @@
-.TH SHMEM_CACHE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_CACHE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_cache \- 
 Controls data cache utilities.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
-
+./ sectionStart
+.B ***********DEPRECATED***********
+./ sectionEnd
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_clear_cache_inv(void)
-
-
 .B void
 .B shmem_set_cache_inv(void)
-
-
 .B void
 .B shmem_clear_cache_line_inv(void
 .I *dest
 .B );
-
-
-
 .B void
 .B shmem_set_cache_line_inv(void
 .I *dest
 .B );
-
-
-
 .B void
 .B shmem_udcflush(void)
-
-
 .B void
 .B shmem_udcflush_line(void
 .I *dest
 .B );
-
-
-
 ./ sectionEnd
-
-
-
-
-
+./ sectionStart
+.B ********************************
+./ sectionEnd
+./ sectionStart
+.B ***********DEPRECATED***********
+./ sectionEnd
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_CLEAR_CACHE_INV"
 .BR "CALL " "SHMEM_SET_CACHE_INV"
 .BR "CALL " "SHMEM_SET_CACHE_LINE_INV(dest)"
 .BR "CALL " "SHMEM_UDCFLUSH"
 .BR "CALL " "SHMEM_UDCFLUSH_LINE(dest)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
-
 ./ sectionStart
-
+.B ********************************
+./ sectionEnd
+./ sectionStart
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -85,75 +60,42 @@ Controls data cache utilities.
 can be of any noncharacter type. If you are using Fortran, it can be of any
 kind.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_set\_cache\_inv
 enables automatic cache coherency mode.
-
-
 .B shmem\_set\_cache\_line\_inv
 enables automatic cache coherency mode for
 the cache line associated with the address of 
 .I dest
 only.
-
-
 .B shmem\_clear\_cache\_inv
 disables automatic cache coherency mode
 previously enabled by 
 .B shmem\_set\_cache\ \_inv
 or
 .BR "shmem\_set\_cache\_line\_inv" .
-
-
-
 .B shmem\_udcflush
 makes the entire user data cache coherent.
-
-
 .B shmem\_udcflush\_line
 makes coherent the cache line that corresponds with
 the address specified by 
 .IR "dest" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 These routines have been retained for improved backward compatibility with
 legacy architectures. They are not required to be supported by implementing
 them as 
 .I no-ops
 and where used, they may have no effect on cache line
 states.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
 None.
-
-
-
-

--- a/man/shmem_calloc.3
+++ b/man/shmem_calloc.3
@@ -1,53 +1,33 @@
-.TH SHMEM_CALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_CALLOC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_calloc \- 
 Allocate a zeroed block of symmetric memory.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B *shmem_calloc(size_t
 .IB "count" ,
 .B size_t
 .I size
 .B );
-
-
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I count
 - The number of elements to allocate.
-
-
 .BR "IN " -
 .I size
 - The size in bytes of each element to allocate.
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_calloc
 routine allocates a region of remotely-accessible
@@ -58,7 +38,6 @@ objects of
 bytes each and
 returns a pointer to the lowest byte address of the allocated symmetric
 memory. The space is initialized to all bits zero.
-
 If the allocation succeeds, the pointer returned shall be suitably
 aligned so that it may be assigned to a pointer to any type of object.
 If the allocation does not succeed, or either 
@@ -67,7 +46,6 @@ or
 .I size
 is
 0, the return value is a null pointer.
-
 The values for 
 .I count
 and 
@@ -77,36 +55,20 @@ all PEs calling
 .B shmem\_calloc
 ; otherwise, the behavior is
 undefined.
-
 The 
 .B shmem\_calloc
 routine calls 
 .B shmem\_barrier\_all
 on exit.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The 
 .B shmem\_calloc
 routine returns a pointer to the lowest byte
 address of the allocated space; otherwise, it returns a null pointer.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_collect.3
+++ b/man/shmem_collect.3
@@ -1,20 +1,15 @@
-.TH SHMEM_COLLECT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_COLLECT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_collect \- 
 Concatenates blocks of data from multiple PEs to an array in every
 PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_collect32(void
 .IB "*dest" ,
@@ -32,9 +27,6 @@ PE.
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_collect64(void
 .IB "*dest" ,
@@ -52,9 +44,6 @@ PE.
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_fcollect32(void
 .IB "*dest" ,
@@ -72,9 +61,6 @@ PE.
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_fcollect64(void
 .IB "*dest" ,
@@ -92,18 +78,10 @@ PE.
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "nelems"
 .BR "INTEGER " "PE_start, logPE_stride, PE_size"
 .BR "INTEGER " "pSync(SHMEM_COLLECT_SYNC_SIZE)"
@@ -115,17 +93,9 @@ PE.
 .BR "CALL " "SHMEM_FCOLLECT8(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_FCOLLECT32(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
 .BR "CALL " "SHMEM_FCOLLECT64(dest, source, nelems, PE_start, logPE_stride, PE_size, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -157,16 +127,12 @@ and  C/C++ structures are not permitted. For
 ,
 any data type with an element size of 32 bits. Fortran derived
 types, Fortran character type, and  C/C++ structures are not permitted.
-
-
 .BR "IN " -
 .I source
 - A symmetric data object that can be of any type permissible
 for the 
 .I "dest"
 argument.
-
-
 .BR "IN " -
 .I nelems
 - The number of elements in the 
@@ -177,8 +143,6 @@ must be of type
 .I size\_t
 for C. If you are using Fortran, it must be
 a default integer value.
-
-
 .BR "IN " -
 .I PE\_start
 - The lowest PE number of the 
@@ -188,8 +152,6 @@ PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran,
 it must be a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 - The log (base 2) of the stride between
@@ -198,8 +160,6 @@ consecutive PE numbers in the
 .I logPE\_stride
 must be of
 type integer. If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 - The number of PEs in the 
@@ -207,8 +167,6 @@ type integer. If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must be a default
 integer value.
-
-
 .BR "IN " -
 .I pSync
 - A symmetric work array. In  C/C++, 
@@ -226,14 +184,9 @@ enter
 .B shmem\_collect
 or 
 .BR "shmem\_fcollect" .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 OpenSHMEM 
 .B collect
 and 
@@ -264,8 +217,6 @@ second, and so on. The collected result is written to the
 array for all
 PEs in the 
 .IR "Active set" .
-
-
 The 
 .B fcollect
 routines require that 
@@ -277,14 +228,12 @@ routines allow
 .I nelems
 to
 vary from PE to PE.
-
 As with all OpenSHMEM collective routines, each of these routines assumes that
 only PEs in the 
 .I "Active set"
 call the routine. If a PE not in the
 .I "Active set"
 and calls this collective routine, the behavior is undefined.
-
 The values of arguments 
 .I PE\_start
 , 
@@ -301,8 +250,6 @@ arrays and the same
 .I pSync
 work array must be passed to all PEs in the
 .IR "Active set" .
-
-
 Upon return from a collective routine, the following are true for the local
 PE: The 
 .I "dest"
@@ -313,23 +260,13 @@ The values in the
 .I pSync
 array are
 restored to the original values.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 All OpenSHMEM collective routines reset the values in 
 .I pSync
 before they
@@ -337,7 +274,6 @@ return, so a particular
 .I pSync
 buffer need only be initialized the first
 time it is used.
-
 You must ensure that the 
 .I pSync
 array is not being updated on any PE
@@ -361,7 +297,6 @@ that used the same
 .I pSync
 array. In general, this may be ensured only by
 doing some type of synchronization. 
-
 The collective routines operate on active PE sets that have a
 non-power-of-two 
 .I PE\_size
@@ -369,50 +304,35 @@ with some performance degradation. They operate
 with no performance degradation when 
 .I nelems
 is a non-power-of-two value.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_collec
 t example is for  C/C++ programs:
-
 .nf
 #include <stdio.h>
 #include <stdlib.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long lock = 0;
   static long pSync[SHMEM_COLLECT_SYNC_SIZE];
   for (int i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
      pSync[i] = SHMEM_SYNC_VALUE;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
   int my_nelem = me + 1; /* linearly increasing number of elements with PE */
   int total_nelem = (npes * (npes + 1)) / 2;
-
   int* source = (int*) shmem_malloc(npes*sizeof(int)); /* symmetric alloc */
   int* dest = (int*) shmem_malloc(total_nelem*sizeof(int));
-
   for (int i = 0; i < my_nelem; i++)
      source[i] = (me * (me + 1)) / 2 + i;
   for (int i = 0; i < total_nelem; i++)
      dest[i] = -9999;
-
   shmem_barrier_all(); /* Wait for all PEs to update source/dest */
-
   shmem_collect32(dest, source, my_nelem, 0, 0, npes, pSync);
-
   shmem_set_lock(&lock); /* Lock prevents interleaving printfs */
   printf("%d: %d", me, dest[0]);
   for (int i = 1; i < total_nelem; i++)
@@ -423,24 +343,13 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
 The following 
 .B SHMEM\_COLLECT
 example is for Fortran programs:
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_COLLECT_SYNC_SIZE)
 DATA PSYNC /SHMEM_COLLECT_SYNC_SIZE*SHMEM_SYNC_VALUE/
-
 CALL SHMEM_COLLECT4(DEST, SOURCE, 64, PE_START, LOGPE_STRIDE,
 &  PE_SIZE, PSYNC)
 .fi
-
-
-
-
-

--- a/man/shmem_fence.3
+++ b/man/shmem_fence.3
@@ -1,54 +1,31 @@
-.TH SHMEM_FENCE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_FENCE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_fence \- 
 Assures ordering of delivery of PUT, AMOs, and memory store routines
 to symmetric data objects.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_fence(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_FENCE"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 This routine assures ordering of delivery of PUT, AMOs, and memory store
 routines to symmetric data objects. All PUT, AMOs, and memory store
 routines to symmetric data objects issued to a particular remote PE prior
@@ -60,23 +37,13 @@ objects to the same PE.
 .B shmem\_fence
 guarantees order of delivery,
 not completion.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 .B shmem\_fence
 only provides per-PE ordering guarantees and does not
 guarantee completion of delivery. 
@@ -103,30 +70,20 @@ and
 guarantees completion of PUT, AMOs, and memory store routines to
 symmetric data objects which makes the updates visible to all other
 PEs. 
-
 The 
 .B shmem\_quiet
 routine should be called if completion of PUT,
 AMOs, and memory store routines to symmetric data objects is desired
 when multiple remote PEs are involved.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_fence
 example is for C11 programs: 
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   int src = 99;
@@ -148,7 +105,6 @@ int main(void)
   return 0;
 }
 .fi
-
 .I Put1
 will be ordered to be delivered before 
 .I put3
@@ -157,7 +113,3 @@ and
 will be ordered to be delivered before 
 .IR "put4" .
 .
-
-
-
-

--- a/man/shmem_finalize.3
+++ b/man/shmem_finalize.3
@@ -1,55 +1,32 @@
-.TH SHMEM_FINALIZE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_FINALIZE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_finalize \- 
 A collective operation that releases resources used by the OpenSHMEM
 library. This only terminates the OpenSHMEM portion of a program, not the
 entire program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_finalize(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_FINALIZE()"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_finalize
 is a collective operation that ends the OpenSHMEM
 portion of a program previously initialized by 
@@ -77,23 +54,13 @@ call to
 .B shmem\_finalize
 returns, but they will no longer have access
 to any resources that have been released.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 .B shmem\_finalize
 releases all resources used by the OpenSHMEM library
 including the symmetric memory heap and pointers initiated by
@@ -111,42 +78,24 @@ is optional. However, an explicit
 .B shmem\_finalize
 may be required as an entry point for wrappers used
 by profiling or other tools that need to perform their own finalization.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following finalize example is for C11 programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h> 
-
 int main(void)
 {
   static long x = 10101;
   long y = -1;
-
   shmem_init();
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
-
   if (me == 0)
      y = shmem_g(&x, npes-1);
-
   printf("%d: y = %ld\\n", me, y); 
-
   shmem_finalize();  
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_g.3
+++ b/man/shmem_g.3
@@ -1,19 +1,14 @@
-.TH SHMEM_G 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_G 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_g \- 
 Copies one data item from a remote PE
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B TYPE
 .B shmem_g(const
 .B TYPE
@@ -21,16 +16,10 @@ Copies one data item from a remote PE
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B TYPE
 .B shmem_<TYPENAME>_g(const
 .B TYPE
@@ -38,72 +27,41 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I addr
 - The remotely accessible array element or scalar data object.
-
-
 .BR "IN " -
 .I pe
 - The number of the remote PE on which 
 .I addr
 resides.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 These routines provide a very low latency get capability for single elements
 of most basic types. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 Returns a single element of type specified in the synopsis.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_g
 example is for C11 programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   long y = -1;
@@ -118,10 +76,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_get.3
+++ b/man/shmem_get.3
@@ -1,19 +1,14 @@
-.TH SHMEM_GET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_GET 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_get \- 
 Copies data from a specified PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_get(TYPE
 .IB "*dest" ,
@@ -25,16 +20,10 @@ Copies data from a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_get(TYPE
 .IB "*dest" ,
@@ -46,15 +35,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_get<SIZE>(void
 .IB "*dest" ,
@@ -66,15 +49,9 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
-
 .B void
 .B shmem_getmem(void
 .IB "*dest" ,
@@ -86,18 +63,10 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "nelems, pe"
 .BR "CALL " "SHMEM_CHARACTER_GET(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_COMPLEX_GET(dest, source, nelems, pe)"
@@ -111,31 +80,20 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_INTEGER_GET(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_LOGICAL_GET(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_GET(dest, source, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - Local data object to be updated.
-
-
 .BR "IN " -
 .I source
 - Data object on the PE identified by 
 .I pe
 that contains the data to be copied. This data object must be remotely
 accessible.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -149,8 +107,6 @@ must be of type
 for C. If you are
 using Fortran, it must be a constant, variable, or array element of default
 integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -159,83 +115,56 @@ must
 be of type integer. If you are using Fortran, it must be a constant,
 variable, or array element of default integer type.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The get routines provide a method for copying a contiguous symmetric data
 object from a different PE to a contiguous data object on the local
 PE. The routines return after the data has been delivered to the
 .I "dest"
 array on the local PE. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to typing constraints,
 which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_getmem
 Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get4, shmem\_get32
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get8
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get64
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get128
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_CHARACTER\_GET
@@ -247,76 +176,48 @@ and
 .I "dest"
 variables are ignored.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_GET
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_GET
 Fortran: Elements of type double precision.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_GET
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_GET
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_GET
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
 If you are using Fortran, data types must be of default size. For example, a real
 variable must be declared as REAL, REAL*4, or
 REAL(KIND=KIND(1.0)).
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 Consider this example for Fortran.
-
 .nf
 PROGRAM REDUCTION
 INCLUDE "shmem.fh"
-
 REAL VALUES, SUM
 COMMON /C/ VALUES
 REAL WORK
@@ -332,11 +233,6 @@ PRINT*,'PE ',SHMEM_MY_PE(),' COMPUTED SUM=',SUM
 CALL SHMEM_BARRIER_ALL
 END
 .fi
-
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_get_nbi.3
+++ b/man/shmem_get_nbi.3
@@ -1,20 +1,15 @@
-.TH SHMEM_GET_NBI 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_GET_NBI 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_get_nbi \- 
 The nonblocking get routines provide a method for copying data from a
 contiguous remote data object on the specified PE to the local data object. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_get_nbi(TYPE
 .IB "*dest" ,
@@ -26,16 +21,10 @@ contiguous remote data object on the specified PE to the local data object.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_get_nbi(TYPE
 .IB "*dest" ,
@@ -47,15 +36,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_get<SIZE>_nbi(void
 .IB "*dest" ,
@@ -67,15 +50,9 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
-
 .B void
 .B shmem_getmem_nbi(void
 .IB "*dest" ,
@@ -87,18 +64,10 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "nelems, pe"
 .BR "CALL " "SHMEM_CHARACTER_GET_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_COMPLEX_GET_NBI(dest, source, nelems, pe)"
@@ -112,31 +81,20 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_INTEGER_GET_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_LOGICAL_GET_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_GET_NBI(dest, source, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - Local data object to be updated.
-
-
 .BR "IN " -
 .I source
 - Data object on the PE identified by 
 .I pe
 that contains the data to be copied. This data object must be remotely
 accessible.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -150,8 +108,6 @@ must be of type
 for C. If you are
 using Fortran, it must be a constant, variable, or array element of default
 integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -160,12 +116,8 @@ must
 be of type integer. If you are using Fortran, it must be a constant,
 variable, or array element of default integer type.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The get routines provide a method for copying a contiguous symmetric data
 object from a different PE to a contiguous data object on the local
 PE. The routines return after posting the operation. The operation is considered 
@@ -177,72 +129,49 @@ At the completion of
 data has been delivered to the 
 .I "dest"
 array on the local PE. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to typing constraints,
 which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_getmem\_nbi
 Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get4\_nbi, shmem\_get32\_nbi
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get8\_nbi
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get64\_nbi
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_get128\_nbi
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_CHARACTER\_GET\_NBI
@@ -254,66 +183,42 @@ and
 .I "dest"
 variables are ignored.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_GET\_NBI
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_GET\_NBI
 Fortran: Elements of type double precision.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_GET\_NBI
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_GET\_NBI
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_GET\_NBI
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
 If you are using Fortran, data types must be of default size. For example, a real
 variable must be declared as REAL, REAL*4, or
 REAL(KIND=KIND(1.0)).
-
 ./ sectionEnd
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_getmem.3
+++ b/man/shmem_getmem.3
@@ -1,1 +1,1 @@
-.so shmem_get
+.so shmem_get.3

--- a/man/shmem_global_exit.3
+++ b/man/shmem_global_exit.3
@@ -1,74 +1,43 @@
-.TH SHMEM_GLOBAL_EXIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_GLOBAL_EXIT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_global_exit \- 
 A routine that allows any PE to force termination of an entire program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B _Noreturn
 .B void
 .B shmem_global_exit(int
 .I status
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_global_exit(int
 .I status
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "STATUS"
 .BR "CALL " "SHMEM_GLOBAL_EXIT(status)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I status
 - The exit status from the main program.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_global\_exit
 is a non-collective routine that allows any one
 PE to force termination of an OpenSHMEM program for all PEs,
@@ -90,24 +59,13 @@ status argument. There is no return to the caller of
 .B shmem\_global\_exit
 ; control is returned from the OpenSHMEM program
 to the execution environment for all PEs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS API Notes
-
 .B shmem\_global\_exit
 may be used in situations where one or more
 PEs have determined that the program has completed and/or should
@@ -125,23 +83,13 @@ according to C/C++/Fortran standard language requirements, but this may not
 include all resources allocated for the OpenSHMEM program. However, a
 quality implementation will make a best effort to flush all I/O and clean
 up all resources.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
-
-
 .nf
 #include <stdio.h>
 #include <stdlib.h>
 #include <shmem.h> 
-
 int main(void)
 {
   shmem_init();
@@ -158,8 +106,3 @@ int main(void)
  return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_iget.3
+++ b/man/shmem_iget.3
@@ -1,19 +1,14 @@
-.TH SHMEM_IGET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_IGET 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_iget \- 
 Copies strided data from a specified PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_iget(TYPE
 .IB "*dest" ,
@@ -29,16 +24,10 @@ Copies strided data from a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_iget(TYPE
 .IB "*dest" ,
@@ -54,15 +43,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_iget<SIZE>(void
 .IB "*dest" ,
@@ -78,18 +61,11 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "dst, sst, nelems, pe"
 .BR "CALL " "SHMEM_COMPLEX_IGET(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_DOUBLE_IGET(dest, source, dst, sst, nelems, pe)"
@@ -101,28 +77,17 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_INTEGER_IGET(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_LOGICAL_IGET(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_IGET(dest, source, dst, sst, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - Array to be updated on the local PE. 
-
-
 .BR "IN " -
 .I source
 - Array containing the data to be copied on the remote PE.
-
-
 .BR "IN " -
 .I dst
 - The stride between consecutive elements of the 
@@ -135,8 +100,6 @@ A value of 1 indicates contiguous data.
 must be of
 type ptrdiff\_t. If you are calling from Fortran, it must
 be a default integer value.
-
-
 .BR "IN " -
 .I sst
 - The stride between consecutive elements of the
@@ -148,8 +111,6 @@ array. A value of 1 indicates contiguous data.
 must be
 of type ptrdiff\_t. If you are calling from Fortran, it must
 be a default integer value.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -163,8 +124,6 @@ must be of type
 for C. If you are
 using Fortran, it must be a constant, variable, or array element of
 default integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -173,12 +132,8 @@ must be
 of type integer. If you are using Fortran, it must be a constant,
 variable, or array element of default integer type.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B iget
 routines provide a method for copying strided data elements from
@@ -186,13 +141,8 @@ a symmetric array from a specified remote PE to strided locations on a
 local array. The routines return when the data has been copied into the local
 .I dest
 array.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I dest
 and 
@@ -205,114 +155,74 @@ Data type of
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iget4, shmem\_iget32
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iget8
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iget64
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iget128
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_IGET
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_IGET
 Fortran: Elements of type double precision.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_IGET
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_IGET
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_IGET
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 If you are using Fortran, data types must be of default size. For example, a
 real variable must be declared as REAL, REAL*4, or
 REAL(KIND=KIND(1.0)). 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following example uses 
 .B shmem\_logical\_iget
 in a Fortran
 program.
-
 .nf
 PROGRAM STRIDELOGICAL
 INCLUDE "shmem.fh"
-
 LOGICAL SOURCE(10), DEST(5)
 SAVE SOURCE   ! SAVE MAKES IT REMOTELY ACCESSIBLE
 DATA SOURCE /.T.,.F.,.T.,.F.,.T.,.F.,.T.,.F.,.T.,.F./
@@ -324,11 +234,6 @@ IF (SHMEM_MY_PE() .EQ. 0) THEN
 ENDIF
 CALL SHMEM_BARRIER_ALL
 .fi
-
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_info_get_name.3
+++ b/man/shmem_info_get_name.3
@@ -1,59 +1,35 @@
-.TH SHMEM_INFO_GET_NAME 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_INFO_GET_NAME 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_info_get_name \- 
 This routine returns the vendor defined character string.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_info_get_name(char
 .I *name
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CHARACTER " "*(*)NAME"
 SHMEM_INFO_GET_NAME(NAME)   
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I name
 - The vendor defined string.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 This routine returns the vendor defined character string of size defined by
 the library constant SHMEM\_MAX\_NAME\_LEN. The program calling
 this function prepares the 
@@ -71,27 +47,12 @@ memory buffer is provided with size less than
 SHMEM\_MAX\_NAME\_LEN, behavior is undefined. For a given library
 implementation, the vendor string returned is consistent with the library
 constant SHMEM\_VENDOR\_STRING.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None. 
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_info_get_version.3
+++ b/man/shmem_info_get_version.3
@@ -1,91 +1,50 @@
-.TH SHMEM_INFO_GET_VERSION 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_INFO_GET_VERSION 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_info_get_version \- 
 Returns the major and minor version of the library implementation.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_info_get_version(int
 .IB "*major" ,
 .B int
 .I *minor
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "MAJOR, MINOR"
 SHMEM_INFO_GET_VERSION(MAJOR, MINOR)   
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I major
 - The major version of the OpenSHMEM standard in use.
-
-
 .BR "OUT " -
 .I minor
 - The minor version of the OpenSHMEM standard in use.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 This routine returns the major and minor version of the OpenSHMEM standard
 in use. For a given library implementation, the major and minor version
 returned by these calls are consistent with the library constants
 SHMEM\_MAJOR\_VERSION and SHMEM\_MINOR\_VERSION.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None. 
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_init.3
+++ b/man/shmem_init.3
@@ -1,55 +1,31 @@
-.TH SHMEM_INIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_INIT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_init \- 
 A collective operation that allocates and initializes the resources used by
 the OpenSHMEM library.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_init(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INIT()"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_init
 allocates and initializes resources used by the OpenSHMEM
 library. It is a collective operation that all PEs must call before any
@@ -66,23 +42,13 @@ subsequent call to
 .B shmem\_init
 in the same program results in undefined
 behavior.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM Specification 1.2 the use of 
 .B start\_pes
 has been
@@ -113,46 +79,27 @@ case of
 .B start\_pes
 after the
 first one resulted in a no-op.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This is a simple program that calls 
 .B shmem\_init
 : 
-
 .nf
 PROGRAM PUT
 INCLUDE "shmem.fh"
-
 INTEGER TARG, SRC, RECEIVER, BAR
 COMMON /T/ TARG
 PARAMETER (RECEIVER=1)
 CALL SHMEM_INIT()
-
 IF (SHMEM_MY_PE() .EQ. 0) THEN
    SRC = 33
    CALL SHMEM_INTEGER_PUT(TARG, SRC, 1, RECEIVER)
 ENDIF
-
 CALL SHMEM_BARRIER_ALL           ! SYNCHRONIZES SENDER AND RECEIVER
-
 IF (SHMEM_MY_PE() .EQ. RECEIVER) THEN
    PRINT*,'PE ', SHMEM_MY_PE(),' TARG=',TARG,' (expect 33)'
 ENDIF
-
 CALL SHMEM_FINALIZE()
-
 END
 .fi
-
-
-
-
-

--- a/man/shmem_iput.3
+++ b/man/shmem_iput.3
@@ -1,19 +1,14 @@
-.TH SHMEM_IPUT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_IPUT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_iput \- 
 Copies strided data to a specified PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_iput(TYPE
 .IB "*dest" ,
@@ -29,16 +24,10 @@ Copies strided data to a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_iput(TYPE
 .IB "*dest" ,
@@ -54,15 +43,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_iput<SIZE>(void
 .IB "*dest" ,
@@ -78,18 +61,11 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "dst, sst, nelems, pe"
 .BR "CALL " "SHMEM_COMPLEX_IPUT(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_DOUBLE_IPUT(dest, source, dst, sst, nelems, pe)"
@@ -101,29 +77,18 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_IPUT128(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_LOGICAL_IPUT(dest, source, dst, sst, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - Array to be updated on the remote PE. This data
 object must be remotely accessible.
-
-
 .BR "IN " -
 .I source
 - Array containing the data to be copied.
-
-
 .BR "IN " -
 .I dst
 - The stride between consecutive elements of the 
@@ -135,8 +100,6 @@ value of 1 indicates contiguous data.
 .I dst
 must be of type
 ptrdiff\_t. If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I sst
 - The stride between consecutive elements of the
@@ -148,8 +111,6 @@ array. A value of 1 indicates contiguous data.
 must be
 of type ptrdiff\_t. If you are using Fortran, it must be a
 default integer value.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -163,8 +124,6 @@ must be of type
 for C. If you are
 using Fortran, it must be a constant, variable, or array element of
 default integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -173,13 +132,8 @@ must be
 of type integer. If you are using Fortran, it must be a constant,
 variable, or array element of default integer type.
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B iput
 routines provide a method for copying strided data
@@ -203,134 +157,88 @@ been copied out of the
 .I source
 array on the local PE but not
 necessarily before the data has been delivered to the remote data object.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
 .I "source"
 data objects must conform to typing constraints,
 which are as follows:
-
 .TP 25
 Routine
 Data type of 
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iput4, shmem\_iput32
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iput8
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iput64
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_iput128
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_IPUT
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_IPUT
 Elements of type double precision.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_IPUT
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_IPUT
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_IPUT
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 If you are using Fortran, data types must be of default size. For example, a
 real variable must be declared as REAL, REAL*4 or
 REAL(KIND=KIND(1.0)).
 Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 Consider the following 
 .B shmem\_iput
 example for C11 programs.
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   short source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -348,10 +256,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_lock.3
+++ b/man/shmem_lock.3
@@ -1,62 +1,37 @@
-.TH SHMEM_LOCK 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_LOCK 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_lock \- 
 Releases, locks, and tests a mutual exclusion memory lock.
-
 ./ sectionEnd
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_clear_lock(long
 .I *lock
 .B );
-
-
-
 .B void
 .B shmem_set_lock(long
 .I *lock
 .B );
-
-
-
 .B int
 .B shmem_test_lock(long
 .I *lock
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "lock, SHMEM_TEST_LOCK"
 .BR "CALL " "SHMEM_CLEAR_LOCK(lock)"
 .BR "CALL " "SHMEM_SET_LOCK(lock)"
 I = SHMEM_TEST_LOCK(lock)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -68,12 +43,8 @@ PEs prior to the first use.
 must be of type long.
 If you are using Fortran, it must be of default kind.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_set\_lock
 routine sets a mutual exclusion lock after waiting
@@ -92,50 +63,31 @@ this routine, a PE can avoid blocking on a set lock. If the lock is
 currently set, the routine returns without waiting. These routines are
 appropriate for protecting a critical region from simultaneous update by
 multiple PEs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The 
 .B shmem\_test\_lock
 routine returns 0 if the lock was
 originally cleared and this call was able to set the lock. A value of
 1 is returned if the lock had been set and the call returned without
 waiting to set the lock.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 Please refer to the subsection on the Memory Model for the definition of the term "remotely accessible".
 The lock variable should always be initialized to zero and accessed only by the OpenSHMEM locking
 API. Changing the value of the lock variable by other means without using
 the OpenSHMEM API, can lead to undefined behavior.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following example uses 
 .B shmem\_lock
 in a C[11] program.
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long lock = 0;
@@ -153,8 +105,3 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_malloc.3
+++ b/man/shmem_malloc.3
@@ -1,58 +1,36 @@
-.TH SHMEM_MALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_MALLOC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_malloc \- 
 Symmetric heap memory management routines.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B *shmem_malloc(size_t
 .I size
 .B );
-
-
-
 .B void
 .B shmem_free(void
 .I *ptr
 .B );
-
-
-
 .B void
 .B *shmem_realloc(void
 .IB "*ptr" ,
 .B size_t
 .I size
 .B );
-
-
-
 .B void
 .B *shmem_align(size_t
 .IB "alignment" ,
 .B size_t
 .I size
 .B );
-
-
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -60,26 +38,16 @@ Symmetric heap memory management routines.
 - The size, in bytes, of a block to be
 allocated from the symmetric heap. This argument is of type 
 .I size\_t
-
-
-
 .BR "IN " -
 .I ptr
 - Points to a block within the symmetric heap.
-
-
 .BR "IN " -
 .I alignment
 - Byte alignment of the block allocated from the
 symmetric heap.
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_malloc
 routine returns a pointer to a block of at least
@@ -89,12 +57,10 @@ symmetric heap (in contrast to
 .B malloc
 , which allocates from the private
 heap).
-
 The 
 .B shmem\_align
 routine allocates a block in the symmetric heap that has
 a byte alignment specified by the alignment argument.
-
 The 
 .B shmem\_free
 routine causes the block to which 
@@ -104,7 +70,6 @@ deallocated, that is, made available for further allocation. If
 .I ptr
 is a
 null pointer, no action occurs. 
-
 The 
 .B shmem\_realloc
 routine changes the size of the block to which
@@ -130,7 +95,6 @@ NULL pointer, the block to which it points is freed. If the space cannot
 be allocated, the block to which 
 .I ptr
 points is unchanged.
-
 The 
 .B shmem\_malloc
 , 
@@ -164,40 +128,27 @@ PEs; if differing
 .I size
 arguments are used, the behavior of the call
 and any subsequent OpenSHMEM calls becomes undefined.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The 
 .B shmem\_malloc
 routine returns a pointer to the allocated space;
 otherwise, it returns a NULL pointer.
-
 The 
 .B shmem\_free
 routine returns no value.
-
 The 
 .B shmem\_realloc
 routine returns a pointer to the allocated space
 (which may have moved); otherwise, it returns a null pointer.
-
 The 
 .B shmem\_align
 routine returns an aligned pointer to the allocated
 space; otherwise, it returns a NULL pointer.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of Specification 1.2 the use of 
 .B shmalloc
 , 
@@ -217,11 +168,9 @@ libraries are required to support the calls, program users are encouraged to use
 .B shmem\_realloc
 instead. The behavior and signature of the routines
 remains unchanged from the deprecated versions.
-
 The total size of the symmetric heap is determined at job startup. One can
 adjust the size of the heap using the SHMEM\_SYMMETRIC\_SIZE environment
 variable (where available).
-
 The 
 .B shmem\_malloc
 , 
@@ -231,14 +180,10 @@ The
 routines
 differ from the private heap allocation routines in that all PEs in a
 program must call them (a barrier is used to ensure this).
-
 ./ sectionEnd
 		
-
 ./ sectionStart
-
 .SS API Notes
-
 The symmetric heap allocation routines always return a pointer to corresponding
 symmetric objects across all PEs. The OpenSHMEM specification does not
 require that the virtual addresses are equal across all PEs. Nevertheless,
@@ -249,9 +194,4 @@ implementation may re-map the allocated block of memory based on agreed virtual
 address. Additionally, some operating systems provide an option to disable
 virtual address randomization, which enables predictable allocation of virtual
 memory addresses.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_my_pe.3
+++ b/man/shmem_my_pe.3
@@ -1,54 +1,31 @@
-.TH SHMEM_MY_PE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_MY_PE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_my_pe \- 
 Returns the number of the calling PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B int
 .B shmem_my_pe(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "SHMEM_MY_PE, ME"
 ME = SHMEM_MY_PE()
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 This routine returns the PE number of the calling PE. It accepts no
 arguments. The result is an integer between 0 and 
 .I npes
@@ -57,25 +34,15 @@ arguments. The result is an integer between 0 and
 .I npes
 is the total number of PEs executing the
 current program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 Integer - Between 0 and 
 .I npes
 - 1
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 Each PE has a unique number or identifier. As of OpenSHMEM Specification
 1.2 the use of 
 .B \_my\_pe
@@ -87,9 +54,4 @@ instead. The behavior and signature of the routine
 remains unchanged from the deprecated 
 .B \_my\_pe
 version.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_n_pes.3
+++ b/man/shmem_n_pes.3
@@ -1,72 +1,39 @@
-.TH SHMEM_N_PES 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_N_PES 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_n_pes \- 
 Returns the number of PEs running in a program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B int
 .B shmem_n_pes(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "INTEGER " "SHMEM_N_PES, N_PES"
 N_PES = SHMEM_N_PES()
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The routine returns the number of PEs running in the program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 Integer - Number of PEs running in the OpenSHMEM program.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM Specification 1.2 the use of 
 .B \_num\_pes
 has been
@@ -80,27 +47,18 @@ remains unchanged from the
 deprecated 
 .B \_num\_pes
 version.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_my\_pe
 and 
 .B shmem\_n\_pes
 example is for
 C/C++ programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   shmem_init();
@@ -111,8 +69,3 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_p.3
+++ b/man/shmem_p.3
@@ -1,19 +1,14 @@
-.TH SHMEM_P 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_P 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_p \- 
 Copies one data item to a remote PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_p(TYPE
 .IB "*dest" ,
@@ -22,16 +17,10 @@ Copies one data item to a remote PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_p(TYPE
 .IB "*dest" ,
@@ -40,87 +29,53 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I addr
 - The remotely accessible array element or scalar data object
 which will receive the data on the remote PE.
-
-
 .BR "IN " -
 .I value
 - The value to be transferred to 
 .I addr
 on the
 remote PE.
-
-
 .BR "IN " -
 .I pe
 - The number of the remote PE.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 These routines provide a very low latency put capability for single elements of
 most basic types.
-
 As with 
 .B shmem\_put
 , these routines start the remote transfer and may
 return before the data is delivered to the remote PE. Use
 .B shmem\_quiet
 to force completion of all remote PUT transfers.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following example uses 
 .B shmem\_p
 in a C[11] program.
-
 .nf
 #include <stdio.h>
 #include <math.h>
 #include <shmem.h>
-
 int main(void)
 {
   const double e = 2.71828182;
@@ -137,11 +92,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_pe_accessible.3
+++ b/man/shmem_pe_accessible.3
@@ -1,49 +1,29 @@
-.TH SHMEM_PE_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_PE_ACCESSIBLE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_pe_accessible \- 
 Determines whether a PE is accessible via OpenSHMEM's data transfer
 routines.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B int
 .B shmem_pe_accessible(int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "LOGICAL " "LOG, SHMEM_PE_ACCESSIBLE"
 .BR "INTEGER " "pe"
 LOG = SHMEM_PE_ACCESSIBLE(pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -51,12 +31,8 @@ LOG = SHMEM_PE_ACCESSIBLE(pe)
 - Specific PE to be checked for accessibility from
 the local PE.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_pe\_accessible
 is a query routine that indicates whether a
 specified PE is accessible via OpenSHMEM from the local PE. The
@@ -75,31 +51,15 @@ executable file. However, OpenSHMEM support between processes of different
 executable files is supported only for data objects on the symmetric heap,
 since static data objects are not symmetric between different executable
 files. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 C/C++: The return value is 1 if the specified PE is a valid remote PE
 for OpenSHMEM routines; otherwise, it is 0. 
-
-
-
 Fortran: The return value is .TRUE. if the specified PE is a valid
 remote PE for OpenSHMEM routines; otherwise, it is .FALSE.. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
 None. 
 ./ sectionEnd
-
-
-
-

--- a/man/shmem_ptr.3
+++ b/man/shmem_ptr.3
@@ -1,19 +1,14 @@
-.TH SHMEM_PTR 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_PTR 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_ptr \- 
 Returns a pointer to a data object on a specified PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B *shmem_ptr(const
 .B void
@@ -21,39 +16,21 @@ Returns a pointer to a data object on a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "POINTER " "(PTR, POINTEE)"
 .BR "INTEGER " "pe"
 PTR = SHMEM_PTR(dest, pe)
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I dest
 - The symmetric data object to be referenced.
-
-
 .BR "IN " -
 .I pe
 - An integer that indicates the PE number on which 
@@ -62,18 +39,13 @@ is to
 be accessed. If you are using Fortran, it must be a default
 integer value.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_ptr
 returns an address that may be used to directly reference
 .I "dest"
 on the specified PE. This address can be assigned to a pointer.
 After that, ordinary loads and stores to this remote address may be performed.
-
 When a sequence of loads (gets) and stores (puts) to a data object on a
 remote PE does not match the access pattern provided in an OpenSHMEM data
 transfer routine like 
@@ -84,63 +56,40 @@ or
 .B shmem\_ptr
 routine can provide an efficient means to accomplish the
 communication.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 The return value is a non-NULL address of the 
 .I "dest"
 data object when it is 
 accessible using memory loads and stores in addition to OpenSHMEM operations.
 Otherwise, a NULL address is returned.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 When calling 
 .B shmem\_ptr
 , 
 .I "dest"
 is the address of the referenced
 symmetric data object on the calling PE.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This Fortran program calls 
 .B shmem\_ptr
 and then PE 0 writes to
 the 
 .I BIGD
 array on PE 1: 
-
 .nf
 PROGRAM REMOTEWRITE
 INCLUDE "shmem.fh"
-
 INTEGER BIGD(100)
 SAVE BIGD
-
 INTEGER POINTEE(*)
 POINTER (PTR,POINTEE)
-
 CALL SHMEM_INIT()
-
-
 IF (SHMEM_MY_PE() .EQ. 0) THEN
   ! initialize PE 1's BIGD array
   PTR = SHMEM_PTR(BIGD, 1)     ! get address of PE 1's BIGD
@@ -149,25 +98,17 @@ IF (SHMEM_MY_PE() .EQ. 0) THEN
        POINTEE(I) = I
   ENDDO
 ENDIF
-
 CALL SHMEM_BARRIER_ALL
-
 IF (SHMEM_MY_PE() .EQ. 1) THEN
   PRINT*,'BIGD on PE 1 is: '
   PRINT*,BIGD
 ENDIF
 END
-
 .fi
-
-
-
 This is the equivalent program written in C[11]:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void) 
 {
   static int dest[4];
@@ -189,8 +130,3 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
-

--- a/man/shmem_put.3
+++ b/man/shmem_put.3
@@ -1,20 +1,15 @@
-.TH SHMEM_PUT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_PUT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_put \- 
 The put routines provide a method for copying data from a contiguous local
 data object to a data object on a specified PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_put(TYPE
 .IB "*dest" ,
@@ -26,16 +21,10 @@ data object to a data object on a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_put(TYPE
 .IB "*dest" ,
@@ -47,15 +36,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_put<SIZE>(void
 .IB "*dest" ,
@@ -67,15 +50,9 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
-
 .B void
 .B shmem_putmem(void
 .IB "*dest" ,
@@ -87,18 +64,10 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_CHARACTER_PUT(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_COMPLEX_PUT(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_DOUBLE_PUT(dest, source, nelems, pe)"
@@ -111,29 +80,18 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_PUT128(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_PUTMEM(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_PUT(dest, source, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I dest
 - Data object to be updated on the remote PE. This
 data object must be remotely accessible.
-
-
 .BR "OUT " -
 .I source
 - Data object containing the data to be copied.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -147,8 +105,6 @@ must be of type
 for C. If you are using
 Fortran, it must be a constant, variable, or array element of default
 integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -157,12 +113,8 @@ must be
 of type integer. If you are using Fortran, it must be a constant, variable,
 or array element of default integer type.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The routines return after the data has been copied out of the 
 .I "source"
 array
@@ -172,13 +124,8 @@ routines may deliver data out of order unless a call to
 .B shmem\_fence
 is
 introduced between the two calls. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
@@ -191,51 +138,35 @@ Data type of
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_putmem
 Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put4, shmem\_put32
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put8
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put64
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put128
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_CHARACTER\_PUT
@@ -247,55 +178,37 @@ and
 .I "dest"
 variables are ignored. 
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_PUT
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_PUT
 Elements of type double precision. 
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_PUT
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_PUT
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_PUT
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
 ./ sectionStart
-
 .SS API Notes
-
 If you are using Fortran, data types must be of default size. For example,
 a real variable must be declared as REAL, REAL*4, or
 REAL(KIND=KIND(1.0)). The Fortran API routine 
@@ -307,24 +220,15 @@ or
 .B SHMEM\_PUT64
 should
 be used in its place.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following 
 .B shmem\_put
 example is for C11 programs:
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   long source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
@@ -339,10 +243,6 @@ int main(void)
   return 0;
 }
 .fi
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_put_nbi.3
+++ b/man/shmem_put_nbi.3
@@ -1,20 +1,15 @@
-.TH SHMEM_PUT_NBI 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_PUT_NBI 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_put_nbi \- 
 The nonblocking put routines provide a method for copying data
 from a contiguous local data object to a data object on a specified PE. 
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_put_nbi(TYPE
 .IB "*dest" ,
@@ -26,16 +21,10 @@ from a contiguous local data object to a data object on a specified PE.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types specified by Table 1.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_put_nbi(TYPE
 .IB "*dest" ,
@@ -47,15 +36,9 @@ where TYPE is one of the standard RMA types specified by Table 1.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the standard RMA types and has a corresponding TYPENAME specified by Table 1.
 ./ sectionStart
-
 .B void
 .B shmem_put<SIZE>_nbi(void
 .IB "*dest" ,
@@ -67,15 +50,9 @@ where TYPE is one of the standard RMA types and has a corresponding TYPENAME spe
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
 where SIZE is one of 8, 16, 32, 64, 128.
 ./ sectionStart
-
 .B void
 .B shmem_putmem_nbi(void
 .IB "*dest" ,
@@ -87,18 +64,10 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .B int
 .I pe
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_CHARACTER_PUT_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_COMPLEX_PUT_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_DOUBLE_PUT_NBI(dest, source, nelems, pe)"
@@ -111,29 +80,18 @@ where SIZE is one of 8, 16, 32, 64, 128.
 .BR "CALL " "SHMEM_PUT128_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_PUTMEM_NBI(dest, source, nelems, pe)"
 .BR "CALL " "SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I dest
 - Data object to be updated on the remote PE. This
 data object must be remotely accessible.
-
-
 .BR "IN " -
 .I source
 - Data object containing the data to be copied.
-
-
 .BR "IN " -
 .I nelems
 - Number of elements in the 
@@ -147,8 +105,6 @@ must be of type
 for C. If you are using
 Fortran, it must be a constant, variable, or array element of default
 integer type.
-
-
 .BR "IN " -
 .I pe
 - PE number of the remote PE. 
@@ -157,12 +113,8 @@ must be
 of type integer. If you are using Fortran, it must be a constant, variable,
 or array element of default integer type.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The routines return after posting the operation. The operation is considered 
 complete after a subsequent call to 
 .BR "shmem\_quiet" .
@@ -179,13 +131,8 @@ routines may deliver data out of order unless a call to
 .B shmem\_fence
 is
 introduced between the two calls. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 The 
 .I "dest"
 and 
@@ -198,51 +145,35 @@ Data type of
 .I dest
 and 
 .I source
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_putmem\_nbi
 Fortran: Any noncharacter type. C: Any data type. nelems is scaled in bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put4\_nbi, shmem\_put32\_nbi
 Any noncharacter type that has a storage size equal to 32 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put8\_nbi
 C: Any noncharacter type that has a storage size equal to 8 bits.
 ./ sectionEnd
-
-
-
 ./ sectionStart
 Fortran: Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put64\_nbi
 Any noncharacter type that has a storage size equal to 64 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_put128\_nbi
 Any noncharacter type that has a storage size equal to 128 bits.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_CHARACTER\_PUT\_NBI
@@ -254,60 +185,39 @@ and
 .I "dest"
 variables are ignored. 
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_COMPLEX\_PUT\_NBI
 Elements of type complex of default size.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_DOUBLE\_PUT\_NBI
 Elements of type double precision. 
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_INTEGER\_PUT\_NBI
 Elements of type integer.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_LOGICAL\_PUT\_NBI
 Elements of type logical.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 SHMEM\_REAL\_PUT\_NBI
 Elements of type real.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
 ./ sectionStart
-
 .SS API Notes
 None.
 ./ sectionEnd
-
-
-
-
 .SS Table 1:
 Standard RMA Types and Names
 .TP 25

--- a/man/shmem_quiet.3
+++ b/man/shmem_quiet.3
@@ -1,55 +1,32 @@
-.TH SHMEM_QUIET 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_QUIET 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_quiet \- 
 Waits for completion of all outstanding PUT, AMOs, memory store,
 and non-blocking PUT and GET routines to symmetric data
 objects issued by a PE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_quiet(void)
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_QUIET"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .B None.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B shmem\_quiet
 routine ensures completion of PUT, AMOs,
@@ -60,24 +37,13 @@ symmetric data objects are guaranteed to be completed and visible to all
 PEs when 
 .B shmem\_quiet
 returns. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 .B shmem\_quiet
 is most useful as a way of ensuring completion of
 several PUT, AMOs, memory store, and non-blocking PUT
@@ -96,8 +62,6 @@ are called. The barrier
 routines wait for the completion of outstanding writes (PUT, AMO,
 memory stores, and nonblocking PUT and GET routines) to
 symmetric data objects on all PEs.
-
-
 .B shmem\_quiet
 does not have an effect on the ordering between memory 
 accesses issued by the target PE.
@@ -112,24 +76,15 @@ accesses issued by the target PE.
 .B shmem\_barrier\_all
 routines can be called by the target PE to guarantee 
 ordering of its memory accesses.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following example uses 
 .B shmem\_quiet
 in a C11 program: 
-
 .nf
 #include <stdio.h>
 #include <shmem.h>
-
 int main(void)
 {
   static long dest[3];
@@ -155,7 +110,6 @@ int main(void)
   return 0;
 }
 .fi
-
 .I Put1
 and 
 .I put2
@@ -164,6 +118,3 @@ will be completed and visible before
 and 
 .IR "put4" .
 .
-
-
-

--- a/man/shmem_reductions.3
+++ b/man/shmem_reductions.3
@@ -1,23 +1,16 @@
-.TH SHMEM_REDUCTIONS 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_REDUCTIONS 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_reductions \- 
 Performs arithmetic and logical operations across a set of PEs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
-
 .SH AND
-
 Performs a bitwise AND function across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_short_and_to_all(short
 .IB "*dest" ,
@@ -37,9 +30,6 @@ Performs a bitwise AND function across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_and_to_all(int
 .IB "*dest" ,
@@ -59,9 +49,6 @@ Performs a bitwise AND function across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_and_to_all(long
 .IB "*dest" ,
@@ -81,9 +68,6 @@ Performs a bitwise AND function across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_and_to_all(long
 .B long
@@ -106,32 +90,18 @@ Performs a bitwise AND function across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_AND_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT8_AND_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH MAX
-
 Performs a maximum function reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_short_max_to_all(short
 .IB "*dest" ,
@@ -151,9 +121,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_max_to_all(int
 .IB "*dest" ,
@@ -173,9 +140,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_double_max_to_all(double
 .IB "*dest" ,
@@ -195,9 +159,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_float_max_to_all(float
 .IB "*dest" ,
@@ -217,9 +178,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_max_to_all(long
 .IB "*dest" ,
@@ -239,9 +197,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longdouble_max_to_all(long
 .I double
@@ -264,9 +219,6 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_max_to_all(long
 .B long
@@ -289,35 +241,21 @@ Performs a maximum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT8_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL4_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL8_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL16_MAX_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH MIN
-
 Performs a minimum function reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_short_min_to_all(short
 .IB "*dest" ,
@@ -337,9 +275,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_min_to_all(int
 .IB "*dest" ,
@@ -359,9 +294,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_double_min_to_all(double
 .IB "*dest" ,
@@ -381,9 +313,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_float_min_to_all(float
 .IB "*dest" ,
@@ -403,9 +332,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_min_to_all(long
 .IB "*dest" ,
@@ -425,9 +351,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longdouble_min_to_all(long
 .I double
@@ -450,9 +373,6 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_min_to_all(long
 .B long
@@ -475,35 +395,21 @@ Performs a minimum function reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT8_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL4_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL8_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL16_MIN_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH SUM
-
 Performs a sum reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_complexd_sum_to_all(double
 .I complex
@@ -526,9 +432,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_complexf_sum_to_all(float
 .I complex
@@ -551,9 +454,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_short_sum_to_all(short
 .IB "*dest" ,
@@ -573,9 +473,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_sum_to_all(int
 .IB "*dest" ,
@@ -595,9 +492,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_double_sum_to_all(double
 .IB "*dest" ,
@@ -617,9 +511,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_float_sum_to_all(float
 .IB "*dest" ,
@@ -639,9 +530,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_sum_to_all(long
 .IB "*dest" ,
@@ -660,9 +548,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longdouble_sum_to_all(long
 .I double
@@ -685,9 +570,6 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_sum_to_all(long
 .B long
@@ -710,18 +592,10 @@ Performs a sum reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_COMP4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_COMP8_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
@@ -729,18 +603,12 @@ Performs a sum reduction across a set of processing elements (PEs).
 .BR "CALL " "SHMEM_REAL4_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL8_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL16_SUM_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH PROD
-
 Performs a product reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_complexd_prod_to_all(double
 .I complex
@@ -763,9 +631,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_complexf_prod_to_all(float
 .I complex
@@ -788,9 +653,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_short_prod_to_all(short
 .IB "*dest" ,
@@ -810,9 +672,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_prod_to_all(int
 .IB "*dest" ,
@@ -832,9 +691,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_double_prod_to_all(double
 .IB "*dest" ,
@@ -854,9 +710,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_float_prod_to_all(float
 .IB "*dest" ,
@@ -876,9 +729,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_prod_to_all(long
 .IB "*dest" ,
@@ -898,9 +748,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longdouble_prod_to_all(long
 .I double
@@ -923,9 +770,6 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_prod_to_all(long
 .B long
@@ -948,18 +792,10 @@ Performs a product reduction across a set of processing elements (PEs).
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_COMP4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_COMP8_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
@@ -967,18 +803,12 @@ Performs a product reduction across a set of processing elements (PEs).
 .BR "CALL " "SHMEM_REAL4_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL8_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_REAL16_PROD_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH OR
-
 Performs a bitwise OR function reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_short_or_to_all(short
 .IB "*dest" ,
@@ -998,9 +828,6 @@ Performs a bitwise OR function reduction across a set of processing elements (PE
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_or_to_all(int
 .IB "*dest" ,
@@ -1020,9 +847,6 @@ Performs a bitwise OR function reduction across a set of processing elements (PE
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_or_to_all(long
 .IB "*dest" ,
@@ -1042,9 +866,6 @@ Performs a bitwise OR function reduction across a set of processing elements (PE
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_or_to_all(long
 .B long
@@ -1067,32 +888,18 @@ Performs a bitwise OR function reduction across a set of processing elements (PE
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT8_OR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
 .SH XOR
-
 Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (PEs).
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_short_xor_to_all(short
 .IB "*dest" ,
@@ -1112,9 +919,6 @@ Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (P
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_int_xor_to_all(int
 .IB "*dest" ,
@@ -1134,9 +938,6 @@ Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (P
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_long_xor_to_all(long
 .IB "*dest" ,
@@ -1156,9 +957,6 @@ Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (P
 .B long
 .I *pSync
 .B );
-
-
-
 .B void
 .B shmem_longlong_xor_to_all(long
 .B long
@@ -1181,31 +979,15 @@ Performs a bitwise EXCLUSIVE OR reduction across a set of processing elements (P
 .B long
 .I *pSync
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
 .BR "CALL " "SHMEM_INT8_XOR_TO_ALL(dest, source, nreduce, PE_start, logPE_stride, PE_size, pWrk, pSync)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
@@ -1218,8 +1000,6 @@ receive the result of the reduction routines. The data type of
 varies
 with the version of the reduction routine being called. When calling from
 C/C++, refer to the SYNOPSIS section for data type information.
-
-
 .BR "IN " -
 .I source
 -  A symmetric array, of length 
@@ -1229,9 +1009,6 @@ contains one element for each separate reduction routine. The
 .I "source"
 argument must have the same data type as 
 .IR "dest" .
-
-
-
 .BR "IN " -
 .I nreduce
 - The number of elements in the 
@@ -1242,8 +1019,6 @@ arrays.
 .I nreduce
 must be of type integer. If you are using Fortran, it
 must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_start
 - The lowest PE number of the 
@@ -1253,8 +1028,6 @@ PEs.
 .I PE\_start
 must be of type integer. If you are using Fortran,
 it must be a default integer value.
-
-
 .BR "IN " -
 .I logPE\_stride
 - The log (base 2) of the stride between consecutive
@@ -1263,8 +1036,6 @@ PE numbers in the
 .I logPE\_stride
 must be of type integer.
 If you are using Fortran, it must be a default integer value.
-
-
 .BR "IN " -
 .I PE\_size
 - The number of PEs in the 
@@ -1272,8 +1043,6 @@ If you are using Fortran, it must be a default integer value.
 .I PE\_size
 must be of type integer. If you are using Fortran, it must be a
 default integer value.
-
-
 .BR "IN " -
 .I pWrk
 - A symmetric work array. The 
@@ -1289,8 +1058,6 @@ contains max(
 .I nreduce
 /2 + 1, SHMEM\_REDUCE\_MIN\_WRKDATA\_SIZE)
 elements.
-
-
 .BR "IN " -
 .I pSync
 - A symmetric work array. In  C/C++, 
@@ -1305,16 +1072,11 @@ SHMEM\_SYNC\_VALUE (in Fortran) before any of the PEs in the
 .I "Active set"
 enter the reduction routine.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 OpenSHMEM reduction routines compute one or more reductions across symmetric
 arrays on multiple PEs. A reduction performs an associative binary routine
 across a set of values. 
-
 The 
 .I nreduce
 argument determines the number of separate reductions to
@@ -1337,14 +1099,12 @@ by the
 , 
 .I PE\_size
 triplet.
-
 The 
 .I "source"
 and 
 .I "dest"
 arrays may be the same array, but they may not be
 overlapping arrays.
-
 As with all OpenSHMEM collective routines, each of these routines assumes
 that only PEs in the 
 .I "Active set"
@@ -1353,7 +1113,6 @@ the
 .I "Active set"
 calls an OpenSHMEM collective routine, undefined behavior
 results.
-
 The values of arguments 
 .I nreduce
 , 
@@ -1375,8 +1134,6 @@ and
 work arrays, must
 be passed to all PEs in the 
 .IR "Active set" .
-
-
 Before any PE calls a reduction routine, you must ensure that the
 following conditions exist (synchronization via a 
 .I barrier
@@ -1396,7 +1153,6 @@ array on all PEs in the
 is ready to accept the results of the 
 .IR "reduction" .
 .
-
 Upon return from a reduction routine, the following are true for the local
 PE: The 
 .I "dest"
@@ -1407,246 +1163,172 @@ The values in the
 .I pSync
 array are
 restored to the original values.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
 When calling from Fortran, the 
 .I "dest"
 date types are as follows:
-
 .TP 25
 Routine
 Data type
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_and\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_and\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_comp8\_max\_to\_all
 Complex, with an element size equal to two 8-byte real values.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_max\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_max\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real4\_max\_to\_all
 Real, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real16\_max\_to\_all
 Real, with an element size of 16 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_min\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_min\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real4\_min\_to\_all
 Real, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real8\_min\_to\_all
 Real, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real16\_min\_to\_all
 Real,with an element size of 16 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_comp4\_sum\_to\_all
 Complex, with an element size equal to two 4-byte real values.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_comp8\_sum\_to\_all
 Complex, with an element size equal to two 8-byte real values.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_sum\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_sum\_to\_all
 Integer, with an element size of 8 bytes..
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real4\_sum\_to\_all
 Real, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real8\_sum\_to\_all
 Real, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real16\_sum\_to\_all
 Real, with an element size of 16 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_comp4\_prod\_to\_all
 Complex, with an element size equal to two 4-byte real values. 
 ./ sectionEnd
 		 
-
 ./ sectionStart
 .TP 25
 shmem\_comp8\_prod\_to\_all
 Complex, with an element size equal to two 8-byte real values.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_prod\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_prod\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real4\_prod\_to\_all
 Real, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real8\_prod\_to\_all
 Real, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_real16\_prod\_to\_all
 Real, with an element size of 16 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_or\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_or\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_xor\_to\_all
 Integer, with an element size of 8 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_xor\_to\_all
 Integer, with an element size of 4 bytes.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 All OpenSHMEM reduction routines reset the values in 
 .I pSync
 before they
@@ -1682,16 +1364,9 @@ or
 .I pWrk
 arrays. In general, this can be assured only
 by doing some type of synchronization. 
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This Fortran reduction example statically initializes the 
 .I pSync
 array
@@ -1701,10 +1376,8 @@ of the integer variable
 .I FOO
 across all
 even PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
@@ -1712,7 +1385,6 @@ INTEGER*4 PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 INTEGER FOO, FOOAND
 SAVE FOO, FOOAND, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 FOO = SHMEM_MY_PE()
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
    IF ( MOD(SHMEM_N_PES()(),2) .EQ. 0) THEN
@@ -1726,9 +1398,6 @@ IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
    PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOAND
 ENDIF
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and finds
@@ -1737,27 +1406,20 @@ the
 value of real variable 
 .I FOO
 across all even PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
 REAL FOO, FOOMAX, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 COMMON /COM/ FOO, FOOMAX, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
       CALL SHMEM_REAL8_MAX_TO_ALL(FOOMAX, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOMAX
 ENDIF
-
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and finds
@@ -1767,26 +1429,20 @@ value of real variable
 .I FOO
 across all the even
 PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
 REAL FOO, FOOMIN, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 COMMON /COM/ FOO, FOOMIN, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
       CALL SHMEM_REAL8_MIN_TO_ALL(FOOMIN, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOMIN
 ENDIF
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and finds
@@ -1795,26 +1451,20 @@ the
 of the real variable 
 .I FOO
 across all even PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
 REAL FOO, FOOSUM, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 COMMON /COM/ FOO, FOOSUM, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
       CALL SHMEM_INT4_SUM_TO_ALL(FOOSUM, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOSUM
 ENDIF
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and finds
@@ -1823,26 +1473,20 @@ the
 of the real variable 
 .I FOO
 across all the even PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
 REAL FOO, FOOPROD, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 COMMON /COM/ FOO, FOOPROD, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
        CALL SHMEM_COMP8_PROD_TO_ALL(FOOPROD, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
        PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOPROD
 ENDIF
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and finds
@@ -1852,10 +1496,8 @@ of the integer variable
 .I FOO
 across all even
 PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
@@ -1863,16 +1505,12 @@ REAL PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 INTEGER FOO, FOOOR
 COMMON /COM/ FOO, FOOOR, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
        CALL SHMEM_INT8_OR_TO_ALL(FOOOR, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
        PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOOR
 ENDIF
 .fi
-
-
-
 This Fortran example statically initializes the 
 .I pSync
 array and
@@ -1882,25 +1520,17 @@ of variable
 .I FOO
 across all even
 PEs.
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER PSYNC(SHMEM_REDUCE_SYNC_SIZE)
 DATA PSYNC /SHMEM_REDUCE_SYNC_SIZE*SHMEM_SYNC_VALUE/
 PARAMETER (NR=1)
 REAL FOO, FOOXOR, PWRK(MAX(NR/2+1,SHMEM_REDUCE_MIN_WRKDATA_SIZE))
 COMMON /COM/ FOO, FOOXOR, PWRK
 INTRINSIC SHMEM_MY_PE()
-
 IF ( MOD(SHMEM_MY_PE() .EQ. 0) THEN
       CALL SHMEM_REAL8_XOR_TO_ALL(FOOXOR, FOO, NR, 0, 1, N$PES/2,
 &	 PWRK, PSYNC)
       PRINT*,'Result on PE ',SHMEM_MY_PE(),' is ',FOOXOR
 ENDIF
 .fi
-
-
-
-
-

--- a/man/shmem_test.3
+++ b/man/shmem_test.3
@@ -1,19 +1,14 @@
-.TH SHMEM_TEST 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_TEST 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_test \- 
 Test whether a variable on the local PE has changed.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B int
 .B shmem_test(TYPE
 .IB "*ivar" ,
@@ -22,17 +17,11 @@ Test whether a variable on the local PE has changed.
 .B TYPE
 .I value
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the point-to-point synchronization types specified by
 Table 5.
 ./ sectionStart
 .SS C/C++:
-
 .B int
 .B shmem_<TYPENAME>_test(TYPE
 .IB "*ivar" ,
@@ -41,23 +30,15 @@ Table 5.
 .B TYPE
 .I value
 .B );
-
-
-
 ./ sectionEnd
-
-
 where TYPE is one of the point-to-point synchronization types and has a
 corresponding TYPENAME specified by Table 5.
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I ivar
 - A pointer to a remotely accessible data object.
-
-
 .BR "IN " -
 .I cmp
 - The comparison operator that compares 
@@ -65,8 +46,6 @@ corresponding TYPENAME specified by Table 5.
 with
 .IR "value" .
 .
-
-
 .BR "IN " -
 .I value
 - The value against which the object pointed to
@@ -74,12 +53,8 @@ by
 .I ivar
 will be compared.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_test
 tests the numeric comparison of the symmetric object
 pointed to by 
@@ -90,14 +65,9 @@ according to the
 comparison operator 
 .IR "cmp" .
 .
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 .B shmem\_test
 returns 1 if the comparison of the symmetric object
 pointed to by 
@@ -108,33 +78,20 @@ according to the
 comparison operator 
 .I cmp
 evalutes to true; otherwise, it returns 0.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .SS Examples
-
-
 The following example demonstrates the use of 
 .B shmem\_test
 to
 wait on an array of symmetric objects and return the index of an
 element that satisfies the specified condition.
-
 .nf
 #include <shmem.h>
-
 int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
 {
  int idx = 0;
@@ -143,10 +100,6 @@ int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
  return idx;
 }
 .fi
-
-
-
-
 .SS Table 5:
 Point-to-Point Synchronization Types and Names
 .TP 25

--- a/man/shmem_wait.3
+++ b/man/shmem_wait.3
@@ -1,19 +1,14 @@
-.TH SHMEM_WAIT 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHMEM_WAIT 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shmem_wait \- 
 Wait for a variable on the local PE to change.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS C11:
-
 .B void
 .B shmem_wait_until(TYPE
 .IB "*ivar" ,
@@ -22,32 +17,25 @@ Wait for a variable on the local PE to change.
 .B TYPE
 .I cmp_value
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
+.B ***********DEPRECATED***********
+./ sectionEnd
+./ sectionStart
 .B void
 .B shmem_wait(TYPE
 .IB "*ivar" ,
 .B TYPE
 .I cmp_value
 .B );
-
-
-
 ./ sectionEnd
-
-
+./ sectionStart
+.B ********************************
+./ sectionEnd
 where TYPE is one of the point-to-point synchronization types specified by
 Table 5.
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B shmem_<TYPENAME>_wait_until(TYPE
 .IB "*ivar" ,
@@ -56,51 +44,35 @@ Table 5.
 .B TYPE
 .I cmp_value
 .B );
-
-
-
 ./ sectionEnd
-
-
-
 ./ sectionStart
-
+.B ***********DEPRECATED***********
+./ sectionEnd
+./ sectionStart
 .B void
 .B shmem_<TYPENAME>_wait(TYPE
 .IB "*ivar" ,
 .B TYPE
 .I cmp_value
 .B );
-
-
-
 ./ sectionEnd
-
-
+./ sectionStart
+.B ********************************
+./ sectionEnd
 where TYPE is one of the point-to-point synchronization types and has a
 corresponding TYPENAME specified by Table 5.
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "SHMEM_INT4_WAIT(ivar, cmp_value)"
 .BR "CALL " "SHMEM_INT4_WAIT_UNTIL(ivar, cmp, cmp_value)"
 .BR "CALL " "SHMEM_INT8_WAIT(ivar, cmp_value)"
 .BR "CALL " "SHMEM_INT8_WAIT_UNTIL(ivar, cmp, cmp_value)"
 .BR "CALL " "SHMEM_WAIT(ivar, cmp_value)"
 .BR "CALL " "SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
@@ -110,8 +82,6 @@ by another PE. If you are using  C/C++, the type of
 .I ivar
 should
 match that implied in the SYNOPSIS section. 
-
-
 .BR "IN " -
 .I cmp
 - The compare operator that compares 
@@ -119,9 +89,7 @@ match that implied in the SYNOPSIS section.
 with
 .IR "cmp\_value" .
 . If you are using Fortran, it must be of default kind.
-If you are using  C/C++, it must be of type \CTYPE{shmem\_cmp\_t}.
-
-
+If you are using  C/C++, it must be of type shmem\_cmp\_t.
 .BR "IN " -
 .I cmp\_value
 - 
@@ -135,12 +103,8 @@ the same size and kind as
 .IR "ivar" .
 .
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B shmem\_wait
 and 
 .B shmem\_wait\_until
@@ -183,60 +147,37 @@ argument compared with the
 using the comparison operator, 
 .IR "cmp" .
 . 
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 If you are using Fortran, 
 .I ivar
 must be a specific sized integer type
 according to the routine being called, as follows:
-
 .TP 25
 Routine
 Data type
 ./ sectionEnd
-
-
-
 ./ sectionStart
 .TP 25
 shmem\_wait, shmem\_wait\_until
 default INTEGER
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int4\_wait, shmem\_int4\_wait\_until
 INTEGER*4
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 shmem\_int8\_wait, shmem\_int8\_wait\_until
 INTEGER*8
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 As of OpenSHMEM[1.4], the 
 .B shmem\_wait
 routine is deprecated,
@@ -247,14 +188,9 @@ is equivalent to
 where 
 .I cmp
 is SHMEM\_CMP\_NE.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 Implementations must ensure that 
 .B shmem\_wait
 and
@@ -268,65 +204,40 @@ must not cause
 or 
 .B shmem\_wait\_until
 to return.
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 The following call returns when variable 
 .I ivar
 is not equal to 100:
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER*8 IVAR
 CALL SHMEM_INT8_WAIT(IVAR, INTEGER*8(100))
 .fi
-
-
-
 The following call to 
 .B SHMEM\_INT8\_WAIT\_UNTIL
 is equivalent to the
 call to 
 .B SHMEM\_INT8\_WAIT
 in example 1:
-
 .nf
 INCLUDE "shmem.fh"
-
 INTEGER*8 IVAR
 CALL SHMEM_INT8_WAIT_UNTIL(IVAR, SHMEM_CMP_NE, INTEGER*8(100))
 .fi
-
-
-
 The following  C/C++ call waits until the value in 
 .I ivar
 is set to
 be less than zero by a transfer from a remote PE:
-
 .nf
 #include <stdio.h>#include <shmem.h>
-
 int ivar;
 shmem_int_wait_until(&ivar, SHMEM_CMP_LT, 0);
 .fi
-
-
-
 The following Fortran example is in the context of a subroutine:
-
 .nf
 INCLUDE "shmem.fh"
-
 SUBROUTINE EXAMPLE()
 INTEGER FLAG_VAR
 COMMON/FLAG/FLAG_VAR
@@ -340,11 +251,6 @@ FLAG_VAR = FLAG_VALUE    !  reset the event variable for next time
 . . .
 END
 .fi
-
-
-
-
-
 .SS Table 5:
 Point-to-Point Synchronization Types and Names
 .TP 25

--- a/man/shmemalign.3
+++ b/man/shmemalign.3
@@ -1,1 +1,1 @@
-.so shmem_malloc.3
+.so shmem_align.3

--- a/man/shpalloc.3
+++ b/man/shpalloc.3
@@ -1,63 +1,40 @@
-.TH SHPALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHPALLOC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shpalloc \- 
 Allocates a block of memory from the symmetric heap.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "POINTER " "(addr, A(1))"
 .BR "INTEGER " "length, errcode, abort"
 .BR "CALL " "SHPALLOC(addr, length, errcode, abort)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "OUT " -
 .I addr
 - First word address of the allocated block.
-
-
 .BR "IN " -
 .I length
 - Number of words of memory requested. One word is 32 bits.
-
-
 .BR "OUT " -
 .I errcode
 - Error code is 0 if no error was detected;
 otherwise, it is a negative integer code for the type of error.
-
-
 .BR "IN " -
 .I abort
 - Abort code; nonzero requests abort on error;
 0 requests an error code.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 .B SHPALLOC
 allocates a block of memory from the program's symmetric heap
 that is greater than or equal to the size requested. To maintain symmetric heap
@@ -65,7 +42,6 @@ consistency, all PEs in an program must call
 .B SHPALLOC
 with the same
 value of length; if any PEs are missing, the program will hang.
-
 By using the Fortran POINTER mechanism in the following manner, you
 can use array 
 .I A
@@ -77,53 +53,33 @@ POINTER (
 , 
 .I A
 ())
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 Error Code
 Condition
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -1 
 Length is not an integer greater than 0
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -2
 No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 The total size of the symmetric heap is determined at job startup. One may
 adjust the size of the heap using the SHMEM\_SYMMETRIC\_SIZE environment
 variable (if available).
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 The symmetric heap allocation routines always return a pointer to corresponding
 symmetric objects across all PEs. The OpenSHMEM specification does not
 require that the virtual addresses are equal across all PEs. Nevertheless,
@@ -134,9 +90,4 @@ implementation may re-map the allocated block of memory based on agreed virtual
 address. Additionally, some operating systems provide an option to disable
 virtual address randomization, which enables predictable allocation of virtual
 memory addresses.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shpclmove.3
+++ b/man/shpclmove.3
@@ -1,67 +1,44 @@
-.TH SHPCLMOVE 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHPCLMOVE 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shpclmove \- 
 Extends a symmetric heap block or copies the contents of the block into a
 larger block.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "POINTER " "(addr, A(1))"
 .BR "INTEGER " "length, status, abort"
 .BR "CALL " "SHPCLMOVE (addr, length, status, abort)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "INOUT " -
 .I addr
 - On entry, first word address of the block to
 change; on exit, the new address of the block if it was moved.
-
-
 .BR "IN " -
 .I length
 - Requested new total length in words. One word is
 32 bits.
-
-
 .BR "OUT " -
 .I status
 - Status is 0 if the block was extended in
 place, 1 if it was moved, and a negative integer for the type of
 error detected.
-
-
 .BR "IN " -
 .I abort
 - Abort code. Nonzero requests abort on error;
 0 requests an error code.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B SHPCLMOVE
 routine either extends a symmetric heap block if the block
@@ -74,67 +51,41 @@ with the same value of
 .I addr
 to maintain symmetric heap
 consistency; if any PEs are missing, the program hangs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 Error Code
 Condition
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -1 
 Length is not an integer greater than 0
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -2
 No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -3
 Address is outside the bounds of the symmetric heap.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -4
 Block is already free.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -5
 Address is not at the beginning of a block.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shpdealloc.3
+++ b/man/shpdealloc.3
@@ -1,58 +1,37 @@
-.TH SHPDEALLOC 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH SHPDEALLOC 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 shpdealloc \- 
 Returns a memory block to the symmetric heap.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "POINTER " "(addr, A(1))"
 .BR "INTEGER " "errcode, abort"
 .BR "CALL " "SHPDEALLC(addr, errcode, abort)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
-
 .SH DESCRIPTION
 .SS Arguments
 .BR "IN " -
 .I addr
 -  First word address of the block to deallocate.
-
-
 .BR "OUT " -
 .I errcode
 - Error code is 0 if no error was detected;
 otherwise, it is a negative integer code for the type of error.
-
-
 .BR "IN " -
 .I abort
 - Abort code. Nonzero requests abort on error;
 0 requests an error code.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 SHPDEALLC returns a block of memory (allocated using 
 .B SHPALLOC
 ) to the
@@ -63,67 +42,41 @@ with the same
 value of 
 .I addr
 ; if any PEs are missing, the program hangs.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 Error Code
 Condition
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -1 
 Length is not an integer greater than 0
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -2
 No more memory is available from the system (checked if the request cannot be satisfied from the available blocks on the symmetric heap).
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -3
 Address is outside the bounds of the symmetric heap.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -4
 Block is already free.
 ./ sectionEnd
-
-
 ./ sectionStart
 .TP 25
 -5
 Address is not at the beginning of a block.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 None.
-
 ./ sectionEnd
-
-
-
-

--- a/man/shrealloc.3
+++ b/man/shrealloc.3
@@ -1,1 +1,1 @@
-.so shmem_malloc.3
+.so shmem_realloc.3

--- a/man/start_pes.3
+++ b/man/start_pes.3
@@ -1,4 +1,4 @@
-.TH START_PES 3 "Open Source Software Solutions, Inc.""OpenSHEMEM Library Documentation"
+.TH START_PES 3 "Open Source Software Solutions, Inc.""OpenSHMEM Library Documentation"
 ./ sectionStart
 .SH NAME
 start_pes \-  
@@ -6,60 +6,44 @@ Called at the beginning of an OpenSHMEM program to initialize the execution
 environment. This routine is deprecated and is provided for backwards
 compatibility. Implementations must include it, and the routine should
 function properly and may notify the user about deprecation of its use.
-
 ./ sectionEnd
-
-
 ./ sectionStart
 .SH   SYNOPSIS
 ./ sectionEnd
-
-
+./ sectionStart
+.B ***********DEPRECATED***********
+./ sectionEnd
 ./ sectionStart
 .SS C/C++:
-
 .B void
 .B start_pes(int
 .I npes
 .B );
-
-
-
 ./ sectionEnd
-
-
-
-
-
+./ sectionStart
+.B ********************************
+./ sectionEnd
+./ sectionStart
+.B ***********DEPRECATED***********
+./ sectionEnd
 ./ sectionStart
 .SS Fortran:
-
 .nf
-
 .BR "CALL " "START_PES(npes)"
-
 .fi
-
 ./ sectionEnd
-
-
-
-
-
 ./ sectionStart
-
+.B ********************************
+./ sectionEnd
+./ sectionStart
 .SH DESCRIPTION
 .SS Arguments
 .BR "npes " -
 .I Unused
 -  Should be set to 0.
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Description
-
 The 
 .B start\_pes
 routine initializes the OpenSHMEM execution
@@ -67,23 +51,13 @@ environment. An OpenSHMEM program must call
 .B start\_pes
 before
 calling any other OpenSHMEM routine.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS Return Values
-
 None.
-
 ./ sectionEnd
-
-
 ./ sectionStart
-
 .SS API Notes
-
 If any other OpenSHMEM call occurs before 
 .B start\_pes
 , the
@@ -97,7 +71,6 @@ Calling
 .B start\_pes
 more than once has no subsequent
 effect.
-
 As of OpenSHMEM Specification 1.2 the use of 
 .B start\_pes
 has
@@ -105,44 +78,26 @@ been deprecated. Although OpenSHMEM libraries are required to support the
 call, program users are encouraged to use 
 .B shmem\_init
 instead.
-
 ./ sectionEnd
-
-
-
-
 ./ sectionStart
 .SS Examples
-
-
-
 This is a simple program that calls 
 .B start\_pes
 :
-
 .nf
 PROGRAM PUT
 INCLUDE "shmem.fh"
-
 INTEGER TARG, SRC, RECEIVER, BAR
 COMMON /T/ TARG
 PARAMETER (RECEIVER=1)
 CALL START_PES(0)
-
 IF (SHMEM_MY_PE() .EQ. 0) THEN
    SRC = 33
    CALL SHMEM_INTEGER_PUT(TARG, SRC, 1, RECEIVER)
 ENDIF
-
 CALL SHMEM_BARRIER_ALL           ! SYNCHRONIZES SENDER AND RECEIVER
-
 IF (SHMEM_MY_PE() .EQ. RECEIVER) THEN
    PRINT*,'PE ', SHMEM_MY_PE(),' TARG=',TARG,' (expect 33)'
 ENDIF
 END
 .fi
-
-
-
-
-

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -1231,7 +1231,7 @@ def cleanManFile(man_file):
     """
     Remove all double newlines from manpage file.
     """
-    subprocess.call("tr -s '\n\n' < " + man_file.name + " > .tmpfile", shell=True)
+    subprocess.call("tr -s '\n' < " + man_file.name + " > .tmpfile", shell=True)
     subprocess.call("mv .tmpfile " + man_file.name, shell=True)
 
 def main():

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -23,8 +23,7 @@ def writePageHeader(functionName):
     """
 
     titleHeader = ".TH " + functionName.upper() + " 3 " \
-                     + "\"Open Source Software Solutions, Inc.\" " \
-                     + time.strftime("%m/%d/%Y") + " " \
+                     + "\"Open Source Software Solutions, Inc.\"" \
                      + "\"OpenSHMEM Library Documentation\"" + "\n"
     return titleHeader
 
@@ -1045,8 +1044,6 @@ def parseDeprecationTable(directory, gen_dir, build_fortran):
 def writeOshcc(gen_dir):
     manFile = open(gen_dir + '/' + "oshcc.1", "w")
     manFile.write(".TH " + "OSHCC" + " 1 " \
-                     + "\"Open Source Software Solutions, Inc.\" " \
-                     + time.strftime("%m/%d/%Y") + " " \
                      + "\"OpenSHMEM Library Documentation\"" + "\n")
     manFile.write(".SH NAME\n")
     manFile.write("oshcc - Compiles and links OpenSHMEM programs " + \
@@ -1080,8 +1077,6 @@ def writeOshcc(gen_dir):
 def writeOshCC(gen_dir):
     manFile = open(gen_dir + '/' + "oshc++.1", "w")
     manFile.write(".TH " + "OSHC++" + " 1 " \
-                     + "\"Open Source Software Solutions, Inc.\" " \
-                     + time.strftime("%m/%d/%Y") + " " \
                      + "\"OpenSHMEM Library Documentation\"" + "\n")
     manFile.write(".SH NAME\n")
     manFile.write("oshc++ - Compiles and links OpenSHMEM programs " + \
@@ -1115,8 +1110,6 @@ def writeOshCC(gen_dir):
 def writeOshfort(gen_dir):
     manFile = open(gen_dir + '/' + "oshfort.1", "w")
     manFile.write(".TH " + "OSHFORT" + " 1 " \
-                     + "\"Open Source Software Solutions, Inc.\" " \
-                     + time.strftime("%m/%d/%Y") + " " \
                      + "\"OpenSHMEM Library Documentation\"" + "\n")
     manFile.write(".SH NAME\n")
     manFile.write("oshfort - Compiles and links OpenSHMEM programs " + \
@@ -1150,8 +1143,6 @@ def writeOshfort(gen_dir):
 def writeOshrun(gen_dir):
     manFile = open(gen_dir + '/' + "oshrun.1", "w")
     manFile.write(".TH " + "OSHRUN" + " 1 " \
-                     + "\"Open Source Software Solutions, Inc.\" " \
-                     + time.strftime("%m/%d/%Y") + " " \
                      + "\"OpenSHMEM Library Documentation\"" + "\n")
     manFile.write(".SH NAME\n")
     manFile.write("oshrun - Run a OpenSHMEM program\n")
@@ -1159,6 +1150,7 @@ def writeOshrun(gen_dir):
     manFile.write(".B oshrun\n")
     manFile.write("launches the OpenSHMEM programs with a given number " + \
         "of processes.\n\n")
+    manFile.write("usage: oshrun [oshrun_options] [launcher_arguments]\n")
     manFile.write(".SH COMMAND LINE ARGUMENTS\n")
     manFile.write(".TP 8\n")
     manFile.write(".B --help | -h\n")

--- a/scripts/generate_manpages
+++ b/scripts/generate_manpages
@@ -6,6 +6,7 @@ import string
 import argparse
 import time
 import platform
+import subprocess
 
 # boldWordsC and boldWordsF are a set of the key words that will be
 # bolded in the man page
@@ -1231,6 +1232,15 @@ def convertFile(functionName, directory, gen_dir, build_fortran=False):
     manFile.close()
     texFile.close()
     writeLinkFunctions(functionName, linkFunctions, gen_dir)
+    return manFile
+
+# Quick fix for the extra newline problem seen in vimpager:
+def cleanManFile(man_file):
+    """
+    Remove all double newlines from manpage file.
+    """
+    subprocess.call("tr -s '\n\n' < " + man_file.name + " > .tmpfile", shell=True)
+    subprocess.call("mv .tmpfile " + man_file.name, shell=True)
 
 def main():
     parser = argparse.ArgumentParser(description='Generate OpenSHMEM manpages')
@@ -1243,6 +1253,7 @@ def main():
     parser.add_argument('--build-fortran', required=False, default=False, action="store_true",
                         help='build Fortran manpages (requires setting -d)')
     args = parser.parse_args()
+
 
     if (args.directory == None) and (args.filename == None):
         parser.print_usage()
@@ -1270,9 +1281,12 @@ def main():
                     print("Error: " + routine + ".tex is not in the given directory")
                     exit(1)
                 else:
-                    convertFile(routine, args.directory, args.output_directory, args.build_fortran)
+                    man_file = convertFile(routine, args.directory, args.output_directory, args.build_fortran)
+                    cleanManFile(man_file)
+
             parseDeprecationTable(args.directory, args.output_directory, args.build_fortran)
             writeExecFunctions(args.output_directory)
+
     else:
         if not os.path.isfile(args.filename):
             print("Error: input file, " + args.filename + ", does not appear to exist.")
@@ -1284,7 +1298,8 @@ def main():
                 last = args.filename.find("/", last) + 1
 
             functionName = args.filename[last:per]
-            convertFile(functionName, args.filename[:last], args.output_directory)
+            man_file = convertFile(functionName, args.filename[:last], args.output_directory)
+            cleanManFile(man_file)
 
 if __name__== "__main__":
     main()


### PR DESCRIPTION
This addresses issue #429, which reports extra spacing in the manpages when using [Vimpager](https://github.com/rkitover/vimpager).  I've applied a quick fix that removes the newlines from the generated manpage files post-mortem.  I also fixed a few minor mistakes in the manpages themselves.