### PR TITLE
Add context argument to shemm_internal routines.

### DIFF
--- a/src/atomic_c.c4
+++ b/src/atomic_c.c4
@@ -249,8 +249,8 @@ shmem_swap(long *target, long value, int pe)
     SHMEM_ERR_CHECK_PE(pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(long));
 
-    shmem_internal_swap(ctx, target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG);
-    shmem_internal_get_wait(ctx);
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 #endif

--- a/src/atomic_c.c4
+++ b/src/atomic_c.c4
@@ -230,9 +230,9 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_SET')
         SHMEM_ERR_CHECK_INITIALIZED();                          \
         SHMEM_ERR_CHECK_PE(pe);                                 \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));        \
-        shmem_internal_swap(target, &value, &newval,            \
+        shmem_internal_swap(ctx, target, &value, &newval,       \
                             sizeof(TYPE), pe, ITYPE);           \
-        shmem_internal_get_wait();                              \
+        shmem_internal_get_wait(ctx);                           \
         return newval;                                          \
     }
 
@@ -249,8 +249,8 @@ shmem_swap(long *target, long value, int pe)
     SHMEM_ERR_CHECK_PE(pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(long));
 
-    shmem_internal_swap(target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG);
-    shmem_internal_get_wait();
+    shmem_internal_swap(ctx, target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG);
+    shmem_internal_get_wait(ctx);
     return newval;
 }
 #endif
@@ -264,9 +264,9 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
-        shmem_internal_cswap(target, &value, &newval, &cond,            \
+        shmem_internal_cswap(ctx, target, &value, &newval, &cond,       \
                              sizeof(TYPE), pe, ITYPE);                  \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_get_wait(ctx);                                   \
         return newval;                                                  \
     }
 
@@ -279,9 +279,9 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
-        shmem_internal_cswap(target, &value, &newval, &cond,            \
+        shmem_internal_cswap(ctx, target, &value, &newval, &cond,       \
                              sizeof(TYPE), pe, ITYPE);                  \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_get_wait(ctx);                                   \
         return newval;                                                  \
     }
 
@@ -293,7 +293,7 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
-        shmem_internal_atomic_small(target, &tmp, sizeof(TYPE), pe,     \
+        shmem_internal_atomic_small(ctx, target, &tmp, sizeof(TYPE), pe,\
                                     SHM_INTERNAL_SUM, ITYPE);           \
     }
 
@@ -305,9 +305,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
-        shmem_internal_fetch_atomic(target, &tmp, &oldval, sizeof(TYPE),\
-                                    pe, SHM_INTERNAL_SUM, ITYPE);       \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_fetch_atomic(ctx, target, &tmp, &oldval,         \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
+                                    ITYPE);                             \
+        shmem_internal_get_wait(ctx);                                   \
         return oldval;                                                  \
     }
 
@@ -319,9 +320,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_INITIALIZED();                                  \
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
-        shmem_internal_fetch_atomic(target, &tmp, &oldval, sizeof(TYPE),\
-                                    pe, SHM_INTERNAL_SUM, ITYPE);       \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_fetch_atomic(ctx, target, &tmp, &oldval,         \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
+                                    ITYPE);                             \
+        shmem_internal_get_wait(ctx);                                   \
         return oldval;                                                  \
     }
 
@@ -333,8 +335,8 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_atomic_small(target, &value, sizeof(TYPE), pe,   \
-                                    SHM_INTERNAL_SUM, ITYPE);           \
+        shmem_internal_atomic_small(ctx, target, &value, sizeof(TYPE),  \
+                                    pe, SHM_INTERNAL_SUM, ITYPE);       \
     }
 
 
@@ -347,9 +349,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_fetch_atomic(target, &value, &oldval, sizeof(TYPE), \
-                                    pe, SHM_INTERNAL_SUM, ITYPE);       \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_fetch_atomic(ctx, target, &value, &oldval,       \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
+                                    ITYPE);                             \
+        shmem_internal_get_wait(ctx);                                   \
         return oldval;                                                  \
     }
 
@@ -362,9 +365,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_fetch_atomic(target, &value, &oldval, sizeof(TYPE), \
-                                    pe, SHM_INTERNAL_SUM, ITYPE);       \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_fetch_atomic(ctx, target, &value, &oldval,       \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
+                                    ITYPE);                             \
+        shmem_internal_get_wait(ctx);                                   \
         return oldval;                                                  \
     }
 
@@ -378,9 +382,9 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_atomic_fetch(&val, (void *) source, sizeof(TYPE),\
-                                    pe, ITYPE);                         \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_atomic_fetch(ctx, &val, (void *) source,         \
+                                    sizeof(TYPE), pe, ITYPE);           \
+        shmem_internal_get_wait(ctx);                                   \
         return val;                                                     \
     }
 
@@ -392,8 +396,8 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE));                  \
                                                                         \
-        shmem_internal_atomic_set((void *) dest, &value, sizeof(TYPE),  \
-                                  pe, ITYPE);                           \
+        shmem_internal_atomic_set(ctx, (void *) dest, &value,           \
+                                  sizeof(TYPE), pe, ITYPE);             \
     }
 
 
@@ -404,8 +408,8 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_atomic_small(target, &value, sizeof(TYPE), pe,   \
-                                    SHM_INTERNAL_BXOR, ITYPE);          \
+        shmem_internal_atomic_small(ctx, target, &value, sizeof(TYPE),  \
+                                    pe, SHM_INTERNAL_BXOR, ITYPE);      \
     }
 
 
@@ -416,8 +420,8 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_atomic_small(target, &value, sizeof(TYPE), pe,   \
-                                    SHM_INTERNAL_BAND, ITYPE);          \
+        shmem_internal_atomic_small(ctx, target, &value, sizeof(TYPE),  \
+                                    pe, SHM_INTERNAL_BAND, ITYPE);      \
     }
 
 
@@ -428,8 +432,8 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
-        shmem_internal_atomic_small(target, &value, sizeof(TYPE), pe,   \
-                                    SHM_INTERNAL_BOR, ITYPE);           \
+        shmem_internal_atomic_small(ctx, target, &value, sizeof(TYPE),  \
+                                    pe, SHM_INTERNAL_BOR, ITYPE);       \
     }
 
 
@@ -442,9 +446,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                              \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
-        shmem_internal_fetch_atomic(target, &value, &oldval, sizeof(TYPE),   \
-                                    pe, SHM_INTERNAL_BXOR, ITYPE);           \
-        shmem_internal_get_wait();                                           \
+        shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_BXOR,     \
+                                    ITYPE);                                  \
+        shmem_internal_get_wait(ctx);                                        \
         return oldval;                                                       \
     }
 
