### PR TITLE
 [No merge] Move OFI put/get counters into shmem_ctx_default struct

### DIFF
--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -18,6 +18,7 @@
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
 #include "shmem_internal.h"
+#include "transport.h"
 
 #ifdef ENABLE_PROFILING
 #include "pshmem.h"
@@ -34,7 +35,10 @@ SHMEM_FUNCTION_ATTRIBUTES int
 shmem_ctx_create(long options, shmem_ctx_t *ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
-    SHMEM_ERR_CHECK_NULL(ctx, 1);
+
+    shmem_transport_ctx_create((shmem_transport_ctx_t **) ctx);
+
+    SHMEM_ERR_CHECK_NULL(ctx, 0);
 
     return 0;
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -81,6 +81,13 @@ shmem_transport_fini(void)
 }
 
 static inline
+void
+shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
+{
+    return;
+}
+
+static inline
 int
 shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -129,6 +129,10 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 shmem_transport_ctx_t shmem_transport_ctx_default;
 void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
+void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx) {
+  return;
+}
+
 static
 void
 init_bounce_buffer(shmem_free_list_item_t *item)

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -163,6 +163,7 @@ struct shmem_transport_ctx_t { int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
+void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
 
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset


### PR DESCRIPTION
As a proof-of-concept, set all user-provided contexts to the default context within OFI.  Transport none and portals currently do nothing for ctx_create.

Please feel free to provide feedback before I add a (simple) functional `shmem_ctx_create` for OFI.
