### PR TITLE
First draft of ctx create/destroy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,6 @@ before_install:
     - export TRAVIS_INSTALL=$HOME/travis/install
     ## Disable security protection so CMA will work
     - sudo sysctl -w kernel.yama.ptrace_scope=0
-    - ulimit -n 2048
     ## Run the icc installation script:
     - >
       if [ "$CC" = "icc" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,7 @@ before_install:
     - export TRAVIS_INSTALL=$HOME/travis/install
     ## Disable security protection so CMA will work
     - sudo sysctl -w kernel.yama.ptrace_scope=0
+    - ulimit -n 2048
     ## Run the icc installation script:
     - >
       if [ "$CC" = "icc" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ before_install:
     - make install
     ## Build libfabric
     - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/ofiwg/libfabric.git libfabric
+    - git clone -b v1.5.1 --depth 10 https://github.com/ofiwg/libfabric.git libfabric
     - cd libfabric
     - ./autogen.sh
     - ./configure --prefix=$TRAVIS_INSTALL/libfabric

--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -86,9 +86,9 @@ typedef void* shmem_ctx_t;
 #else
   extern shmem_ctx_t SHMEM_CTX_DEFAULT;
 #endif
-#define SHMEM_CTX_PRIVATE       1
-#define SHMEM_CTX_SERIALIZED    2
-#define SHMEM_CTX_NOSTORE       4
+#define SHMEM_CTX_PRIVATE       (1<<0)
+#define SHMEM_CTX_SERIALIZED    (1<<1)
+#define SHMEM_CTX_NOSTORE       (1<<2)
 
 define(`SHPRE', `')dnl
 include(shmem_c_func.h4)dnl

--- a/mpp/shmemx.h4.in
+++ b/mpp/shmemx.h4.in
@@ -32,4 +32,6 @@ typedef char * shmemx_ct_t;
 define(`SHPRE', `')dnl
 include(shmemx_c_func.h4)dnl
 
+#define SHMEMX_CTX_BOUNCE_BUFFER  (1<<31)
+
 #endif /* SHMEMX_H */

--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -18,6 +18,7 @@
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
 #include "shmem_internal.h"
+#include "transport.h"
 
 #ifdef ENABLE_PROFILING
 #include "pshmem.h"
@@ -34,7 +35,10 @@ SHMEM_FUNCTION_ATTRIBUTES int
 shmem_ctx_create(long options, shmem_ctx_t *ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
-    SHMEM_ERR_CHECK_NULL(ctx, 1);
+
+    shmem_transport_ctx_create((shmem_transport_ctx_t **) ctx);
+
+    SHMEM_ERR_CHECK_NULL(ctx, 0);
 
     return 0;
 }

--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -36,7 +36,7 @@ shmem_ctx_create(long options, shmem_ctx_t *ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_transport_ctx_create((shmem_transport_ctx_t **) ctx);
+    shmem_transport_ctx_create(options, (shmem_transport_ctx_t **) ctx);
 
     SHMEM_ERR_CHECK_NULL(ctx, 0);
 

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -81,6 +81,13 @@ shmem_transport_fini(void)
 }
 
 static inline
+void
+shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
+{
+    return;
+}
+
+static inline
 int
 shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -88,6 +88,13 @@ shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
 }
 
 static inline
+void
+shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
+{
+    return;
+}
+
+static inline
 int
 shmem_transport_quiet(shmem_transport_ctx_t* ctx)
 {

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -84,6 +84,7 @@ static inline
 void
 shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
 {
+    *ctx = NULL;
     return;
 }
 
@@ -91,6 +92,9 @@ static inline
 void
 shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 {
+    if (ctx != NULL) {
+        RAISE_ERROR_STR("Invalid ctx_destroy");
+    }
     return;
 }
 

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -82,7 +82,7 @@ shmem_transport_fini(void)
 
 static inline
 void
-shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
+shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
 {
     *ctx = NULL;
     return;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1376,6 +1376,7 @@ int shmem_transport_fini(void)
     }
 
     //shmem_transport_ctx_destroy(&shmem_transport_ctx_default);
+    shmem_transport_quiet(&shmem_transport_ctx_default);
 
     if (shmem_transport_ctx_default.endpoint.ep &&
         fi_close(&shmem_transport_ctx_default.endpoint.ep->fid)) {

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1252,6 +1252,8 @@ int shmem_transport_init(void)
     //if (ret!=0)
     //    return ret;
 
+    shmem_transport_ctx_default.options |= SHMEMX_CTX_BOUNCE_BUFFER;
+
     ret = allocate_endpoints(&shmem_transport_ctx_default, &shmem_transport_ofi_info);
     if (ret!=0)
         return ret;
@@ -1306,7 +1308,7 @@ int shmem_transport_startup(void)
     return 0;
 }
 
-int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
+int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
 {
     SHMEM_MUTEX_LOCK(shmem_transport_ofi_lock);
 
@@ -1335,6 +1337,8 @@ int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx)
     if (ctxp == NULL) {
         RAISE_ERROR_STR("Error: out of memory when allocating OFI ctx object");
     }
+
+    ctxp->options = options;
 
     ret = shmem_transport_ofi_ctx_init(ctxp, id);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1233,6 +1233,7 @@ int shmem_transport_init(void)
     shmem_transport_ofi_put_poll_limit = shmem_internal_params.OFI_TX_POLL_LIMIT;
     shmem_transport_ofi_get_poll_limit = shmem_internal_params.OFI_RX_POLL_LIMIT;
 
+    /* TODO: initialize the default context with the same routine as user contexts */
     //ret = shmem_transport_ofi_ctx_init(-1, &shmem_transport_ctx_default);
     //if (ret!=0)
     //    return ret;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -202,6 +202,7 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 typedef int shmem_transport_ct_t;
 
 struct shmem_transport_ctx_t {
+  long                            options;
   struct fid_ep*                  cntr_ep;
   struct fid_cntr*                put_cntr;
   struct fid_cntr*                get_cntr;
@@ -213,7 +214,7 @@ struct shmem_transport_ctx_t {
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
-int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
+int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
@@ -472,7 +473,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
 
         shmem_transport_put_small(ctx, target, source, len, pe);
 
-    } else if (len <= shmem_transport_ofi_bounce_buffer_size) {
+    } else if (len <= shmem_transport_ofi_bounce_buffer_size && ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
 
         shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
@@ -859,7 +860,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
         } while(try_again(ret,&polled));
 
     } else if (full_len <=
-               MIN(shmem_transport_ofi_bounce_buffer_size, max_atomic_size)) {
+               MIN(shmem_transport_ofi_bounce_buffer_size, max_atomic_size) && ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
 
         shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, full_len);
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -218,7 +218,7 @@ typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
-int shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
+void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -200,17 +200,13 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 
 typedef int shmem_transport_ct_t;
 
-typedef struct shmem_transport_cntr_ep_t {
-    struct fid_ep*                  ep;
-    struct fid_ep*                  cntr_ep;
-    struct fid_cntr*                put_cntrfd;
-    struct fid_cntr*                get_cntrfd;
-    shmem_internal_atomic_uint64_t  pending_put_counter;
-    shmem_internal_atomic_uint64_t  pending_get_counter;
-} shmem_transport_cntr_ep_t;
-
 struct shmem_transport_ctx_t {
-  shmem_transport_cntr_ep_t endpoint;
+  struct fid_ep*                  ep;
+  struct fid_ep*                  cntr_ep;
+  struct fid_cntr*                put_cntrfd;
+  struct fid_cntr*                get_cntrfd;
+  shmem_internal_atomic_uint64_t  pending_put_counter;
+  shmem_internal_atomic_uint64_t  pending_get_counter;
   int id;
 };
 
@@ -321,9 +317,9 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
     long poll_count = 0;
     while (poll_count < shmem_transport_ofi_put_poll_limit ||
            shmem_transport_ofi_put_poll_limit < 0) {
-        success = fi_cntr_read(ctx->endpoint.put_cntrfd);
-        fail = fi_cntr_readerr(ctx->endpoint.put_cntrfd);
-        cnt = shmem_internal_atomic_read(&ctx->endpoint.pending_put_counter);
+        success = fi_cntr_read(ctx->put_cntrfd);
+        fail = fi_cntr_readerr(ctx->put_cntrfd);
+        cnt = shmem_internal_atomic_read(&ctx->pending_put_counter);
 
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
@@ -336,11 +332,11 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         }
         poll_count++;
     }
-    cnt_new = shmem_internal_atomic_read(&ctx->endpoint.pending_put_counter);
+    cnt_new = shmem_internal_atomic_read(&ctx->pending_put_counter);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->endpoint.put_cntrfd, cnt, -1);
-        cnt_new = shmem_internal_atomic_read(&ctx->endpoint.pending_put_counter);
+        int ret = fi_cntr_wait(ctx->put_cntrfd, cnt, -1);
+        cnt_new = shmem_internal_atomic_read(&ctx->pending_put_counter);
         if (ret) {
             struct fi_cq_err_entry e = {0};
             fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
@@ -405,11 +401,11 @@ void shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const v
 
     shmem_internal_assert(len <= shmem_transport_ofi_max_buffered_send);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_counter);
 
     do {
 
-        ret = fi_inject_write(ctx->endpoint.cntr_ep,
+        ret = fi_inject_write(ctx->cntr_ep,
                               source,
                               len,
                               GET_DEST(dst),
@@ -446,10 +442,10 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
                        (size_t) (((uint8_t *) source) + len - frag_source));
         polled = 0;
 
-        shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+        shmem_internal_atomic_inc(&ctx->pending_put_counter);
 
         do {
-            ret = fi_write(ctx->endpoint.cntr_ep,
+            ret = fi_write(ctx->cntr_ep,
                            frag_source, frag_len, NULL,
                            GET_DEST(dst), frag_target,
                            key, NULL);
@@ -486,7 +482,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
         shmem_internal_atomic_inc(&shmem_transport_ofi_pending_cq_count);
 
         do {
-            ret = fi_write(ctx->endpoint.ep,
+            ret = fi_write(ctx->ep,
                            buff->data, len, NULL,
                            GET_DEST(dst), (uint64_t) addr,
                            key, buff);
@@ -538,9 +534,9 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
 
     if (len <= shmem_transport_ofi_max_msg_size) {
 
-        shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+        shmem_internal_atomic_inc(&ctx->pending_get_counter);
         do {
-            ret = fi_read(ctx->endpoint.cntr_ep,
+            ret = fi_read(ctx->cntr_ep,
                           target,
                           len,
                           NULL,
@@ -560,10 +556,10 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
                            (size_t) (((uint8_t *) target) + len - frag_target));
             polled = 0;
 
-            shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+            shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
             do {
-                ret = fi_read(ctx->endpoint.cntr_ep,
+                ret = fi_read(ctx->cntr_ep,
                               frag_target, frag_len, NULL,
                               GET_DEST(dst), frag_source,
                               key, NULL);
@@ -591,9 +587,9 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
     long poll_count = 0;
     while (poll_count < shmem_transport_ofi_get_poll_limit ||
            shmem_transport_ofi_get_poll_limit < 0) {
-        success = fi_cntr_read(ctx->endpoint.get_cntrfd);
-        fail = fi_cntr_readerr(ctx->endpoint.get_cntrfd);
-        cnt = shmem_internal_atomic_read(&ctx->endpoint.pending_get_counter);
+        success = fi_cntr_read(ctx->get_cntrfd);
+        fail = fi_cntr_readerr(ctx->get_cntrfd);
+        cnt = shmem_internal_atomic_read(&ctx->pending_get_counter);
 
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
@@ -606,11 +602,11 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         }
         poll_count++;
     }
-    cnt_new = shmem_internal_atomic_read(&ctx->endpoint.pending_get_counter);
+    cnt_new = shmem_internal_atomic_read(&ctx->pending_get_counter);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->endpoint.get_cntrfd, cnt, -1);
-        cnt_new = shmem_internal_atomic_read(&ctx->endpoint.pending_get_counter);
+        int ret = fi_cntr_wait(ctx->get_cntrfd, cnt, -1);
+        cnt_new = shmem_internal_atomic_read(&ctx->pending_get_counter);
         if (ret) {
             struct fi_cq_err_entry e = {0};
             fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
@@ -636,10 +632,10 @@ void shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
     do {
-        ret = fi_fetch_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_fetch_atomic(ctx->cntr_ep,
                               source,
                               1,
                               NULL,
@@ -671,10 +667,10 @@ void shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void 
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
     do {
-        ret = fi_compare_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_compare_atomic(ctx->cntr_ep,
                                 source,
                                 1,
                                 NULL,
@@ -707,10 +703,10 @@ void shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void 
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
     do {
-        ret = fi_compare_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_compare_atomic(ctx->cntr_ep,
                                 source,
                                 1,
                                 NULL,
@@ -742,10 +738,10 @@ void shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, cons
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_counter);
 
     do {
-        ret = fi_inject_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_inject_atomic(ctx->cntr_ep,
                                source,
                                1,
                                GET_DEST(dst),
@@ -771,9 +767,9 @@ void shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const 
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_counter);
     do {
-        ret = fi_inject_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_inject_atomic(ctx->cntr_ep,
                                source,
                                1,
                                GET_DEST(dst),
@@ -799,10 +795,10 @@ void shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, cons
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
     do {
-        ret = fi_fetch_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_fetch_atomic(ctx->cntr_ep,
                               NULL,
                               1,
                               NULL,
@@ -833,7 +829,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] * len == full_len);
 
-    ret = fi_atomicvalid(ctx->endpoint.ep, datatype, op,
+    ret = fi_atomicvalid(ctx->ep, datatype, op,
                          &max_atomic_size);
     max_atomic_size = max_atomic_size * SHMEM_Dtsize[datatype];
     if (max_atomic_size > shmem_transport_ofi_max_msg_size
@@ -849,10 +845,10 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
 
         polled = 0;
 
-        shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+        shmem_internal_atomic_inc(&ctx->pending_put_counter);
 
         do {
-            ret = fi_inject_atomic(ctx->endpoint.cntr_ep,
+            ret = fi_inject_atomic(ctx->cntr_ep,
                                    source,
                                    len,
                                    GET_DEST(dst),
@@ -872,7 +868,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
         shmem_internal_atomic_inc(&shmem_transport_ofi_pending_cq_count);
 
         do {
-            ret = fi_atomic(ctx->endpoint.ep,
+            ret = fi_atomic(ctx->ep,
                             buff->data,
                             len,
                             NULL,
@@ -892,9 +888,9 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
             size_t chunksize = MIN((len-sent),
                                    (max_atomic_size/SHMEM_Dtsize[datatype]));
             polled = 0;
-            shmem_internal_atomic_inc(&ctx->endpoint.pending_put_counter);
+            shmem_internal_atomic_inc(&ctx->pending_put_counter);
             do {
-                ret = fi_atomic(ctx->endpoint.cntr_ep,
+                ret = fi_atomic(ctx->cntr_ep,
                                 (void *)((char *)source +
                                          (sent*SHMEM_Dtsize[datatype])),
                                 chunksize,
@@ -929,10 +925,10 @@ void shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, cons
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->endpoint.pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_counter);
 
     do {
-        ret = fi_fetch_atomic(ctx->endpoint.cntr_ep,
+        ret = fi_fetch_atomic(ctx->cntr_ep,
                               source,
                               1,
                               NULL,
@@ -955,7 +951,7 @@ int shmem_transport_atomic_supported(shm_internal_op_t op,
                                      shm_internal_datatype_t datatype)
 {
     size_t size = 0;
-    int ret = fi_atomicvalid(shmem_transport_ctx_default.endpoint.ep, datatype, op, &size);
+    int ret = fi_atomicvalid(shmem_transport_ctx_default.ep, datatype, op, &size);
     return !(ret != 0 || size == 0);
 }
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -203,10 +203,10 @@ typedef int shmem_transport_ct_t;
 
 struct shmem_transport_ctx_t {
   struct fid_ep*                  cntr_ep;
-  struct fid_cntr*                put_cntrfd;
-  struct fid_cntr*                get_cntrfd;
-  shmem_internal_atomic_uint64_t  pending_put_counter;
-  shmem_internal_atomic_uint64_t  pending_get_counter;
+  struct fid_cntr*                put_cntr;
+  struct fid_cntr*                get_cntr;
+  shmem_internal_atomic_uint64_t  pending_put_cntr;
+  shmem_internal_atomic_uint64_t  pending_get_cntr;
   int id;
 };
 
@@ -317,9 +317,9 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
     long poll_count = 0;
     while (poll_count < shmem_transport_ofi_put_poll_limit ||
            shmem_transport_ofi_put_poll_limit < 0) {
-        success = fi_cntr_read(ctx->put_cntrfd);
-        fail = fi_cntr_readerr(ctx->put_cntrfd);
-        cnt = shmem_internal_atomic_read(&ctx->pending_put_counter);
+        success = fi_cntr_read(ctx->put_cntr);
+        fail = fi_cntr_readerr(ctx->put_cntr);
+        cnt = shmem_internal_atomic_read(&ctx->pending_put_cntr);
 
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
@@ -332,11 +332,11 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         }
         poll_count++;
     }
-    cnt_new = shmem_internal_atomic_read(&ctx->pending_put_counter);
+    cnt_new = shmem_internal_atomic_read(&ctx->pending_put_cntr);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->put_cntrfd, cnt, -1);
-        cnt_new = shmem_internal_atomic_read(&ctx->pending_put_counter);
+        int ret = fi_cntr_wait(ctx->put_cntr, cnt, -1);
+        cnt_new = shmem_internal_atomic_read(&ctx->pending_put_cntr);
         if (ret) {
             struct fi_cq_err_entry e = {0};
             fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
@@ -401,7 +401,7 @@ void shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const v
 
     shmem_internal_assert(len <= shmem_transport_ofi_max_buffered_send);
 
-    shmem_internal_atomic_inc(&ctx->pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
     do {
 
@@ -442,7 +442,7 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
                        (size_t) (((uint8_t *) source) + len - frag_source));
         polled = 0;
 
-        shmem_internal_atomic_inc(&ctx->pending_put_counter);
+        shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
         do {
             ret = fi_write(ctx->cntr_ep,
@@ -534,7 +534,7 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
 
     if (len <= shmem_transport_ofi_max_msg_size) {
 
-        shmem_internal_atomic_inc(&ctx->pending_get_counter);
+        shmem_internal_atomic_inc(&ctx->pending_get_cntr);
         do {
             ret = fi_read(ctx->cntr_ep,
                           target,
@@ -556,7 +556,7 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
                            (size_t) (((uint8_t *) target) + len - frag_target));
             polled = 0;
 
-            shmem_internal_atomic_inc(&ctx->pending_get_counter);
+            shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
             do {
                 ret = fi_read(ctx->cntr_ep,
@@ -587,9 +587,9 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
     long poll_count = 0;
     while (poll_count < shmem_transport_ofi_get_poll_limit ||
            shmem_transport_ofi_get_poll_limit < 0) {
-        success = fi_cntr_read(ctx->get_cntrfd);
-        fail = fi_cntr_readerr(ctx->get_cntrfd);
-        cnt = shmem_internal_atomic_read(&ctx->pending_get_counter);
+        success = fi_cntr_read(ctx->get_cntr);
+        fail = fi_cntr_readerr(ctx->get_cntr);
+        cnt = shmem_internal_atomic_read(&ctx->pending_get_cntr);
 
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
@@ -602,11 +602,11 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         }
         poll_count++;
     }
-    cnt_new = shmem_internal_atomic_read(&ctx->pending_get_counter);
+    cnt_new = shmem_internal_atomic_read(&ctx->pending_get_cntr);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->get_cntrfd, cnt, -1);
-        cnt_new = shmem_internal_atomic_read(&ctx->pending_get_counter);
+        int ret = fi_cntr_wait(ctx->get_cntr, cnt, -1);
+        cnt_new = shmem_internal_atomic_read(&ctx->pending_get_cntr);
         if (ret) {
             struct fi_cq_err_entry e = {0};
             fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
@@ -632,7 +632,7 @@ void shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     do {
         ret = fi_fetch_atomic(ctx->cntr_ep,
@@ -667,7 +667,7 @@ void shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void 
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     do {
         ret = fi_compare_atomic(ctx->cntr_ep,
@@ -703,7 +703,7 @@ void shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void 
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     do {
         ret = fi_compare_atomic(ctx->cntr_ep,
@@ -738,7 +738,7 @@ void shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, cons
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
     do {
         ret = fi_inject_atomic(ctx->cntr_ep,
@@ -767,7 +767,7 @@ void shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const 
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_put_counter);
+    shmem_internal_atomic_inc(&ctx->pending_put_cntr);
     do {
         ret = fi_inject_atomic(ctx->cntr_ep,
                                source,
@@ -795,7 +795,7 @@ void shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, cons
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     do {
         ret = fi_fetch_atomic(ctx->cntr_ep,
@@ -845,7 +845,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
 
         polled = 0;
 
-        shmem_internal_atomic_inc(&ctx->pending_put_counter);
+        shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
         do {
             ret = fi_inject_atomic(ctx->cntr_ep,
@@ -888,7 +888,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
             size_t chunksize = MIN((len-sent),
                                    (max_atomic_size/SHMEM_Dtsize[datatype]));
             polled = 0;
-            shmem_internal_atomic_inc(&ctx->pending_put_counter);
+            shmem_internal_atomic_inc(&ctx->pending_put_cntr);
             do {
                 ret = fi_atomic(ctx->cntr_ep,
                                 (void *)((char *)source +
@@ -925,7 +925,7 @@ void shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, cons
     shmem_internal_assert(len <= sizeof(double _Complex));
     shmem_internal_assert(SHMEM_Dtsize[datatype] == len);
 
-    shmem_internal_atomic_inc(&ctx->pending_get_counter);
+    shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     do {
         ret = fi_fetch_atomic(ctx->cntr_ep,

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -203,7 +203,7 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 typedef int shmem_transport_ct_t;
 
 typedef struct shmem_transport_cntr_ep_t {
-    struct fid_ep* ep;
+    struct fid_ep*                  ep;
     struct fid_cntr*                put_cntrfd;
     struct fid_cntr*                get_cntrfd;
     shmem_internal_atomic_uint64_t  pending_put_counter;
@@ -218,7 +218,7 @@ struct shmem_transport_ctx_t {
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
-void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
+int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
 
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -218,6 +218,7 @@ typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 int shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
+int shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 extern shmem_free_list_t *shmem_transport_ofi_bounce_buffers;
 

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -130,10 +130,14 @@ shmem_transport_ctx_t shmem_transport_ctx_default;
 void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
 void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx) {
+  *ctx = NULL;
   return;
 }
 
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx) {
+  if (ctx != NULL) {
+      RAISE_ERROR_STR("Invalid ctx_destroy");
+  }
   return;
 }
 

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -133,6 +133,10 @@ void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx) {
   return;
 }
 
+void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx) {
+  return;
+}
+
 static
 void
 init_bounce_buffer(shmem_free_list_item_t *item)

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -129,6 +129,10 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 shmem_transport_ctx_t shmem_transport_ctx_default;
 void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
+void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx) {
+  return;
+}
+
 static
 void
 init_bounce_buffer(shmem_free_list_item_t *item)

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -129,7 +129,7 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 shmem_transport_ctx_t shmem_transport_ctx_default;
 void *SHMEM_CTX_DEFAULT = &shmem_transport_ctx_default;
 
-void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx) {
+void shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx) {
   *ctx = NULL;
   return;
 }

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -163,7 +163,7 @@ struct shmem_transport_ctx_t { int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
-void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
+void shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 /*

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -164,6 +164,7 @@ struct shmem_transport_ctx_t { int dummy; };
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
+void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -163,6 +163,7 @@ struct shmem_transport_ctx_t { int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
+void shmem_transport_ctx_create(shmem_transport_ctx_t **ctx);
 
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset

--- a/test/unit/many-ctx.c
+++ b/test/unit/many-ctx.c
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define NUM_CTX 64
+#define NUM_CTX 32
 
 long data = 0;
 

--- a/test/unit/web.c
+++ b/test/unit/web.c
@@ -46,8 +46,8 @@
     }                              \
   } while(0)
 
-#define NUM_UNSAFE_CTX 64
-#define NUM_CONTEXTS   128
+#define NUM_UNSAFE_CTX 10
+#define NUM_CONTEXTS   20
 
 typedef struct {
   int idx;


### PR DESCRIPTION
Highlights:
- Adds `shmem_ctx_create()` and `shmem_ctx_destroy()` for OFI, based on the [prototype](https://github.com/jdinan/sandia-shmem/tree/contexts).
- Removes the (presumably) extraneous [cntr_info object](https://github.com/jdinan/sandia-shmem/blob/contexts/src/transport_ofi.c#L1252) and renames it to `shmem_transport_ofi_info`.
- Adds a couple endpoints to the ctx struct

To do:
- Initialize the default context with the same routine as user contexts (`shmem_transport_ofi_ctx_init`).
- Do resource cleanup upon error from shmem_ctx_create and address [JD's comments](https://github.com/Sandia-OpenSHMEM/SOS/compare/v1.4.0-dev...davidozog:pr/ctx_create_destroy?expand=1#diff-02eef8be694d26121d1275651d32e9a5R1303).
- Assure this works with latest libfabric:master (`many-ctx` and `web.c` tests currently seem to have progress issues in the sockets provider up to and including libfabric 1.5.1).


