### PR TITLE
Propagate context argument through the transport layer

### DIFF
--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -86,7 +86,11 @@ extern "C" {
 
 /* Contexts */
 typedef void* shmem_ctx_t;
-extern shmem_ctx_t SHMEM_CTX_DEFAULT;
+#if SHMEM_HAVE_ATTRIBUTE_VISIBILITY == 1
+  __attribute__((visibility("default"))) extern shmem_ctx_t SHMEM_CTX_DEFAULT;
+#else
+  extern shmem_ctx_t SHMEM_CTX_DEFAULT;
+#endif
 #define SHMEM_CTX_PRIVATE       1
 #define SHMEM_CTX_SERIALIZED    2
 #define SHMEM_CTX_NOSTORE       4

--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -84,13 +84,12 @@ extern "C" {
 #define SHMEM_THREAD_SERIALIZED 2
 #define SHMEM_THREAD_MULTIPLE   3
 
+/* Contexts */
+typedef void* shmem_ctx_t;
+extern shmem_ctx_t SHMEM_CTX_DEFAULT;
 #define SHMEM_CTX_PRIVATE       1
 #define SHMEM_CTX_SERIALIZED    2
 #define SHMEM_CTX_NOSTORE       4
-
-/* Temporary placeholder to avoid undefined warnings: */
-#define SHMEM_CTX_DEFAULT NULL
-typedef void *shmem_ctx_t;
 
 define(`SHPRE', `')dnl
 include(shmem_c_func.m4)dnl

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ endif
 if !USE_PORTALS4
 if !USE_OFI
 libsma_la_SOURCES += \
+	transport_none.c \
 	transport_none.h
 endif
 endif

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -68,7 +68,7 @@ shmem_internal_put_small(shmem_ctx_t ctx, void *target, const void *source, size
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_small(ctx, target, source, len, pe);
+        shmem_transport_put_small((shmem_transport_ctx_t *)ctx, target, source, len, pe);
     }
 }
 
@@ -89,7 +89,7 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_PUT_MAX) {
-            shmem_transport_put_nb(ctx, target, source, len, pe, completion);
+            shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, completion);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
         }
@@ -97,7 +97,7 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_nb(ctx, target, source, len, pe, completion);
+        shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, completion);
     }
 }
 
@@ -116,7 +116,7 @@ shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_PUT_MAX) {
-            shmem_transport_put_nbi(ctx, target, source, len, pe);
+            shmem_transport_put_nbi((shmem_transport_ctx_t *)ctx, target, source, len, pe);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
         }
@@ -124,7 +124,7 @@ shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_nbi(ctx, target, source, len, pe);
+        shmem_transport_put_nbi((shmem_transport_ctx_t *)ctx, target, source, len, pe);
     }
 }
 
@@ -144,7 +144,7 @@ static inline
 void
 shmem_internal_put_wait(shmem_ctx_t ctx, long *completion)
 {
-    shmem_transport_put_wait(ctx, completion);
+    shmem_transport_put_wait((shmem_transport_ctx_t *)ctx, completion);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
@@ -172,7 +172,7 @@ shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_get(ctx, target, source, len, pe);
+        shmem_transport_get((shmem_transport_ctx_t *)ctx, target, source, len, pe);
     }
 }
 
@@ -202,7 +202,7 @@ shmem_internal_swap(shmem_ctx_t ctx, void *target, void *source, void *dest, siz
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_swap(ctx, target, source, dest, len, pe, datatype);
+    shmem_transport_swap((shmem_transport_ctx_t *)ctx, target, source, dest, len, pe, datatype);
 }
 
 
@@ -213,7 +213,7 @@ shmem_internal_cswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_cswap(ctx, target, source, dest, operand, len, pe, datatype);
+    shmem_transport_cswap((shmem_transport_ctx_t *)ctx, target, source, dest, operand, len, pe, datatype);
 }
 
 
@@ -224,7 +224,7 @@ shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_mswap(ctx, target, source, dest, mask, len, pe, datatype);
+    shmem_transport_mswap((shmem_transport_ctx_t *)ctx, target, source, dest, mask, len, pe, datatype);
 }
 
 
@@ -236,7 +236,7 @@ shmem_internal_atomic_small(shmem_ctx_t ctx, void *target, const void *source, s
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_small(ctx, target, source, len, pe, op, datatype);
+    shmem_transport_atomic_small((shmem_transport_ctx_t *)ctx, target, source, len, pe, op, datatype);
 }
 
 
@@ -247,7 +247,7 @@ shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, s
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_fetch(ctx, target, source, len, pe, datatype);
+    shmem_transport_atomic_fetch((shmem_transport_ctx_t *)ctx, target, source, len, pe, datatype);
 }
 
 
@@ -258,7 +258,7 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_set(ctx, target, source, len, pe, datatype);
+    shmem_transport_atomic_set((shmem_transport_ctx_t *)ctx, target, source, len, pe, datatype);
 }
 
 
@@ -270,7 +270,7 @@ shmem_internal_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_nb(ctx, target, source, len, pe, op, datatype, completion);
+    shmem_transport_atomic_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, op, datatype, completion);
 }
 
 