@@ -457,9 +462,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                              \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
-        shmem_internal_fetch_atomic(target, &value, &oldval, sizeof(TYPE),   \
-                                    pe, SHM_INTERNAL_BAND, ITYPE);           \
-        shmem_internal_get_wait();                                           \
+        shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_BAND,     \
+                                    ITYPE);                                  \
+        shmem_internal_get_wait(ctx);                                        \
         return oldval;                                                       \
     }
 
@@ -472,9 +478,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                              \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
-        shmem_internal_fetch_atomic(target, &value, &oldval, sizeof(TYPE),   \
-                                    pe, SHM_INTERNAL_BOR, ITYPE);            \
-        shmem_internal_get_wait();                                           \
+        shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
+                                    sizeof(TYPE), pe, SHM_INTERNAL_BOR,      \
+                                    ITYPE);                                  \
+        shmem_internal_get_wait(ctx);                                        \
         return oldval;                                                       \
     }
 

--- a/src/atomic_f.c
+++ b/src/atomic_f.c
@@ -40,9 +40,9 @@ FC_SHMEM_SWAP(fortran_integer_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, SIZEOF_FORTRAN_INTEGER);
 
-    shmem_internal_swap(target, value, &newval, SIZEOF_FORTRAN_INTEGER,
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, SIZEOF_FORTRAN_INTEGER,
                         *pe, SHM_INTERNAL_FORTRAN_INTEGER);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -63,9 +63,9 @@ FC_SHMEM_INT4_SWAP(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_swap(target, value, &newval, 4,
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 4,
                         *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -86,9 +86,9 @@ FC_SHMEM_INT8_SWAP(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_swap(target, value, &newval, 8,
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 8,
                         *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -111,9 +111,9 @@ FC_SHMEM_REAL4_SWAP(float *target,
 
     shmem_internal_assert(sizeof(float) == 4);
 
-    shmem_internal_swap(target, value, &newval, 4,
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 4,
                         *pe, SHM_INTERNAL_FLOAT);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -136,9 +136,9 @@ FC_SHMEM_REAL8_SWAP(double *target,
 
     shmem_internal_assert(sizeof(double) == 8);
 
-    shmem_internal_swap(target, value, &newval, 8,
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 8,
                         *pe, SHM_INTERNAL_DOUBLE);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -161,10 +161,10 @@ FC_SHMEM_INT4_CSWAP(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_cswap(target, value, &newval, cond,
+    shmem_internal_cswap(SHMEM_CTX_DEFAULT, target, value, &newval, cond,
                          4,
                          *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -187,10 +187,10 @@ FC_SHMEM_INT8_CSWAP(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_cswap(target, value, &newval, cond,
+    shmem_internal_cswap(SHMEM_CTX_DEFAULT, target, value, &newval, cond,
                          8,
                          *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return newval;
 }
 
@@ -211,9 +211,9 @@ FC_SHMEM_INT4_FADD(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_fetch_atomic(target, value, &oldval, 4,
+    shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, value, &oldval, 4,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return oldval;
 }
 
@@ -234,9 +234,9 @@ FC_SHMEM_INT8_FADD(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_fetch_atomic(target, value, &oldval, 8,
+    shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, value, &oldval, 8,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return oldval;
 }
 
@@ -255,9 +255,9 @@ FC_SHMEM_INT4_FINC(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_fetch_atomic(target, &tmp, &oldval, 4,
+    shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, &tmp, &oldval, 4,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return oldval;
 }
 
@@ -276,9 +276,9 @@ FC_SHMEM_INT8_FINC(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_fetch_atomic(target, &tmp, &oldval, 8,
+    shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, &tmp, &oldval, 8,
                                 *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     return oldval;
 }
 
@@ -297,7 +297,7 @@ FC_SHMEM_INT4_ADD(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_atomic_small(target, value, 4,
+    shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, target, value, 4,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
 }
 
@@ -316,7 +316,7 @@ FC_SHMEM_INT8_ADD(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_atomic_small(target, value, 8,
+    shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, target, value, 8,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
 }
 
@@ -335,7 +335,7 @@ FC_SHMEM_INT4_INC(int32_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
-    shmem_internal_atomic_small(target, &tmp, 4,
+    shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, target, &tmp, 4,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
 }
 
@@ -354,7 +354,7 @@ FC_SHMEM_INT8_INC(int64_t *target,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
-    shmem_internal_atomic_small(target, &tmp, 8,
+    shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, target, &tmp, 8,
                                  *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
 }
 
@@ -373,8 +373,8 @@ FC_SHMEM_INT4_FETCH(int32_t *source,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(source, 4);
 
-    shmem_internal_atomic_fetch(&val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 
     return val;
 }
@@ -394,8 +394,8 @@ FC_SHMEM_INT8_FETCH(int64_t *source,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(source, 8);
 
-    shmem_internal_atomic_fetch(&val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 
     return val;
 }
@@ -417,8 +417,8 @@ FC_SHMEM_REAL4_FETCH(float *source,
 
     shmem_internal_assert(sizeof(float) == 4);
 
-    shmem_internal_atomic_fetch(&val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait();
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 
     return val;
 }
@@ -440,8 +440,8 @@ FC_SHMEM_REAL8_FETCH(double *source,
 
     shmem_internal_assert(sizeof(double) == 8);
 
-    shmem_internal_atomic_fetch(&val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait();
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 
     return val;
 }
@@ -461,7 +461,7 @@ FC_SHMEM_INT4_SET(int32_t *dest,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, 4);
 
-    shmem_internal_atomic_set((void *) dest, (const void *) value, 4, *pe,
+    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, (void *) dest, (const void *) value, 4, *pe,
                               SHM_INTERNAL_INT32);
 }
 
@@ -480,7 +480,7 @@ FC_SHMEM_INT8_SET(int64_t *dest,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, 8);
 
-    shmem_internal_atomic_set((void *) dest, (const void *) value, 8, *pe,
+    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, (void *) dest, (const void *) value, 8, *pe,
                               SHM_INTERNAL_INT64);
 }
 
@@ -501,7 +501,7 @@ FC_SHMEM_REAL4_SET(float *dest,
 
     shmem_internal_assert(sizeof(float) == 4);
 
-    shmem_internal_atomic_set((void *) dest, (const void *) value, 4, *pe,
+    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, (void *) dest, (const void *) value, 4, *pe,
                               SHM_INTERNAL_INT32);
 }
 
@@ -522,6 +522,6 @@ FC_SHMEM_REAL8_SET(double *dest,
 
     shmem_internal_assert(sizeof(double) == 8);
 
-    shmem_internal_atomic_set((void *) dest, (const void *) value, 8, *pe,
+    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, (void *) dest, (const void *) value, 8, *pe,
                               SHM_INTERNAL_INT64);
 }

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -409,7 +409,7 @@ shmem_internal_sync_dissem(int PE_start, int logPE_stride, int PE_size, long *pS
     }
 
     /* Ensure local pSync decrements are done before a subsequent barrier */
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
 
 
@@ -443,7 +443,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         }
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* send completion ack to all peers */
         for (pe = PE_start,i=0; i < PE_size; pe += stride, i++) {
@@ -531,7 +531,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* send completion ack to all peers */
         for (i = 0 ; i < num_children ; ++i) {
@@ -599,7 +599,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_quiet();
+        shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
         /* let everyone know that it's safe to send to us */
         for (pe = PE_start + stride, i = 1 ;
@@ -627,7 +627,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
         shmem_internal_atomic_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size, PE_start,
                                  op, datatype, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
@@ -681,7 +681,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_quiet();
+        shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
         /* let everyone know that it's safe to send to us */
         for (i = 0 ; i < num_children ; ++i) {
@@ -710,7 +710,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
                                  count * type_size, parent,
                                  op, datatype, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
@@ -786,7 +786,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size, peer,
                               &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready, sizeof(long), peer);
         SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, ps_data_ready);
@@ -816,7 +816,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
                 shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion);
                 shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-                shmem_internal_fence();
+                shmem_internal_fence(SHMEM_CTX_DEFAULT);
                 shmem_internal_put_small(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer);
             }
@@ -826,7 +826,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
                 shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion);
                 shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-                shmem_internal_fence();
+                shmem_internal_fence(SHMEM_CTX_DEFAULT);
                 shmem_internal_put_small(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer);
 
@@ -844,7 +844,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size,
                                   peer, &completion);
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-            shmem_internal_fence();
+            shmem_internal_fence(SHMEM_CTX_DEFAULT);
             shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready,
                                      sizeof(long), peer);
         }
@@ -967,7 +967,7 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         /* ensure ordering */
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* send completion update */
         shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
@@ -1016,7 +1016,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + iter_offset, (char*) target + iter_offset,
                              len, next_proc, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* send completion for this round to next proc.  Note that we
            only ever sent to next_proc and there's a shmem_fence
@@ -1078,7 +1078,7 @@ shmem_internal_fcollect_recdbl(void *target, const void *source, size_t len,
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + curr_offset, (char*) target + curr_offset,
                               distance * len, real_peer, &completion);
         shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
-        shmem_internal_fence();
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* mark completion for this round */
         shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, &pSync_ints[i], &one, sizeof(int),
@@ -1097,7 +1097,7 @@ shmem_internal_fcollect_recdbl(void *target, const void *source, size_t len,
         }
     }
 
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
 
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -258,7 +258,7 @@ shmem_internal_sync_linear(int PE_start, int logPE_stride, int PE_size, long *pS
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
@@ -266,19 +266,19 @@ shmem_internal_sync_linear(int PE_start, int logPE_stride, int PE_size, long *pS
         for (pe = PE_start + stride, i = 1 ;
              i < PE_size ;
              i++, pe += stride) {
-            shmem_internal_put_small(pSync, &one, sizeof(one), pe);
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe);
         }
 
     } else {
         /* send message to root */
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), PE_start,
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), PE_start,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -318,13 +318,13 @@ shmem_internal_sync_tree(int PE_start, int logPE_stride, int PE_size, long *pSyn
             /* The root of the tree */
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero),
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
-                shmem_internal_atomic_small(pSync, &one, sizeof(one),
+                shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                             children[i],
                                             SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
             }
@@ -333,20 +333,20 @@ shmem_internal_sync_tree(int PE_start, int logPE_stride, int PE_size, long *pSyn
             /* Middle of the tree */
 
             /* send ack to parent */
-            shmem_internal_atomic_small(pSync, &one, sizeof(one),
+            shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                         parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
             /* wait for ack from parent */
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children  + 1);
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero),
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
-                shmem_internal_atomic_small(pSync, &one, sizeof(one),
+                shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                             children[i],
                                             SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
             }
@@ -356,14 +356,14 @@ shmem_internal_sync_tree(int PE_start, int logPE_stride, int PE_size, long *pSyn
         /* Leaf node */
 
         /* send message up psync tree */
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), parent,
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), parent,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -392,7 +392,7 @@ shmem_internal_sync_dissem(int PE_start, int logPE_stride, int PE_size, long *pS
         to = ((coll_rank + distance) % PE_size);
         to = PE_start + (to * stride);
 
-        shmem_internal_atomic_small(&pSync_ints[i], &one, sizeof(int),
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, &pSync_ints[i], &one, sizeof(int),
                                     to,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
 
@@ -403,7 +403,7 @@ shmem_internal_sync_dissem(int PE_start, int logPE_stride, int PE_size, long *pS
         shmem_internal_assert(pSync_ints[i] < 3);
 
         /* this slot is no longer used, so subtract off results now */
-        shmem_internal_atomic_small(&pSync_ints[i], &neg_one, sizeof(int),
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, &pSync_ints[i], &neg_one, sizeof(int),
                                     shmem_internal_my_pe,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
     }
@@ -439,16 +439,16 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         /* send data to all peers */
         for (pe = PE_start,i=0; i < PE_size; pe += stride, i++) {
             if (pe == shmem_internal_my_pe) continue;
-            shmem_internal_put_nb(target, source, len, pe, &completion);
+            shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, len, pe, &completion);
         }
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         shmem_internal_fence();
 
         /* send completion ack to all peers */
         for (pe = PE_start,i=0; i < PE_size; pe += stride, i++) {
             if (pe == shmem_internal_my_pe) continue;
-            shmem_internal_put_small(pSync, &one, sizeof(long), pe);
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(long), pe);
         }
 
         if (1 == complete) {
@@ -456,7 +456,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
             /* Clear pSync */
-            shmem_internal_put_small(pSync, &zero, sizeof(zero),
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                      shmem_internal_my_pe);
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
         }
@@ -466,13 +466,13 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
         if (1 == complete) {
             /* send ack back to root */
-            shmem_internal_atomic_small(pSync, &one, sizeof(one),
+            shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                         real_root,
                                         SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
         }
@@ -518,7 +518,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
 
             /* if complete, send ack */
             if (1 == complete) {
-                shmem_internal_atomic_small(pSync, &one, sizeof(one),
+                shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                             parent,
                                             SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
             }
@@ -526,16 +526,16 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
 
         /* send data to all leaves */
         for (i = 0 ; i < num_children ; ++i) {
-            shmem_internal_put_nb(target, send_buf, len, children[i],
+            shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, send_buf, len, children[i],
                                   &completion);
         }
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         shmem_internal_fence();
 
         /* send completion ack to all peers */
         for (i = 0 ; i < num_children ; ++i) {
-            shmem_internal_put_small(pSync, &one, sizeof(long),
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(long),
                                      children[i]);
         }
 
@@ -548,7 +548,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
@@ -558,13 +558,13 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
 
         /* if complete, send ack */
         if (1 == complete) {
-            shmem_internal_atomic_small(pSync, &one, sizeof(one),
+            shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
                                         parent,
                                         SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
         }
 
         /* Clear pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero),
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
                                  shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
@@ -596,23 +596,23 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
         /* update our target buffer with our contribution.  The put
            will flush any atomic cache value that may currently
            exist. */
-        shmem_internal_put_nb(target, source, count * type_size,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_quiet();
 
         /* let everyone know that it's safe to send to us */
         for (pe = PE_start + stride, i = 1 ;
              i < PE_size ;
              i++, pe += stride) {
-            shmem_internal_put_small(pSync, &one, sizeof(one), pe);
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe);
         }
 
         /* Wait for others to acknowledge sending data */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
     } else {
@@ -620,16 +620,16 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
         /* send data, ack, and wait for completion */
-        shmem_internal_atomic_nb(target, source, count * type_size, PE_start,
+        shmem_internal_atomic_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size, PE_start,
                                  op, datatype, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence();
 
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
 
     /* broadcast out */
@@ -678,21 +678,21 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
         /* update our target buffer with our contribution.  The put
            will flush any atomic cache value that may currently
            exist. */
-        shmem_internal_put_nb(target, source, count * type_size,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_quiet();
 
         /* let everyone know that it's safe to send to us */
         for (i = 0 ; i < num_children ; ++i) {
-            shmem_internal_put_small(pSync + 1, &one, sizeof(one), children[i]);
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync + 1, &one, sizeof(one), children[i]);
         }
 
         /* Wait for others to acknowledge sending data */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children);
 
         /* reset pSync */
-        shmem_internal_put_small(pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     }
 
@@ -701,17 +701,18 @@ shmem_internal_op_to_all_tree(void *target, const void *source, int count, int t
         SHMEM_WAIT(pSync + 1, 0);
 
         /* reset pSync */
-        shmem_internal_put_small(pSync + 1, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync + 1, &zero, sizeof(zero), shmem_internal_my_pe);
         SHMEM_WAIT_UNTIL(pSync + 1, SHMEM_CMP_EQ, 0);
 
         /* send data, ack, and wait for completion */
-        shmem_internal_atomic_nb(target, (num_children == 0) ? source : target,
+        shmem_internal_atomic_nb(SHMEM_CTX_DEFAULT, target, 
+                                 (num_children == 0) ? source : target,
                                  count * type_size, parent,
                                  op, datatype, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence();
 
-        shmem_internal_atomic_small(pSync, &one, sizeof(one), parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
 
     /* broadcast out */
@@ -782,18 +783,18 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
         /* Wait for target ready, required when source and target overlap */
         SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, ps_target_ready);
 
-        shmem_internal_put_nb(target, current_target, wrk_size, peer,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size, peer,
                               &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence();
 
-        shmem_internal_put_small(pSync_extra_peer, &ps_data_ready, sizeof(long), peer);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready, sizeof(long), peer);
         SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, ps_data_ready);
 
     } else {
         if (my_id < PE_size - pow2_proc) {
             int peer = (my_id + pow2_proc) * stride + PE_start;
-            shmem_internal_put_small(pSync_extra_peer, &ps_target_ready, sizeof(long), peer);
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_target_ready, sizeof(long), peer);
 
             SHMEM_WAIT_UNTIL(pSync_extra_peer, SHMEM_CMP_EQ, ps_data_ready);
             shmem_internal_reduce_local(op, datatype, count, target, current_target);
@@ -808,25 +809,25 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
             int peer = (my_id ^ (1 << i)) * stride + PE_start;
 
             if (shmem_internal_my_pe < peer) {
-                shmem_internal_put_small(step_psync, &ps_target_ready,
+                shmem_internal_put_small(SHMEM_CTX_DEFAULT, step_psync, &ps_target_ready,
                                          sizeof(long), peer);
                 SHMEM_WAIT_UNTIL(step_psync, SHMEM_CMP_EQ, ps_data_ready);
 
-                shmem_internal_put_nb(target, current_target,
+                shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion);
-                shmem_internal_put_wait(&completion);
+                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
                 shmem_internal_fence();
-                shmem_internal_put_small(step_psync, &ps_data_ready,
+                shmem_internal_put_small(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer);
             }
             else {
                 SHMEM_WAIT_UNTIL(step_psync, SHMEM_CMP_EQ, ps_target_ready);
 
-                shmem_internal_put_nb(target, current_target,
+                shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion);
-                shmem_internal_put_wait(&completion);
+                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
                 shmem_internal_fence();
-                shmem_internal_put_small(step_psync, &ps_data_ready,
+                shmem_internal_put_small(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer);
 
                 SHMEM_WAIT_UNTIL(step_psync, SHMEM_CMP_EQ, ps_data_ready);
@@ -840,11 +841,11 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, int count, 
         if (my_id < PE_size - pow2_proc) {
             int peer = (my_id + pow2_proc) * stride + PE_start;
 
-            shmem_internal_put_nb(target, current_target, wrk_size,
+            shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size,
                                   peer, &completion);
-            shmem_internal_put_wait(&completion);
+            shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence();
-            shmem_internal_put_small(pSync_extra_peer, &ps_data_ready,
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready,
                                      sizeof(long), peer);
         }
 
@@ -888,7 +889,7 @@ shmem_internal_collect_linear(void *target, const void *source, size_t len,
         my_offset = 0;
         tmp[0] = (long) len; /* FIXME: Potential truncation of size_t into long */
         tmp[1] = 1; /* FIXME: Packing flag with data relies on byte ordering */
-        shmem_internal_put_small(pSync, tmp, 2 * sizeof(long), PE_start + stride);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, tmp, 2 * sizeof(long), PE_start + stride);
     }
     else {
         /* wait for send data */
@@ -899,7 +900,7 @@ shmem_internal_collect_linear(void *target, const void *source, size_t len,
         if (shmem_internal_my_pe < PE_start + stride * (PE_size - 1)) {
             tmp[0] = (long) (my_offset + len);
             tmp[1] = 1;
-            shmem_internal_put_small(pSync, tmp, 2 * sizeof(long),
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, tmp, 2 * sizeof(long),
                                      shmem_internal_my_pe + stride);
         }
     }
@@ -911,7 +912,7 @@ shmem_internal_collect_linear(void *target, const void *source, size_t len,
     peer = start_pe;
     do {
         if (len > 0) {
-            shmem_internal_put_nbi(((uint8_t *) target) + my_offset, source,
+            shmem_internal_put_nbi(SHMEM_CTX_DEFAULT, ((uint8_t *) target) + my_offset, source,
                                   len, peer);
         }
         peer = shmem_internal_circular_iter_next(peer, PE_start, logPE_stride,
@@ -949,27 +950,27 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
         if (source != target) memcpy(target, source, len);
 
         /* send completion update */
-        shmem_internal_atomic_small(pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for N updates */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size);
 
         /* Clear pSync */
         tmp = 0;
-        shmem_internal_put_small(pSync, &tmp, sizeof(tmp), PE_start);
+        shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(tmp), PE_start);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     } else {
         /* Push data into the target */
         size_t offset = ((shmem_internal_my_pe - PE_start) / stride) * len;
-        shmem_internal_put_nb((char*) target + offset, source, len, PE_start,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + offset, source, len, PE_start,
                               &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         /* ensure ordering */
         shmem_internal_fence();
 
         /* send completion update */
-        shmem_internal_atomic_small(pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(long), PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
     }
 
     shmem_internal_bcast(target, target, len * PE_size, 0, PE_start, logPE_stride,
@@ -1012,23 +1013,23 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
         size_t iter_offset = ((my_id + 1 - i + PE_size) % PE_size) * len;
 
         /* send data to me + 1 */
-        shmem_internal_put_nb((char*) target + iter_offset, (char*) target + iter_offset,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + iter_offset, (char*) target + iter_offset,
                              len, next_proc, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence();
 
         /* send completion for this round to next proc.  Note that we
            only ever sent to next_proc and there's a shmem_fence
            between successive calls to the put above.  So a rolling
            counter is safe here. */
-        shmem_internal_atomic_small(pSync, &one, sizeof(long), next_proc, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(long), next_proc, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for completion for this round */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_GE, i);
     }
 
     /* zero out psync */
-    shmem_internal_put_small(pSync, &zero, sizeof(long), shmem_internal_my_pe);
+    shmem_internal_put_small(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(long), shmem_internal_my_pe);
     SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 }
 
@@ -1074,20 +1075,20 @@ shmem_internal_fcollect_recdbl(void *target, const void *source, size_t len,
         int real_peer = PE_start + (peer * stride);
 
         /* send data to peer */
-        shmem_internal_put_nb((char*) target + curr_offset, (char*) target + curr_offset,
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + curr_offset, (char*) target + curr_offset,
                               distance * len, real_peer, &completion);
-        shmem_internal_put_wait(&completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence();
 
         /* mark completion for this round */
-        shmem_internal_atomic_small(&pSync_ints[i], &one, sizeof(int),
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, &pSync_ints[i], &one, sizeof(int),
                                     real_peer,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
 
         SHMEM_WAIT_UNTIL(&pSync_ints[i], SHMEM_CMP_NE, 0);
 
         /* this slot is no longer used, so subtract off results now */
-        shmem_internal_atomic_small(&pSync_ints[i], &neg_one, sizeof(int),
+        shmem_internal_atomic_small(SHMEM_CTX_DEFAULT, &pSync_ints[i], &neg_one, sizeof(int),
                                     shmem_internal_my_pe,
                                     SHM_INTERNAL_SUM, SHM_INTERNAL_INT);
 
@@ -1122,7 +1123,7 @@ shmem_internal_alltoall(void *dest, const void *source, size_t len,
     do {
         int peer_as_rank = (peer - PE_start) / stride; /* Peer's index in active set */
 
-        shmem_internal_put_nbi((void *) dest_ptr, (uint8_t *) source + peer_as_rank * len,
+        shmem_internal_put_nbi(SHMEM_CTX_DEFAULT, (void *) dest_ptr, (uint8_t *) source + peer_as_rank * len,
                               len, peer);
         peer = shmem_internal_circular_iter_next(peer, PE_start, logPE_stride,
                                                  PE_size);
@@ -1170,7 +1171,7 @@ shmem_internal_alltoalls(void *dest, const void *source, ptrdiff_t dst,
         uint8_t *source_ptr = (uint8_t *) source + peer_as_rank * nelems * sst * elem_size;
 
         for (i = nelems ; i > 0; i--) {
-            shmem_internal_put_small((void *) dest_ptr, (uint8_t *) source_ptr,
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, (void *) dest_ptr, (uint8_t *) source_ptr,
                                      elem_size, peer);
 
             source_ptr += sst * elem_size;

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -133,7 +133,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_INITIALIZED();                             \
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(addr, sizeof(TYPE));             \
-    shmem_internal_put_small(addr, &value, sizeof(TYPE), pe);  \
+    shmem_internal_put_small(ctx, addr, &value, sizeof(TYPE),  \
+                             pe);                              \
   }
 
 #define SHMEM_DEF_G(STYPE,TYPE)                      \
@@ -144,8 +145,9 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_INITIALIZED();                   \
     SHMEM_ERR_CHECK_PE(pe);                          \
     SHMEM_ERR_CHECK_SYMMETRIC(addr, sizeof(TYPE));   \
-    shmem_internal_get(&tmp, addr, sizeof(TYPE), pe);\
-    shmem_internal_get_wait();                       \
+    shmem_internal_get(ctx, &tmp, addr, sizeof(TYPE),\
+                       pe);                          \
+    shmem_internal_get_wait(ctx);                    \
     return tmp;                                      \
   }
 
@@ -158,9 +160,10 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                      \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
-    shmem_internal_put_nb(target, source, sizeof(TYPE) * nelems, \
-                          pe, &completion);                      \
-    shmem_internal_put_wait(&completion);                        \
+    shmem_internal_put_nb(ctx, target, source,                   \
+                          sizeof(TYPE) * nelems, pe,             \
+                          &completion);                          \
+    shmem_internal_put_wait(ctx, &completion);                   \
   }
 
 
@@ -174,9 +177,9 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
-    shmem_internal_put_nb(target, source, (SIZE) * nelems, pe, \
-                          &completion);                        \
-    shmem_internal_put_wait(&completion);                      \
+    shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,\
+                          pe, &completion);                    \
+    shmem_internal_put_wait(ctx, &completion);                 \
   }
 
 
@@ -188,7 +191,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                      \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
-    shmem_internal_put_nbi(target, source, sizeof(TYPE)*nelems,  \
+    shmem_internal_put_nbi(ctx, target, source,                  \
+                           sizeof(TYPE)*nelems,                  \
         pe);                                                     \
   }
 
@@ -202,7 +206,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
-    shmem_internal_put_nbi(target, source, (SIZE)*nelems, pe); \
+    shmem_internal_put_nbi(ctx, target, source, (SIZE)*nelems, \
+                           pe);                                \
   }
 
 
@@ -215,9 +220,9 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                   \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
-    shmem_internal_get(target, source, sizeof(TYPE) * nelems, \
-        pe);                                                  \
-    shmem_internal_get_wait();                                \
+    shmem_internal_get(ctx, target, source,                   \
+                       sizeof(TYPE) * nelems, pe);            \
+    shmem_internal_get_wait(ctx);                             \
   }
 
 
@@ -230,8 +235,9 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                  \
-    shmem_internal_get(target, source, (SIZE)*nelems, pe); \
-    shmem_internal_get_wait();                             \
+    shmem_internal_get(ctx, target, source, (SIZE)*nelems, \
+                       pe);                                \
+    shmem_internal_get_wait(ctx);                          \
   }
 
 
@@ -244,7 +250,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                      \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                        \
-    shmem_internal_get(target, source, sizeof(TYPE)*nelems, pe); \
+    shmem_internal_get(ctx, target, source, sizeof(TYPE)*nelems, \
+                       pe);                                      \
   }
 
 
@@ -257,7 +264,7 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(target, nelems);                      \
-    shmem_internal_get(target, source, (SIZE)*nelems, pe);     \
+    shmem_internal_get(ctx, target, source, (SIZE)*nelems, pe);\
   }
 
 #define SHMEM_DEF_IPUT(STYPE,TYPE)                            \
@@ -272,8 +279,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                     \
     for ( ; nelems > 0 ; --nelems) {                          \
-      shmem_internal_put_small(target, source, sizeof(TYPE),  \
-          pe);                                                \
+      shmem_internal_put_small(ctx, target, source,           \
+                               sizeof(TYPE), pe);             \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
@@ -292,7 +299,8 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                    \
     for ( ; nelems > 0 ; --nelems) {                         \
-      shmem_internal_put_small(target, source, (SIZE), pe);  \
+      shmem_internal_put_small(ctx, target, source, (SIZE),  \
+                               pe);                          \
       target = (uint8_t*)target + tst*(SIZE);                \
       source = (uint8_t*)source + sst*(SIZE);                \
     }                                                        \
@@ -312,11 +320,12 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
     for ( ; nelems > 0 ; --nelems) {                          \
-      shmem_internal_get(target, source, sizeof(TYPE), pe);   \
+      shmem_internal_get(ctx, target, source, sizeof(TYPE),   \
+                         pe);                                 \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
-    shmem_internal_get_wait();                                \
+    shmem_internal_get_wait(ctx);                             \
   }
 
 #define SHMEM_DEF_IGET_N(NAME,SIZE)                       \
@@ -332,11 +341,11 @@ SHMEM_DEFINE_FOR_SIZES(`SHMEM_PROF_DEF_IGET_N')
     SHMEM_ERR_CHECK_SYMMETRIC(source, SIZE * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                 \
     for ( ; nelems > 0 ; --nelems) {                      \
-      shmem_internal_get(target, source, (SIZE), pe);     \
+      shmem_internal_get(ctx, target, source, (SIZE), pe);\
       target = (uint8_t*)target + tst*(SIZE);             \
       source = (uint8_t*)source + sst*(SIZE);             \
     }                                                     \
-    shmem_internal_get_wait();                            \
+    shmem_internal_get_wait(ctx);                         \
   }
 
 /* Function prototype for standard routines with the default context: */
@@ -396,7 +405,7 @@ shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems
     SHMEM_ERR_CHECK_NULL(target, nelems);
 
     shmem_internal_get_ct(ct, target, source, nelems, pe);
-    shmem_internal_get_wait();
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES shmemx_putmem_ct(shmemx_ct_t ct, void *target, const void *source,
@@ -410,7 +419,7 @@ void SHMEM_FUNCTION_ATTRIBUTES shmemx_putmem_ct(shmemx_ct_t ct, void *target, co
     SHMEM_ERR_CHECK_NULL(source, nelems);
 
     shmem_internal_put_ct_nb(ct, target, source, nelems, pe, &completion);
-    shmem_internal_put_wait(&completion);
+    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 }
 
 

--- a/src/data_f.c4
+++ b/src/data_f.c4
@@ -46,9 +46,9 @@ include(shmem_bind_f.m4)dnl
         SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * *len);                 \
         SHMEM_ERR_CHECK_NULL(source, *len);                             \
                                                                         \
-        shmem_internal_put_nb(target, source, SIZE * *len, *pe,         \
-                              &completion);                             \
-        shmem_internal_put_wait(&completion);                           \
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source,        \
+                              SIZE * *len, *pe, &completion);           \
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);        \
     }
 
 define(`SHMEM_WRAP_FC_PUT',
@@ -73,7 +73,8 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_PUT_SIZE')
         SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * *nelems);              \
         SHMEM_ERR_CHECK_NULL(source, *nelems);                          \
                                                                         \
-        shmem_internal_put_nbi(target, source, SIZE * *nelems, *pe);    \
+        shmem_internal_put_nbi(SHMEM_CTX_DEFAULT, target, source,       \
+        SIZE * *nelems, *pe);                                           \
     }
 
 define(`SHMEM_WRAP_FC_PUT_NBI',
@@ -106,7 +107,8 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_PUT_NBI_SIZE')
         SHMEM_ERR_CHECK_NULL(source, len);                              \
                                                                         \
         for ( ; len > 0 ; --len) {                                      \
-            shmem_internal_put_small(target, source, SIZE, *pe);        \
+            shmem_internal_put_small(SHMEM_CTX_DEFAULT, target, source, \
+            SIZE, *pe);                                                 \
             target += (*tst * SIZE);                                    \
             source += (*sst * SIZE);                                    \
         }                                                               \
@@ -133,8 +135,9 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_IPUT_SIZE')
         SHMEM_ERR_CHECK_SYMMETRIC(source, SIZE * *len);                 \
         SHMEM_ERR_CHECK_NULL(target, *len);                             \
                                                                         \
-        shmem_internal_get(target, source, SIZE * *len, *pe);           \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_get(SHMEM_CTX_DEFAULT, target, source,           \
+                           SIZE * *len, *pe);                           \
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);                     \
     }
 
 define(`SHMEM_WRAP_FC_GET',
@@ -157,7 +160,8 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_GET_SIZE')
         SHMEM_ERR_CHECK_SYMMETRIC(source, SIZE * *nelems);              \
         SHMEM_ERR_CHECK_NULL(target, *nelems);                          \
                                                                         \
-        shmem_internal_get(target, source, SIZE * *nelems, *pe);        \
+        shmem_internal_get(SHMEM_CTX_DEFAULT, target, source,           \
+                           SIZE * *nelems, *pe);                        \
     }
 
 define(`SHMEM_WRAP_FC_GET_NBI',
@@ -190,11 +194,12 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_GET_NBI_SIZE')
         SHMEM_ERR_CHECK_NULL(target, len);                              \
                                                                         \
         for ( ; len > 0 ; --len ) {                                     \
-            shmem_internal_get(target, source, SIZE, *pe);              \
+            shmem_internal_get(SHMEM_CTX_DEFAULT, target, source, SIZE, \
+                               *pe);                                    \
             target += (*tst * SIZE);                                    \
             source += (*sst * SIZE);                                    \
         }                                                               \
-        shmem_internal_get_wait();                                      \
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);                     \
     }
 
 define(`SHMEM_WRAP_FC_IGET',

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -84,7 +84,7 @@ static inline
 void
 shmem_internal_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync)
 {
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
     shmem_internal_sync(PE_start, logPE_stride, PE_size, pSync);
 }
 
@@ -93,7 +93,7 @@ static inline
 void
 shmem_internal_barrier_all(void)
 {
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
     shmem_internal_sync(0, 0, shmem_internal_num_pes, shmem_internal_barrier_all_psync);
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -51,7 +51,7 @@ extern char *shmem_internal_location_array;
 
 static inline
 void
-shmem_internal_put_small(void *target, const void *source, size_t len, int pe)
+shmem_internal_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
 
@@ -75,7 +75,7 @@ shmem_internal_put_small(void *target, const void *source, size_t len, int pe)
 
 static inline
 void
-shmem_internal_put_nb(void *target, const void *source, size_t len, int pe,
+shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
                       long *completion)
 {
     int node_rank;
@@ -103,7 +103,7 @@ shmem_internal_put_nb(void *target, const void *source, size_t len, int pe,
 
 static inline
 void
-shmem_internal_put_nbi(void *target, const void *source, size_t len, int pe)
+shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
 
@@ -142,7 +142,7 @@ shmem_internal_put_ct_nb(shmemx_ct_t ct, void *target, const void *source, size_
 
 static inline
 void
-shmem_internal_put_wait(long *completion)
+shmem_internal_put_wait(shmem_ctx_t ctx, long *completion)
 {
     shmem_transport_put_wait(completion);
     /* on-node is always blocking, so this is a no-op for them */
@@ -151,7 +151,7 @@ shmem_internal_put_wait(long *completion)
 
 static inline
 void
-shmem_internal_get(void *target, const void *source, size_t len, int pe)
+shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     int node_rank;
 
@@ -189,7 +189,7 @@ shmem_internal_get_ct(shmemx_ct_t ct, void *target, const void *source, size_t l
 
 static inline
 void
-shmem_internal_get_wait(void)
+shmem_internal_get_wait(shmem_ctx_t ctx)
 {
     shmem_transport_get_wait();
     /* on-node is always blocking, so this is a no-op for them */
@@ -197,7 +197,7 @@ shmem_internal_get_wait(void)
 
 static inline
 void
-shmem_internal_swap(void *target, void *source, void *dest, size_t len,
+shmem_internal_swap(shmem_ctx_t ctx, void *target, void *source, void *dest, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
     shmem_internal_assert(len > 0);
@@ -208,7 +208,7 @@ shmem_internal_swap(void *target, void *source, void *dest, size_t len,
 
 static inline
 void
-shmem_internal_cswap(void *target, void *source, void *dest, void *operand, size_t len,
+shmem_internal_cswap(shmem_ctx_t ctx, void *target, void *source, void *dest, void *operand, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
     shmem_internal_assert(len > 0);
@@ -219,7 +219,7 @@ shmem_internal_cswap(void *target, void *source, void *dest, void *operand, size
 
 static inline
 void
-shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t len,
+shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, void *mask, size_t len,
                     int pe, shm_internal_datatype_t datatype)
 {
     shmem_internal_assert(len > 0);
@@ -230,7 +230,7 @@ shmem_internal_mswap(void *target, void *source, void *dest, void *mask, size_t 
 
 static inline
 void
-shmem_internal_atomic_small(void *target, const void *source, size_t len,
+shmem_internal_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                             int pe, shm_internal_op_t op,
                             shm_internal_datatype_t datatype)
 {
@@ -242,7 +242,7 @@ shmem_internal_atomic_small(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_internal_atomic_fetch(void *target, const void *source, size_t len,
+shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                             int pe, shm_internal_datatype_t datatype)
 {
     shmem_internal_assert(len > 0);
@@ -253,7 +253,7 @@ shmem_internal_atomic_fetch(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_internal_atomic_set(void *target, const void *source, size_t len,
+shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                           int pe, shm_internal_datatype_t datatype)
 {
     shmem_internal_assert(len > 0);
@@ -264,7 +264,7 @@ shmem_internal_atomic_set(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_internal_atomic_nb(void *target, const void *source, size_t len,
+shmem_internal_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                          int pe, shm_internal_op_t op,
                          shm_internal_datatype_t datatype, long *completion)
 {
@@ -277,7 +277,7 @@ shmem_internal_atomic_nb(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_internal_fetch_atomic(void *target, void *source, void *dest, size_t len,
+shmem_internal_fetch_atomic(shmem_ctx_t ctx, void *target, void *source, void *dest, size_t len,
                             int pe, shm_internal_op_t op,
                             shm_internal_datatype_t datatype)
 {

--- a/src/shmem_lock.h
+++ b/src/shmem_lock.h
@@ -45,8 +45,8 @@ shmem_internal_clear_lock(volatile long *lockp)
 
     /* release the lock if I'm the last to try to obtain it */
     cond = shmem_internal_my_pe + 1;
-    shmem_internal_cswap(&(lock->last), &zero, &curr, &cond, sizeof(int), 0, SHM_INTERNAL_INT);
-    shmem_internal_get_wait();
+    shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &zero, &curr, &cond, sizeof(int), 0, SHM_INTERNAL_INT);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
 
     /* if local PE was not the last to hold the lock, have to look for the next in line */
     if (curr != shmem_internal_my_pe + 1) {
@@ -61,8 +61,8 @@ shmem_internal_clear_lock(volatile long *lockp)
         }
 
         /* set the signal bit on new lock holder */
-        shmem_internal_mswap(&(lock->data), &sig, &curr, &sig, sizeof(int), NEXT(lock->data) - 1, SHM_INTERNAL_INT);
-        shmem_internal_get_wait();
+        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &sig, &curr, &sig, sizeof(int), NEXT(lock->data) - 1, SHM_INTERNAL_INT);
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     }
 }
 
@@ -74,16 +74,16 @@ shmem_internal_set_lock(volatile long *lockp)
     int curr, zero = 0, me = shmem_internal_my_pe + 1, next_mask = NEXT_MASK;
 
     /* initialize my elements to zero */
-    shmem_internal_put_small(&(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
+    shmem_internal_put_small(SHMEM_CTX_DEFAULT, &(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
     shmem_internal_quiet();
 
     /* update last with my value to add me to the queue */
-    shmem_internal_swap(&(lock->last), &me, &curr, sizeof(int), 0, SHM_INTERNAL_INT);
-    shmem_internal_get_wait();
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, sizeof(int), 0, SHM_INTERNAL_INT);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     /* If I wasn't the first, need to add myself to the previous last's next */
     if (0 != curr) {
-        shmem_internal_mswap(&(lock->data), &me, &curr, &next_mask, sizeof(int), curr - 1, SHM_INTERNAL_INT);
-        shmem_internal_get_wait();
+        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &me, &curr, &next_mask, sizeof(int), curr - 1, SHM_INTERNAL_INT);
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
         /* now wait for the signal part of data to be non-zero */
         for (;;) {
             lock_t lock_cur = *lock;
@@ -104,12 +104,12 @@ shmem_internal_test_lock(volatile long *lockp)
     int curr, me = shmem_internal_my_pe + 1, zero = 0;
 
     /* initialize my elements to zero */
-    shmem_internal_put_small(&(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
+    shmem_internal_put_small(SHMEM_CTX_DEFAULT, &(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
     shmem_internal_quiet();
 
     /* add self to last if and only if the lock is zero (ie, no one has the lock) */
-    shmem_internal_cswap(&(lock->last), &me, &curr, &zero, sizeof(int), 0, SHM_INTERNAL_INT);
-    shmem_internal_get_wait();
+    shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, &zero, sizeof(int), 0, SHM_INTERNAL_INT);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     if (0 == curr) {
         return 0;
     }

--- a/src/shmem_lock.h
+++ b/src/shmem_lock.h
@@ -41,7 +41,7 @@ shmem_internal_clear_lock(volatile long *lockp)
     lock_t *lock = (lock_t*) lockp;
     int curr, cond, zero = 0, sig = SIGNAL_MASK;
 
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
     /* release the lock if I'm the last to try to obtain it */
     cond = shmem_internal_my_pe + 1;
@@ -75,7 +75,7 @@ shmem_internal_set_lock(volatile long *lockp)
 
     /* initialize my elements to zero */
     shmem_internal_put_small(SHMEM_CTX_DEFAULT, &(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
     /* update last with my value to add me to the queue */
     shmem_internal_swap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, sizeof(int), 0, SHM_INTERNAL_INT);
@@ -105,7 +105,7 @@ shmem_internal_test_lock(volatile long *lockp)
 
     /* initialize my elements to zero */
     shmem_internal_put_small(SHMEM_CTX_DEFAULT, &(lock->data), &zero, sizeof(zero), shmem_internal_my_pe);
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
     /* add self to last if and only if the lock is zero (ie, no one has the lock) */
     shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, &zero, sizeof(int), 0, SHM_INTERNAL_INT);

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -22,7 +22,7 @@
 
 
 static inline void
-shmem_internal_quiet(void)
+shmem_internal_quiet(shmem_ctx_t ctx)
 {
     int ret;
 
@@ -37,7 +37,7 @@ shmem_internal_quiet(void)
 
 
 static inline void
-shmem_internal_fence(void)
+shmem_internal_fence(shmem_ctx_t ctx)
 {
     int ret;
 

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -83,7 +83,7 @@ shmem_ctx_quiet(shmem_ctx_t ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_quiet();
+    shmem_internal_quiet(ctx);
 }
 
 
@@ -92,7 +92,7 @@ shmem_ctx_fence(shmem_ctx_t ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_fence();
+    shmem_internal_fence(ctx);
 }
 
 

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -60,7 +60,7 @@ shmem_quiet(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
 
 
@@ -69,7 +69,7 @@ shmem_fence(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_fence();
+    shmem_internal_fence(SHMEM_CTX_DEFAULT);
 }
 
 

--- a/src/synchronization_f.c
+++ b/src/synchronization_f.c
@@ -34,7 +34,7 @@ FC_SHMEM_QUIET(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_quiet();
+    shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
 
 
@@ -46,7 +46,7 @@ FC_SHMEM_FENCE(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_fence();
+    shmem_internal_fence(SHMEM_CTX_DEFAULT);
 }
 
 


### PR DESCRIPTION
Incorporates ctx args into the `shmem_internal` layer.  AMO and RMA routines now call the updated `shmem_internal(ctx,...)` functions.  Uses `SHMEM_CTX_DEFAULT` for the collective, shmem_lock, shmem_ct, and Fortran routines.