### PR TITLE
OFI: fix memory registration for  FI_MR_BASIC

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -536,11 +536,11 @@ int allocate_recv_cntr_mr(void)
 
 #else
     /* Register separate data and heap segments using keys 0 and 1,
-     * respectively.  In MR_BASIC_MODE, the keys are ignored and selected by
+     * respectively.  In MR_BASIC_MODE, the keys are selected by
      * the provider. */
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, shmem_internal_heap_base,
                     shmem_internal_heap_length,
-                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 1ULL, flags,
+                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0ULL, flags,
                     &shmem_transport_ofi_target_heap_mrfd, NULL);
     if (ret != 0) {
         RAISE_WARN_STR("mr_reg heap failed");


### PR DESCRIPTION
It turns out the GNI provider's memory registration
implementation has gotten pickier about adhering
to the libfabric man pages.  It rejects memory
registration requests for domains using FI_MR_BASIC
which have a non-zero input key value.

This commit lets SOS again work with the GNI provider.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>