### PR TITLE
Cleanup noreturn usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -372,14 +372,6 @@ AS_IF([test "$enable_pmi_simple" = "yes"],
 dnl check for types
 
 AC_LANG_PUSH([C])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>
-                   _Noreturn void f(void){ exit(0); }
-                   ]], [[ f(); ]] )],
-                  [NORETURN_FN_SPEC="_Noreturn"
-                   AC_SUBST(NORETURN_FN_SPEC)
-                   AC_DEFINE([NORETURN_FN_SPEC], [_Noreturn], [Defined to C _Noreturn function specifier, if present])],
-                  [AC_DEFINE([NORETURN_FN_SPEC], [], [Defined to C _Noreturn function specifier, if present])],
-                 )
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ _Complex v; ]] )],
                   [],
                   [AC_ERROR([C Compiler does not support _Complex])])

--- a/mpp/shmem_c_func.h4.in
+++ b/mpp/shmem_c_func.h4.in
@@ -30,12 +30,14 @@ SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_n_pes(void);
 SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_my_pe(void);
 #ifdef __cplusplus
 #  if __cplusplus >= 201103L
-SHMEM_FUNCTION_ATTRIBUTES [[ noreturn ]] void SHPRE()shmem_global_exit(int status);
+[[noreturn]] void SHPRE()shmem_global_exit(int status) SHMEM_FUNCTION_ATTRIBUTES;
 #  else
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_global_exit(int status);
 #  endif
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+SHMEM_FUNCTION_ATTRIBUTES _Noreturn void SHPRE()shmem_global_exit(int status);
 #else
-SHMEM_FUNCTION_ATTRIBUTES @NORETURN_FN_SPEC@ void SHPRE()shmem_global_exit(int status);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_global_exit(int status);
 #endif
 
 SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_pe_accessible(int pe);

--- a/src/init.c
+++ b/src/init.c
@@ -346,7 +346,7 @@ void shmem_internal_finalize(void)
 }
 
 
-void NORETURN_FN_SPEC
+void
 shmem_internal_global_exit(int status)
 {
     char str[256];

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -167,7 +167,7 @@ shmem_runtime_fini(void)
 }
 
 
-void NORETURN_FN_SPEC
+void
 shmem_runtime_abort(int exit_code, const char msg[])
 {
 

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -132,7 +132,7 @@ shmem_runtime_fini(void)
 }
 
 
-void NORETURN_FN_SPEC
+void
 shmem_runtime_abort(int exit_code, const char msg[])
 {
 

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -82,7 +82,7 @@ shmem_runtime_fini(void)
 }
 
 
-void NORETURN_FN_SPEC
+void
 shmem_runtime_abort(int exit_code, const char msg[])
 {
 

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -21,7 +21,7 @@
 
 int shmem_runtime_init(void);
 int shmem_runtime_fini(void);
-NORETURN_FN_SPEC void shmem_runtime_abort(int exit_code, const char msg[]) SHMEM_ATTRIBUTE_NORETURN ;
+void shmem_runtime_abort(int exit_code, const char msg[]) SHMEM_ATTRIBUTE_NORETURN ;
 
 int shmem_runtime_get_rank(void);
 int shmem_runtime_get_size(void);

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -26,6 +26,7 @@
 #include "runtime.h"
 #include "config.h"
 #include "shmem_env.h"
+#include "shmem_decl.h"
 
 extern int shmem_internal_my_pe;
 extern int shmem_internal_num_pes;
@@ -403,7 +404,7 @@ extern shmem_internal_mutex_t shmem_internal_mutex_alloc;
 void shmem_internal_start_pes(int npes);
 void shmem_internal_init(int tl_requested, int *tl_provided);
 void shmem_internal_finalize(void);
-NORETURN_FN_SPEC void shmem_internal_global_exit(int status);
+void shmem_internal_global_exit(int status) SHMEM_ATTRIBUTE_NORETURN;
 char *shmem_internal_nodename(void);
 
 int shmem_internal_symmetric_init(void);


### PR DESCRIPTION
Use language version to decide when to use _Noreturn and [[noreturn]].
This should clean up warnings when building SOS from using _Noreturn
with -std=c99. Transition internal usage back to compiler attributes
instead of _Noreturn to avoid a dependence on C11.

Also, shuffle the attribute location in C++ shmem_global_exit to work
around Clang error.

Signed-off-by: James Dinan <james.dinan@intel.com>