### PR TITLE
Sync API: revert shmem_cmp_t back to int

### DIFF
--- a/man/shmem_test.3
+++ b/man/shmem_test.3
@@ -12,7 +12,7 @@ Test whether a variable on the local PE has changed.
 .B int
 .B shmem_test(TYPE
 .IB "*ivar" ,
-.I shmem_cmp_t
+.I int
 .IB "cmp" ,
 .B TYPE
 .I value
@@ -25,7 +25,7 @@ Table 5.
 .B int
 .B shmem_<TYPENAME>_test(TYPE
 .IB "*ivar" ,
-.I shmem_cmp_t
+.I int
 .IB "cmp" ,
 .B TYPE
 .I value
@@ -92,7 +92,7 @@ wait on an array of symmetric objects and return the index of an
 element that satisfies the specified condition.
 .nf
 #include <shmem.h>
-int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
+int user_wait_any(long *ivar, int count, int cmp, long value)
 {
  int idx = 0;
  while (!shmem_test(&ivar[idx], cmp, value))

--- a/man/shmem_wait.3
+++ b/man/shmem_wait.3
@@ -12,7 +12,7 @@ Wait for a variable on the local PE to change.
 .B void
 .B shmem_wait_until(TYPE
 .IB "*ivar" ,
-.I shmem_cmp_t
+.I int
 .IB "cmp" ,
 .B TYPE
 .I cmp_value
@@ -39,7 +39,7 @@ Table 5.
 .B void
 .B shmem_<TYPENAME>_wait_until(TYPE
 .IB "*ivar" ,
-.I shmem_cmp_t
+.I int
 .IB "cmp" ,
 .B TYPE
 .I cmp_value

--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -31,12 +31,12 @@ include(shmem_bind_cxx.m4)dnl
 extern "C" {
 #endif
 
-typedef enum { SHMEM_CMP_EQ=1,
-               SHMEM_CMP_NE=2,
-               SHMEM_CMP_GT=3,
-               SHMEM_CMP_GE=4,
-               SHMEM_CMP_LT=5,
-               SHMEM_CMP_LE=6 } shmem_cmp_t;
+#define SHMEM_CMP_EQ 1
+#define SHMEM_CMP_NE 2
+#define SHMEM_CMP_GT 3
+#define SHMEM_CMP_GE 4
+#define SHMEM_CMP_LT 5
+#define SHMEM_CMP_LE 6
 
 #define _SHMEM_CMP_EQ 1
 #define _SHMEM_CMP_NE 2
@@ -369,13 +369,13 @@ SHMEM_CXX_DEFINE_FOR_EXTENDED_AMO(`SHMEM_CXX_ATOMIC_SET')
 /* Point-to-point synchronization */
 
 define(`SHMEM_CXX_WAIT_UNTIL',
-`static inline void shmem_wait_until($2 *ivar, shmem_cmp_t cmp, $2 cmp_value) {
+`static inline void shmem_wait_until($2 *ivar, int cmp, $2 cmp_value) {
     shmem_$1_wait_until(ivar, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_WAIT_UNTIL')
 
 define(`SHMEM_CXX_TEST',
-`static inline int shmem_test($2 *ivar, shmem_cmp_t cmp, $2 cmp_value) {
+`static inline int shmem_test($2 *ivar, int cmp, $2 cmp_value) {
     return shmem_$1_test(ivar, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_TEST')

--- a/mpp/shmem_c_func.h4.in
+++ b/mpp/shmem_c_func.h4.in
@@ -436,17 +436,17 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_wait(long *ivar, long cmp_value) SHM
 SHMEM_BIND_C_WAIT(`SHMEM_C_WAIT')
 
 define(`SHMEM_C_WAIT_UNTIL',
-`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_wait_until($2 *var, shmem_cmp_t cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_$1_wait_until($2 *var, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_WAIT_UNTIL')
 
 /* Special case, only enabled when C++ and C11 bindings are disabled */
 #if !defined(__cplusplus) && \
     !(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)
-SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_wait_until(long *ivar, shmem_cmp_t cmp, long value);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_wait_until(long *ivar, int cmp, long value);
 #endif
 
 define(`SHMEM_C_TEST',
-`SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_$1_test($2 *var, shmem_cmp_t cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_$1_test($2 *var, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_TEST')
 
 /* Memory Ordering Routines */

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -112,7 +112,7 @@ shmem_wait(long *ivar, long cmp_value)
 
 
 void SHMEM_FUNCTION_ATTRIBUTES
-shmem_wait_until(long *ivar, shmem_cmp_t cmp, long value)
+shmem_wait_until(long *ivar, int cmp, long value)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(ivar, sizeof(long));
@@ -136,7 +136,7 @@ SHMEM_BIND_C_WAIT(`SHMEM_DEF_WAIT')
 
 #define SHMEM_DEF_WAIT_UNTIL(STYPE,TYPE)                                                       \
     void SHMEM_FUNCTION_ATTRIBUTES                                                             \
-    shmem_##STYPE##_wait_until(TYPE *var, shmem_cmp_t cond, TYPE value)                        \
+    shmem_##STYPE##_wait_until(TYPE *var, int cond, TYPE value)                                \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(var, sizeof(TYPE));                                          \
@@ -149,7 +149,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
 
 #define SHMEM_DEF_TEST(STYPE,TYPE)                                                             \
     int SHMEM_FUNCTION_ATTRIBUTES                                                              \
-    shmem_##STYPE##_test(TYPE *var, shmem_cmp_t cond, TYPE value)                              \
+    shmem_##STYPE##_test(TYPE *var, int cond, TYPE value)                                      \
     {                                                                                          \
         int cmpret;                                                                            \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \

--- a/test/unit/shmem_test.c
+++ b/test/unit/shmem_test.c
@@ -34,7 +34,7 @@
 
 /* Wait for any entry in the given ivar array to match the wait criteria and
  * return the index of the entry that satisfied the test. */
-int wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
+int wait_any(long *ivar, int count, int cmp, long value)
 {
   int idx = 0;
   while (!shmem_long_test(&ivar[idx], cmp, value))


### PR DESCRIPTION
New change that will be incorporated into the next draft of OpenSHMEM 1.4.