### PR TITLE
Add missing manpages, primarily in collectives

### DIFF
--- a/man/shmem_alltoall32.3
+++ b/man/shmem_alltoall32.3
@@ -1,0 +1,1 @@
+.so shmem_alltoall.3

--- a/man/shmem_alltoall64.3
+++ b/man/shmem_alltoall64.3
@@ -1,0 +1,1 @@
+.so shmem_alltoall.3

--- a/man/shmem_alltoalls32.3
+++ b/man/shmem_alltoalls32.3
@@ -1,0 +1,1 @@
+.so shmem_alltoalls.3

--- a/man/shmem_alltoalls64.3
+++ b/man/shmem_alltoalls64.3
@@ -1,0 +1,1 @@
+.so shmem_alltoalls.3

--- a/man/shmem_broadcast32.3
+++ b/man/shmem_broadcast32.3
@@ -1,0 +1,1 @@
+.so shmem_broadcast.3

--- a/man/shmem_broadcast64.3
+++ b/man/shmem_broadcast64.3
@@ -1,0 +1,1 @@
+.so shmem_broadcast.3

--- a/man/shmem_cmp_.3
+++ b/man/shmem_cmp_.3
@@ -1,0 +1,1 @@
+.so shmem_test.3

--- a/man/shmem_collect32.3
+++ b/man/shmem_collect32.3
@@ -1,0 +1,1 @@
+.so shmem_collect.3

--- a/man/shmem_collect64.3
+++ b/man/shmem_collect64.3
@@ -1,0 +1,1 @@
+.so shmem_collect.3

--- a/man/shmem_complexd_prod_to_all.3
+++ b/man/shmem_complexd_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_complexd_sum_to_all.3
+++ b/man/shmem_complexd_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_complexf_prod_to_all.3
+++ b/man/shmem_complexf_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_complexf_sum_to_all.3
+++ b/man/shmem_complexf_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_double_max_to_all.3
+++ b/man/shmem_double_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_double_min_to_all.3
+++ b/man/shmem_double_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_double_prod_to_all.3
+++ b/man/shmem_double_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_double_sum_to_all.3
+++ b/man/shmem_double_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_fcollect32.3
+++ b/man/shmem_fcollect32.3
@@ -1,0 +1,1 @@
+.so shmem_collect.3

--- a/man/shmem_fcollect64.3
+++ b/man/shmem_fcollect64.3
@@ -1,0 +1,1 @@
+.so shmem_collect.3

--- a/man/shmem_float_max_to_all.3
+++ b/man/shmem_float_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_float_min_to_all.3
+++ b/man/shmem_float_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_float_prod_to_all.3
+++ b/man/shmem_float_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_float_sum_to_all.3
+++ b/man/shmem_float_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_and_to_all.3
+++ b/man/shmem_int_and_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_max_to_all.3
+++ b/man/shmem_int_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_min_to_all.3
+++ b/man/shmem_int_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_or_to_all.3
+++ b/man/shmem_int_or_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_prod_to_all.3
+++ b/man/shmem_int_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_sum_to_all.3
+++ b/man/shmem_int_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_int_xor_to_all.3
+++ b/man/shmem_int_xor_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_and_to_all.3
+++ b/man/shmem_long_and_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_max_to_all.3
+++ b/man/shmem_long_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_min_to_all.3
+++ b/man/shmem_long_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_or_to_all.3
+++ b/man/shmem_long_or_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_prod_to_all.3
+++ b/man/shmem_long_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_sum_to_all.3
+++ b/man/shmem_long_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_long_xor_to_all.3
+++ b/man/shmem_long_xor_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longdouble_max_to_all.3
+++ b/man/shmem_longdouble_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longdouble_min_to_all.3
+++ b/man/shmem_longdouble_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longdouble_prod_to_all.3
+++ b/man/shmem_longdouble_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longdouble_sum_to_all.3
+++ b/man/shmem_longdouble_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_and_to_all.3
+++ b/man/shmem_longlong_and_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_max_to_all.3
+++ b/man/shmem_longlong_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_min_to_all.3
+++ b/man/shmem_longlong_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_or_to_all.3
+++ b/man/shmem_longlong_or_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_prod_to_all.3
+++ b/man/shmem_longlong_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_sum_to_all.3
+++ b/man/shmem_longlong_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_longlong_xor_to_all.3
+++ b/man/shmem_longlong_xor_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_putmem_nbi.3
+++ b/man/shmem_putmem_nbi.3
@@ -1,0 +1,1 @@
+.so shmem_put_nbi.3

--- a/man/shmem_short_and_to_all.3
+++ b/man/shmem_short_and_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_max_to_all.3
+++ b/man/shmem_short_max_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_min_to_all.3
+++ b/man/shmem_short_min_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_or_to_all.3
+++ b/man/shmem_short_or_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_prod_to_all.3
+++ b/man/shmem_short_prod_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_sum_to_all.3
+++ b/man/shmem_short_sum_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3

--- a/man/shmem_short_xor_to_all.3
+++ b/man/shmem_short_xor_to_all.3
@@ -1,0 +1,1 @@
+.so shmem_reductions.3


### PR DESCRIPTION
Several generated manpages for collectives were missing - all of them references to the "primary" manpage, e.g. `shmem_reductions.3`.

Note that this suggested issue #482.