@@ -283,7 +283,7 @@ shmem_internal_fetch_atomic(shmem_ctx_t ctx, void *target, void *source, void *d
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_fetch_atomic(ctx, target, source, dest, len, pe, op, datatype);
+    shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target, source, dest, len, pe, op, datatype);
 }
 
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -68,7 +68,7 @@ shmem_internal_put_small(shmem_ctx_t ctx, void *target, const void *source, size
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_small(target, source, len, pe);
+        shmem_transport_put_small(ctx, target, source, len, pe);
     }
 }
 
@@ -89,7 +89,7 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_PUT_MAX) {
-            shmem_transport_put_nb(target, source, len, pe, completion);
+            shmem_transport_put_nb(ctx, target, source, len, pe, completion);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
         }
@@ -97,7 +97,7 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_nb(target, source, len, pe, completion);
+        shmem_transport_put_nb(ctx, target, source, len, pe, completion);
     }
 }
 
@@ -116,7 +116,7 @@ shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_PUT_MAX) {
-            shmem_transport_put_nbi(target, source, len, pe);
+            shmem_transport_put_nbi(ctx, target, source, len, pe);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
         }
@@ -124,7 +124,7 @@ shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_put_nbi(target, source, len, pe);
+        shmem_transport_put_nbi(ctx, target, source, len, pe);
     }
 }
 
@@ -144,7 +144,7 @@ static inline
 void
 shmem_internal_put_wait(shmem_ctx_t ctx, long *completion)
 {
-    shmem_transport_put_wait(completion);
+    shmem_transport_put_wait(ctx, completion);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
@@ -164,7 +164,7 @@ shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len
         shmem_transport_xpmem_get(target, source, len, pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_GET_MAX) {
-            shmem_transport_get(target, source, len, pe);
+            shmem_transport_get(ctx, target, source, len, pe);
         } else {
             shmem_transport_cma_get(target, source, len, pe, node_rank);
         }
@@ -172,7 +172,7 @@ shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len
         RAISE_ERROR_STR("No path to peer");
 #endif
     } else {
-        shmem_transport_get(target, source, len, pe);
+        shmem_transport_get(ctx, target, source, len, pe);
     }
 }
 
@@ -191,7 +191,7 @@ static inline
 void
 shmem_internal_get_wait(shmem_ctx_t ctx)
 {
-    shmem_transport_get_wait();
+    shmem_transport_get_wait(ctx);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
@@ -202,7 +202,7 @@ shmem_internal_swap(shmem_ctx_t ctx, void *target, void *source, void *dest, siz
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_swap(target, source, dest, len, pe, datatype);
+    shmem_transport_swap(ctx, target, source, dest, len, pe, datatype);
 }
 
 
@@ -213,7 +213,7 @@ shmem_internal_cswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_cswap(target, source, dest, operand, len, pe, datatype);
+    shmem_transport_cswap(ctx, target, source, dest, operand, len, pe, datatype);
 }
 
 
@@ -224,7 +224,7 @@ shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_mswap(target, source, dest, mask, len, pe, datatype);
+    shmem_transport_mswap(ctx, target, source, dest, mask, len, pe, datatype);
 }
 
 
@@ -236,7 +236,7 @@ shmem_internal_atomic_small(shmem_ctx_t ctx, void *target, const void *source, s
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_small(target, source, len, pe, op, datatype);
+    shmem_transport_atomic_small(ctx, target, source, len, pe, op, datatype);
 }
 
 
@@ -247,7 +247,7 @@ shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, s
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_fetch(target, source, len, pe, datatype);
+    shmem_transport_atomic_fetch(ctx, target, source, len, pe, datatype);
 }
 
 
@@ -258,7 +258,7 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_set(target, source, len, pe, datatype);
+    shmem_transport_atomic_set(ctx, target, source, len, pe, datatype);
 }
 
 
@@ -270,7 +270,7 @@ shmem_internal_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_atomic_nb(target, source, len, pe, op, datatype, completion);
+    shmem_transport_atomic_nb(ctx, target, source, len, pe, op, datatype, completion);
 }
 
 
@@ -283,7 +283,7 @@ shmem_internal_fetch_atomic(shmem_ctx_t ctx, void *target, void *source, void *d
 {
     shmem_internal_assert(len > 0);
 
-    shmem_transport_fetch_atomic(target, source, dest, len, pe, op, datatype);
+    shmem_transport_fetch_atomic(ctx, target, source, dest, len, pe, op, datatype);
 }
 
 

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -26,7 +26,7 @@ shmem_internal_quiet(shmem_ctx_t ctx)
 {
     int ret;
 
-    ret = shmem_transport_quiet();
+    ret = shmem_transport_quiet(ctx);
     if (0 != ret) { RAISE_ERROR(ret); }
 
 #ifdef USE_XPMEM
@@ -41,7 +41,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
 {
     int ret;
 
-    ret = shmem_transport_fence();
+    ret = shmem_transport_fence(ctx);
     if (0 != ret) { RAISE_ERROR(ret); }
 
 #ifdef USE_XPMEM

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -41,7 +41,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
 {
     int ret;
 
-    ret = shmem_transport_fence(ctx);
+    ret = shmem_transport_fence((shmem_transport_ctx_t *)ctx);
     if (0 != ret) { RAISE_ERROR(ret); }
 
 #ifdef USE_XPMEM

--- a/src/transport_none.c
+++ b/src/transport_none.c
@@ -10,5 +10,6 @@
  */
 
 #include "transport_none.h"
+#include "shmem.h"
 
 void *SHMEM_CTX_DEFAULT = NULL;

--- a/src/transport_none.c
+++ b/src/transport_none.c
@@ -11,5 +11,4 @@
 
 #include "transport_none.h"
 
-void *SHMEMX_CTX_DEFAULT = NULL;
-void *SHMEMX_DOMAIN_DEFAULT = NULL;
+void *SHMEM_CTX_DEFAULT = NULL;

--- a/src/transport_none.c
+++ b/src/transport_none.c
@@ -1,0 +1,15 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+#include "transport_none.h"
+
+void *SHMEMX_CTX_DEFAULT = NULL;
+void *SHMEMX_DOMAIN_DEFAULT = NULL;

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -58,7 +58,6 @@ typedef int shmem_transport_ct_t;
 struct shmem_transport_ctx_t{ int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
-extern void * SHMEM_CTX_DEFAULT;
 
 static inline
 int

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -55,10 +55,9 @@ typedef int shm_internal_datatype_t;
 typedef int shm_internal_op_t;
 typedef int shmem_transport_ct_t;
 
-struct shmem_transport_ctx_t{};
+struct shmem_transport_ctx_t{ int dummy };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
-shmem_transport_ctx_t shmem_transport_ctx_default;
 
 static inline
 int

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -55,7 +55,7 @@ typedef int shm_internal_datatype_t;
 typedef int shm_internal_op_t;
 typedef int shmem_transport_ct_t;
 
-struct shmem_transport_ctx_t{ int dummy };
+struct shmem_transport_ctx_t{ int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -55,6 +55,11 @@ typedef int shm_internal_datatype_t;
 typedef int shm_internal_op_t;
 typedef int shmem_transport_ct_t;
 
+struct shmem_transport_ctx_t{};
+
+typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
+shmem_transport_ctx_t shmem_transport_ctx_default;
+
 static inline
 int
 shmem_transport_init(void)
@@ -78,28 +83,28 @@ shmem_transport_fini(void)
 
 static inline
 int
-shmem_transport_quiet(shmem_ctx_t ctx)
+shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {
     return 0;
 }
 
 static inline
 int
-shmem_transport_fence(shmem_ctx_t ctx)
+shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
     return 0;
 }
 
 static inline
 void
-shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                        int pe, long *completion)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -107,14 +112,14 @@ shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t
 
 static inline
 void
-shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                        int pe)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -122,14 +127,14 @@ shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_
 
 static inline
 void
-shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_get_wait(shmem_ctx_t ctx)
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -137,7 +142,7 @@ shmem_transport_get_wait(shmem_ctx_t ctx)
 
 static inline
 void
-shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                      size_t len, int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -145,7 +150,7 @@ shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *de
 
 static inline
 void
-shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
                       shm_internal_datatype_t datatype)
 {
@@ -154,7 +159,7 @@ shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *d
 
 static inline
 void
-shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
                       shm_internal_datatype_t datatype)
 {
@@ -163,7 +168,7 @@ shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *d
 
 static inline
 void
-shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -171,7 +176,7 @@ shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, 
 
 static inline
 void
-shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                           int pe, shm_internal_op_t op, shm_internal_datatype_t datatype,
                           long *completion)
 {
@@ -180,7 +185,7 @@ shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, siz
 
 static inline
 void
-shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, void *dest, size_t len,
+shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
                              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -188,7 +193,7 @@ shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, 
 
 static inline
 void
-shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -196,7 +201,7 @@ shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, 
 
 static inline
 void
-shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -58,6 +58,7 @@ typedef int shmem_transport_ct_t;
 struct shmem_transport_ctx_t{ int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
+extern void * SHMEM_CTX_DEFAULT;
 
 static inline
 int

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -78,28 +78,28 @@ shmem_transport_fini(void)
 
 static inline
 int
-shmem_transport_quiet(void)
+shmem_transport_quiet(shmem_ctx_t ctx)
 {
     return 0;
 }
 
 static inline
 int
-shmem_transport_fence(void)
+shmem_transport_fence(shmem_ctx_t ctx)
 {
     return 0;
 }
 
 static inline
 void
-shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
+shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_put_nb(void *target, const void *source, size_t len,
+shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                        int pe, long *completion)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -107,14 +107,14 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_put_wait(long *completion)
+shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_put_nbi(void *target, const void *source, size_t len,
+shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                        int pe)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -122,14 +122,14 @@ shmem_transport_put_nbi(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_get(void *target, const void *source, size_t len, int pe)
+shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_get_wait(void)
+shmem_transport_get_wait(shmem_ctx_t ctx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -137,7 +137,7 @@ shmem_transport_get_wait(void)
 
 static inline
 void
-shmem_transport_swap(void *target, const void *source, void *dest,
+shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                      size_t len, int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -145,7 +145,7 @@ shmem_transport_swap(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_cswap(void *target, const void *source, void *dest,
+shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
                       shm_internal_datatype_t datatype)
 {
@@ -154,7 +154,7 @@ shmem_transport_cswap(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_mswap(void *target, const void *source, void *dest,
+shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
                       shm_internal_datatype_t datatype)
 {
@@ -163,7 +163,7 @@ shmem_transport_mswap(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_atomic_small(void *target, const void *source, size_t len,
+shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -171,7 +171,7 @@ shmem_transport_atomic_small(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_atomic_nb(void *target, const void *source, size_t len,
+shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                           int pe, shm_internal_op_t op, shm_internal_datatype_t datatype,
                           long *completion)
 {
@@ -180,7 +180,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_fetch_atomic(void *target, const void *source, void *dest, size_t len,
+shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, void *dest, size_t len,
                              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -188,7 +188,7 @@ shmem_transport_fetch_atomic(void *target, const void *source, void *dest, size_
 
 static inline
 void
-shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
+shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");
@@ -196,7 +196,7 @@ shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_atomic_set(void *target, const void *source, size_t len,
+shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
     RAISE_ERROR_STR("No path to peer");

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1214,7 +1214,7 @@ int shmem_transport_startup(void)
 int shmem_transport_fini(void)
 {
     /* Wait for acks before shutdown */
-    shmem_transport_quiet(SHMEM_CTX_DEFAULT);
+    shmem_transport_quiet(&shmem_transport_ctx_default);
 
     if (shmem_transport_ofi_epfd &&
         fi_close(&shmem_transport_ofi_epfd->fid)) {

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1214,7 +1214,7 @@ int shmem_transport_startup(void)
 int shmem_transport_fini(void)
 {
     /* Wait for acks before shutdown */
-    shmem_transport_quiet();
+    shmem_transport_quiet(SHMEM_CTX_DEFAULT);
 
     if (shmem_transport_ofi_epfd &&
         fi_close(&shmem_transport_ofi_epfd->fid)) {

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -89,6 +89,9 @@ fi_addr_t                       *addr_table;
 static char                     myephostname[EPHOSTNAMELEN];
 #endif
 
+
+shmem_transport_ctx_t shmem_transport_ctx_default;
+
 size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
 
 static char * SHMEM_DtName[FI_DATATYPE_LAST];

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -91,6 +91,7 @@ static char                     myephostname[EPHOSTNAMELEN];
 
 
 shmem_transport_ctx_t shmem_transport_ctx_default;
+void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
 size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -214,7 +214,7 @@ struct shmem_transport_ctx_t {
 };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
-shmem_transport_ctx_t shmem_transport_ctx_default;
+extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -206,6 +206,16 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 
 typedef int shmem_transport_ct_t;
 
+struct shmem_transport_ctx_t {
+  struct fid_domain* domain;
+  struct fid_ep* endpoint;
+  /* etc... */
+  /* TODO fully populate this context struct */
+};
+
+typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
+shmem_transport_ctx_t shmem_transport_ctx_default;
+
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
 
 int shmem_transport_init(void);
@@ -214,10 +224,10 @@ int shmem_transport_fini(void);
 
 extern size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
 
-static inline void shmem_transport_get_wait(shmem_ctx_t ctx);
+static inline void shmem_transport_get_wait(shmem_transport_ctx_t* ctx);
 
 static inline
-void shmem_transport_ofi_drain_cq()
+void shmem_transport_ofi_drain_cq(void)
 {
 
     ssize_t ret = 0;
@@ -288,7 +298,7 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(const void *source,
 }
 
 static inline
-void shmem_transport_put_quiet(shmem_ctx_t ctx)
+void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
 {
     /* wait until all outstanding queue operations have completed */
     while (shmem_internal_atomic_read(&shmem_transport_ofi_pending_cq_count)) {
@@ -337,7 +347,7 @@ void shmem_transport_put_quiet(shmem_ctx_t ctx)
 }
 
 static inline
-int shmem_transport_quiet(shmem_ctx_t ctx)
+int shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {
 
     shmem_transport_put_quiet(ctx);
@@ -348,7 +358,7 @@ int shmem_transport_quiet(shmem_ctx_t ctx)
 
 
 static inline
-int shmem_transport_fence(shmem_ctx_t ctx)
+int shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
     /*unordered network model*/
@@ -378,7 +388,7 @@ int try_again(const int ret, uint64_t *polled) {
 }
 
 static inline
-void shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                int pe)
 {
     int ret = 0;
@@ -410,7 +420,7 @@ void shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source
 }
 
 static inline
-void shmem_transport_ofi_put_large(shmem_ctx_t ctx, void *target, const void *source,
+void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, const void *source,
                                    size_t len, int pe)
 {
     int ret = 0;
@@ -447,7 +457,7 @@ void shmem_transport_ofi_put_large(shmem_ctx_t ctx, void *target, const void *so
 }
 
 static inline
-void shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                             int pe, long *completion)
 {
     int ret = 0;
@@ -486,7 +496,7 @@ void shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, s
 
 /* compatibility with Portals transport */
 static inline
-void shmem_transport_put_wait(shmem_ctx_t ctx, long *completion) {
+void shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion) {
 
     shmem_internal_assert((*completion) >= 0);
 
@@ -497,7 +507,7 @@ void shmem_transport_put_wait(shmem_ctx_t ctx, long *completion) {
 }
 
 static inline
-void shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe)
 {
     if (len <= shmem_transport_ofi_max_buffered_send) {
@@ -512,7 +522,7 @@ void shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, 
 
 
 static inline
-void shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -563,7 +573,7 @@ void shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size
 
 
 static inline
-void shmem_transport_get_wait(shmem_ctx_t ctx)
+void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
 {
     /* wait for get counter to meet outstanding count value */
 
@@ -608,7 +618,7 @@ void shmem_transport_get_wait(shmem_ctx_t ctx)
 
 
 static inline
-void shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+void shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                           size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -643,7 +653,7 @@ void shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, voi
 
 
 static inline
-void shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+void shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                            const void *operand, size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -679,7 +689,7 @@ void shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, vo
 
 
 static inline
-void shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+void shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                            const void *mask, size_t len, int pe, int datatype)
 {
     int ret = 0;
@@ -715,7 +725,7 @@ void shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, vo
 
 
 static inline
-void shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                   int pe, int op, int datatype)
 {
     int ret = 0;
@@ -744,7 +754,7 @@ void shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *sou
 
 
 static inline
-void shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                 int pe, int datatype)
 {
     int ret = 0;
@@ -772,7 +782,7 @@ void shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *sourc
 
 
 static inline
-void shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+void shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                   int pe, int datatype)
 {
     int ret = 0;
@@ -805,7 +815,7 @@ void shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *sou
 
 
 static inline
-void shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source,
+void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *source,
                                size_t full_len, int pe, int op, int datatype,
                                long *completion)
 {
@@ -901,7 +911,7 @@ void shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source
 
 
 static inline
-void shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+void shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                                   size_t len, int pe, int op, int datatype)
 {
     int ret = 0;

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -127,6 +127,7 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 #endif
 
 shmem_transport_ctx_t shmem_transport_ctx_default;
+void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
 static
 void

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -126,6 +126,8 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_event_slots;
 shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 #endif
 
+shmem_transport_ctx_t shmem_transport_ctx_default;
+
 static
 void
 init_bounce_buffer(shmem_free_list_item_t *item)

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -160,7 +160,7 @@ struct shmem_transport_ct_t {
 typedef struct shmem_transport_ct_t shmem_transport_ct_t;
 
 /* TODO populate this context struct: */
-struct shmem_transport_ctx_t { int dummy };
+struct shmem_transport_ctx_t { int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -159,6 +159,12 @@ struct shmem_transport_ct_t {
 };
 typedef struct shmem_transport_ct_t shmem_transport_ct_t;
 
+/* TODO populate this context struct: */
+struct shmem_transport_ctx_t {};
+
+typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
+shmem_transport_ctx_t shmem_transport_ctx_default;
+
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset
  * from the base of the list entry on that PT for a given target
@@ -251,11 +257,11 @@ int shmem_transport_startup(void);
 
 int shmem_transport_fini(void);
 
-static inline void shmem_transport_get_wait(shmem_ctx_t);
+static inline void shmem_transport_get_wait(shmem_transport_ctx_t*);
 
 static inline
 int
-shmem_transport_quiet(shmem_ctx_t ctx)
+shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {
     int ret;
     ptl_ct_event_t ct;
@@ -278,7 +284,7 @@ shmem_transport_quiet(shmem_ctx_t ctx)
 
 static inline
 int
-shmem_transport_fence(shmem_ctx_t ctx)
+shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
     int ret = 0;
 
@@ -336,7 +342,7 @@ shmem_transport_portals4_fence_complete(void)
 
 static inline
 void
-shmem_transport_portals4_drain_eq()
+shmem_transport_portals4_drain_eq(void)
 {
     int ret;
     ptl_event_t ev;
@@ -386,7 +392,7 @@ shmem_transport_portals4_drain_eq()
 
 static inline
 void
-shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
     int ret;
     ptl_process_t peer;
@@ -417,7 +423,7 @@ shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, siz
 
 static inline
 void
-shmem_transport_portals4_put_nb_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_portals4_put_nb_internal(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                 int pe, long *completion, ptl_pt_index_t data_pt,
                                 ptl_pt_index_t heap_pt)
 {
@@ -533,7 +539,7 @@ shmem_transport_portals4_put_nb_internal(shmem_ctx_t ctx, void *target, const vo
 
 static inline
 void
-shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                 int pe, long *completion)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
@@ -552,7 +558,7 @@ shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t
 
 static inline
 void
-shmem_transport_portals4_put_nbi_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_portals4_put_nbi_internal(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                 int pe, ptl_pt_index_t data_pt, ptl_pt_index_t heap_pt)
 {
     int ret;
@@ -607,7 +613,7 @@ shmem_transport_portals4_put_nbi_internal(shmem_ctx_t ctx, void *target, const v
 
 static inline
 void
-shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_put_nbi_internal(ctx, target, source, len, pe,
@@ -637,7 +643,7 @@ shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *so
 
 static inline
 void
-shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 {
     while (*completion > 0) {
         shmem_transport_portals4_drain_eq();
@@ -646,7 +652,7 @@ shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
 
 static inline
 void
-shmem_transport_portals4_get_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
+shmem_transport_portals4_get_internal(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe,
                              ptl_pt_index_t data_pt, ptl_pt_index_t heap_pt)
 {
     int ret;
@@ -677,7 +683,7 @@ shmem_transport_portals4_get_internal(shmem_ctx_t ctx, void *target, const void 
 
 
 static inline
-void shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_get_internal(ctx, target, source, len, pe,
@@ -705,7 +711,7 @@ void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
 
 static inline
 void
-shmem_transport_get_wait(shmem_ctx_t ctx)
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
 {
     int ret;
     ptl_ct_event_t ct;
@@ -720,7 +726,7 @@ shmem_transport_get_wait(shmem_ctx_t ctx)
 
 static inline
 void
-shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *dest, size_t len,
+shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
                      int pe, ptl_datatype_t datatype)
 {
     int ret;
@@ -760,7 +766,7 @@ shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *de
 
 static inline
 void
-shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
                       ptl_datatype_t datatype)
 {
@@ -801,7 +807,7 @@ shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *d
 
 static inline
 void
-shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
                       ptl_datatype_t datatype)
 {
@@ -842,7 +848,7 @@ shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *d
 
 static inline
 void
-shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, ptl_op_t op, ptl_datatype_t datatype)
 {
     int ret;
@@ -878,7 +884,7 @@ shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, 
 
 static inline
 void
-shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
+shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe,
                           ptl_op_t op, ptl_datatype_t datatype, long *completion)
 {
     int ret;
@@ -1003,7 +1009,7 @@ shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, siz
 
 static inline
 void
-shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, void *dest,
+shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                              size_t len, int pe, ptl_op_t op,
                              ptl_datatype_t datatype)
 {
@@ -1043,7 +1049,7 @@ shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, 
 
 static inline
 void
-shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                            int pe, int datatype)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_atomic_size);
@@ -1054,7 +1060,7 @@ shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, si
 
 static inline
 void
-shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
+shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, int datatype)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_fetch_atomic_size);

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -336,7 +336,7 @@ shmem_transport_portals4_fence_complete(void)
 
 static inline
 void
-shmem_transport_portals4_drain_eq(shmem_ctx_t ctx)
+shmem_transport_portals4_drain_eq()
 {
     int ret;
     ptl_event_t ev;
@@ -454,7 +454,7 @@ shmem_transport_portals4_put_nb_internal(shmem_ctx_t ctx, void *target, const vo
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq(ctx);
+            shmem_transport_portals4_drain_eq();
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -494,7 +494,7 @@ shmem_transport_portals4_put_nb_internal(shmem_ctx_t ctx, void *target, const vo
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq(ctx);
+            shmem_transport_portals4_drain_eq();
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -640,7 +640,7 @@ void
 shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
 {
     while (*completion > 0) {
-        shmem_transport_portals4_drain_eq(ctx);
+        shmem_transport_portals4_drain_eq();
     }
 }
 
@@ -918,7 +918,7 @@ shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, siz
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq(ctx);
+            shmem_transport_portals4_drain_eq();
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -970,7 +970,7 @@ shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, siz
              SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
              while (0 >= --shmem_transport_portals4_event_slots) {
                   shmem_transport_portals4_event_slots++;
-                  shmem_transport_portals4_drain_eq(ctx);
+                  shmem_transport_portals4_drain_eq();
              }
              SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -251,11 +251,11 @@ int shmem_transport_startup(void);
 
 int shmem_transport_fini(void);
 
-static inline void shmem_transport_get_wait(void);
+static inline void shmem_transport_get_wait(shmem_ctx_t);
 
 static inline
 int
-shmem_transport_quiet(void)
+shmem_transport_quiet(shmem_ctx_t ctx)
 {
     int ret;
     ptl_ct_event_t ct;
@@ -264,7 +264,7 @@ shmem_transport_quiet(void)
     PtlAtomicSync();
 
     /* wait for completion of all pending NB get events */
-    shmem_transport_get_wait();
+    shmem_transport_get_wait(ctx);
 
     /* wait for remote completion (acks) of all pending put events */
     ret = PtlCTWait(shmem_transport_portals4_put_ct_h,
@@ -278,7 +278,7 @@ shmem_transport_quiet(void)
 
 static inline
 int
-shmem_transport_fence(void)
+shmem_transport_fence(shmem_ctx_t ctx)
 {
     int ret = 0;
 
@@ -292,7 +292,7 @@ shmem_transport_fence(void)
         shmem_transport_portals4_fence_pending = 1;
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
 #else
-        ret = shmem_transport_quiet();
+        ret = shmem_transport_quiet(ctx);
 #endif
     }
 #if WANT_TOTAL_DATA_ORDERING != 0
@@ -303,7 +303,7 @@ shmem_transport_fence(void)
         shmem_transport_portals4_fence_pending = 1;
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
 #else
-        ret = shmem_transport_quiet();
+        ret = shmem_transport_quiet(ctx);
 #endif
         shmem_transport_portals4_long_pending = 0;
     }
@@ -324,7 +324,7 @@ shmem_transport_portals4_fence_complete(void)
     /* If a fence is pending, complete */
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_nb_fence);
     if (0 != shmem_transport_portals4_fence_pending) {
-        ret = shmem_transport_quiet();
+        ret = shmem_transport_quiet(ctx);
         shmem_transport_portals4_fence_pending = 0;
     }
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
@@ -336,7 +336,7 @@ shmem_transport_portals4_fence_complete(void)
 
 static inline
 void
-shmem_transport_portals4_drain_eq(void)
+shmem_transport_portals4_drain_eq(shmem_ctx_t ctx)
 {
     int ret;
     ptl_event_t ev;
@@ -386,7 +386,7 @@ shmem_transport_portals4_drain_eq(void)
 
 static inline
 void
-shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
+shmem_transport_put_small(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
     int ret;
     ptl_process_t peer;
@@ -417,7 +417,7 @@ shmem_transport_put_small(void *target, const void *source, size_t len, int pe)
 
 static inline
 void
-shmem_transport_portals4_put_nb_internal(void *target, const void *source, size_t len,
+shmem_transport_portals4_put_nb_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                                 int pe, long *completion, ptl_pt_index_t data_pt,
                                 ptl_pt_index_t heap_pt)
 {
@@ -454,7 +454,7 @@ shmem_transport_portals4_put_nb_internal(void *target, const void *source, size_
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq();
+            shmem_transport_portals4_drain_eq(ctx);
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -494,7 +494,7 @@ shmem_transport_portals4_put_nb_internal(void *target, const void *source, size_
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq();
+            shmem_transport_portals4_drain_eq(ctx);
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -533,16 +533,16 @@ shmem_transport_portals4_put_nb_internal(void *target, const void *source, size_
 
 static inline
 void
-shmem_transport_put_nb(void *target, const void *source, size_t len,
+shmem_transport_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                                 int pe, long *completion)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    shmem_transport_portals4_put_nb_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nb_internal(ctx, target, source, len, pe,
                                              completion,
                                              shmem_transport_portals4_pt,
                                              -1);
 #else
-    shmem_transport_portals4_put_nb_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nb_internal(ctx, target, source, len, pe,
                                              completion,
                                              shmem_transport_portals4_data_pt,
                                              shmem_transport_portals4_heap_pt);
@@ -552,7 +552,7 @@ shmem_transport_put_nb(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_portals4_put_nbi_internal(void *target, const void *source, size_t len,
+shmem_transport_portals4_put_nbi_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                                 int pe, ptl_pt_index_t data_pt, ptl_pt_index_t heap_pt)
 {
     int ret;
@@ -607,14 +607,14 @@ shmem_transport_portals4_put_nbi_internal(void *target, const void *source, size
 
 static inline
 void
-shmem_transport_put_nbi(void *target, const void *source, size_t len, int pe)
+shmem_transport_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    shmem_transport_portals4_put_nbi_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nbi_internal(ctx, target, source, len, pe,
                                              shmem_transport_portals4_pt,
                                              -1);
 #else
-    shmem_transport_portals4_put_nbi_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nbi_internal(ctx, target, source, len, pe,
                                              shmem_transport_portals4_data_pt,
                                              shmem_transport_portals4_heap_pt);
 #endif
@@ -626,10 +626,10 @@ shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *so
                           size_t len, int pe, long *completion)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    shmem_transport_portals4_put_nb_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nb_internal(SHMEM_CTX_DEFAULT, target, source, len, pe,
                                              completion, ct->shr_pt, -1);
 #else
-    shmem_transport_portals4_put_nb_internal(target, source, len, pe,
+    shmem_transport_portals4_put_nb_internal(SHMEM_CTX_DEFAULT, target, source, len, pe,
                                              completion, ct->data_pt, ct->heap_pt);
 #endif
 }
@@ -637,16 +637,16 @@ shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *so
 
 static inline
 void
-shmem_transport_put_wait(long *completion)
+shmem_transport_put_wait(shmem_ctx_t ctx, long *completion)
 {
     while (*completion > 0) {
-        shmem_transport_portals4_drain_eq();
+        shmem_transport_portals4_drain_eq(ctx);
     }
 }
 
 static inline
 void
-shmem_transport_portals4_get_internal(void *target, const void *source, size_t len, int pe,
+shmem_transport_portals4_get_internal(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
                              ptl_pt_index_t data_pt, ptl_pt_index_t heap_pt)
 {
     int ret;
@@ -677,13 +677,13 @@ shmem_transport_portals4_get_internal(void *target, const void *source, size_t l
 
 
 static inline
-void shmem_transport_get(void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    shmem_transport_portals4_get_internal(target, source, len, pe,
+    shmem_transport_portals4_get_internal(ctx, target, source, len, pe,
                                           shmem_transport_portals4_pt, -1);
 #else
-    shmem_transport_portals4_get_internal(target, source, len, pe,
+    shmem_transport_portals4_get_internal(ctx, target, source, len, pe,
                                           shmem_transport_portals4_data_pt,
                                           shmem_transport_portals4_heap_pt);
 #endif
@@ -695,9 +695,9 @@ void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
                             const void *source, size_t len, int pe)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    shmem_transport_portals4_get_internal(target, source, len, pe, ct->shr_pt, -1);
+    shmem_transport_portals4_get_internal(SHMEM_CTX_DEFAULT, target, source, len, pe, ct->shr_pt, -1);
 #else
-    shmem_transport_portals4_get_internal(target, source, len, pe,
+    shmem_transport_portals4_get_internal(SHMEM_CTX_DEFAULT, target, source, len, pe,
                                           ct->data_pt, ct->heap_pt);
 #endif
 }
@@ -705,7 +705,7 @@ void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
 
 static inline
 void
-shmem_transport_get_wait(void)
+shmem_transport_get_wait(shmem_ctx_t ctx)
 {
     int ret;
     ptl_ct_event_t ct;
@@ -720,7 +720,7 @@ shmem_transport_get_wait(void)
 
 static inline
 void
-shmem_transport_swap(void *target, const void *source, void *dest, size_t len,
+shmem_transport_swap(shmem_ctx_t ctx, void *target, const void *source, void *dest, size_t len,
                      int pe, ptl_datatype_t datatype)
 {
     int ret;
@@ -760,7 +760,7 @@ shmem_transport_swap(void *target, const void *source, void *dest, size_t len,
 
 static inline
 void
-shmem_transport_cswap(void *target, const void *source, void *dest,
+shmem_transport_cswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
                       ptl_datatype_t datatype)
 {
@@ -801,7 +801,7 @@ shmem_transport_cswap(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_mswap(void *target, const void *source, void *dest,
+shmem_transport_mswap(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
                       ptl_datatype_t datatype)
 {
@@ -842,7 +842,7 @@ shmem_transport_mswap(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_atomic_small(void *target, const void *source, size_t len,
+shmem_transport_atomic_small(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                              int pe, ptl_op_t op, ptl_datatype_t datatype)
 {
     int ret;
@@ -878,7 +878,7 @@ shmem_transport_atomic_small(void *target, const void *source, size_t len,
 
 static inline
 void
-shmem_transport_atomic_nb(void *target, const void *source, size_t len, int pe,
+shmem_transport_atomic_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
                           ptl_op_t op, ptl_datatype_t datatype, long *completion)
 {
     int ret;
@@ -918,7 +918,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t len, int pe,
         SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
         while (0 >= --shmem_transport_portals4_event_slots) {
             shmem_transport_portals4_event_slots++;
-            shmem_transport_portals4_drain_eq();
+            shmem_transport_portals4_drain_eq(ctx);
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -970,7 +970,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t len, int pe,
              SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_event_slots);
              while (0 >= --shmem_transport_portals4_event_slots) {
                   shmem_transport_portals4_event_slots++;
-                  shmem_transport_portals4_drain_eq();
+                  shmem_transport_portals4_drain_eq(ctx);
              }
              SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
@@ -1003,7 +1003,7 @@ shmem_transport_atomic_nb(void *target, const void *source, size_t len, int pe,
 
 static inline
 void
-shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
+shmem_transport_fetch_atomic(shmem_ctx_t ctx, void *target, const void *source, void *dest,
                              size_t len, int pe, ptl_op_t op,
                              ptl_datatype_t datatype)
 {
@@ -1043,23 +1043,23 @@ shmem_transport_fetch_atomic(void *target, const void *source, void *dest,
 
 static inline
 void
-shmem_transport_atomic_set(void *target, const void *source, size_t len,
+shmem_transport_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                            int pe, int datatype)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_atomic_size);
 
-    shmem_transport_put_small(target, source, len, pe);
+    shmem_transport_put_small(ctx, target, source, len, pe);
 }
 
 
 static inline
 void
-shmem_transport_atomic_fetch(void *target, const void *source, size_t len,
+shmem_transport_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
                              int pe, int datatype)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_fetch_atomic_size);
 
-    shmem_transport_get(target, source, len, pe);
+    shmem_transport_get(ctx, target, source, len, pe);
 }
 
 

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -160,10 +160,10 @@ struct shmem_transport_ct_t {
 typedef struct shmem_transport_ct_t shmem_transport_ct_t;
 
 /* TODO populate this context struct: */
-struct shmem_transport_ctx_t {};
+struct shmem_transport_ctx_t { int dummy };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
-shmem_transport_ctx_t shmem_transport_ctx_default;
+extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset


### PR DESCRIPTION
Add the `shmem_ctx_t ctx` argument to each routine in the transport layer (for ofi, portals, and none).