### PR TITLE
Move CQ into the context

### DIFF
--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -90,6 +90,7 @@ typedef struct { int dummy; } * shmem_ctx_t;
 #define SHMEM_CTX_PRIVATE       (1<<0)
 #define SHMEM_CTX_SERIALIZED    (1<<1)
 #define SHMEM_CTX_NOSTORE       (1<<2)
+#define SHMEM_CTX_DEFAULT_ID   -1
 
 define(`SHPRE', `')dnl
 include(shmem_c_func.h4)dnl

--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -48,7 +48,14 @@ SHMEM_FUNCTION_ATTRIBUTES void
 shmem_ctx_destroy(shmem_ctx_t ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
-    /* TODO: Error check: ctx != SHMEM_CTX_DEFAULT */
+
+    if (ctx == SHMEM_CTX_DEFAULT) {
+        fprintf(stderr, "ERROR: %s(): SHMEM_CTX_DEFAULT cannot be destroyed\n",
+                __func__);
+        shmem_runtime_abort(100, PACKAGE_NAME " exited in error");
+    }
+
+    shmem_transport_ctx_destroy((shmem_transport_ctx_t *) ctx);
 
     return;
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1115,7 +1115,7 @@ int shmem_transport_init(void)
 
     shmem_transport_ctx_default.options = SHMEMX_CTX_BOUNCE_BUFFER;
 
-    ret = shmem_transport_ofi_ctx_init(&shmem_transport_ctx_default, -1);
+    ret = shmem_transport_ofi_ctx_init(&shmem_transport_ctx_default, SHMEM_CTX_DEFAULT_ID);
     if (ret != 0) return ret;
 
     ret = allocate_recv_cntr_mr();
@@ -1225,7 +1225,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
         SHMEM_MUTEX_UNLOCK(shmem_transport_ofi_lock);
         free(ctx);
     }
-    else if (ctx->id != -1) {
+    else if (ctx->id != SHMEM_CTX_DEFAULT_ID) {
         RAISE_ERROR_MSG("Attempted to destroy an invalid context (%s)\n", fi_strerror(errno));
     }
 }

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -33,8 +33,6 @@
 #include "shmem_internal.h"
 #include "shmem_atomic.h"
 
-extern struct fid_ep*                   shmem_transport_ofi_epfd;
-extern struct fid_cq*                   shmem_transport_ofi_put_nb_cqfd;
 #ifndef ENABLE_HARD_POLLING
 extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;
 #endif
@@ -46,7 +44,6 @@ extern uint8_t**                       shmem_transport_ofi_target_heap_addrs;
 extern uint8_t**                       shmem_transport_ofi_target_data_addrs;
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 #endif /* ENABLE_MR_SCALABLE */
-extern shmem_internal_atomic_uint64_t   shmem_transport_ofi_pending_cq_count;
 extern uint64_t                         shmem_transport_ofi_max_poll;
 extern long                             shmem_transport_ofi_put_poll_limit;
 extern long                             shmem_transport_ofi_get_poll_limit;
@@ -58,18 +55,47 @@ extern size_t                           shmem_transport_ofi_bounce_buffer_size;
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #endif
 
-#define OFI_RET_CHECK(ret)                                                      \
+#define OFI_CHECK_ERROR(ret)                                                    \
     do {                                                                        \
         if (ret) {                                                              \
-            RAISE_ERROR_MSG("OFI error #%d: %s\n", ret, fi_strerror(ret));      \
+            RAISE_ERROR_MSG("OFI error %d: %s\n", ret, fi_strerror(ret));       \
         }                                                                       \
     } while (0)
 
-#define OFI_CQ_ERROR(cq, err)                                                   \
+#define OFI_CHECK_ERROR_MSG(ret, ...)                                           \
     do {                                                                        \
-        const char *errmsg = fi_cq_strerror(cq, (err)->prov_errno,              \
-                                            (err)->err_data, NULL, 0);          \
-        RAISE_ERROR_STR(errmsg);                                                \
+        if (ret) {                                                              \
+            RAISE_ERROR_MSG(__VA_ARGS__);                                       \
+        }                                                                       \
+    } while (0)
+
+#define OFI_CHECK_RETURN_STR(ret, msg)                                          \
+    do {                                                                        \
+        if (ret) {                                                              \
+            RAISE_WARN_STR(msg);                                                \
+            return ret;                                                         \
+        }                                                                       \
+    } while (0)
+
+#define OFI_CHECK_RETURN_MSG(ret, ...)                                          \
+    do {                                                                        \
+        if (ret) {                                                              \
+            RAISE_WARN_MSG(__VA_ARGS__);                                        \
+            return ret;                                                         \
+        }                                                                       \
+    } while (0)
+
+#define OFI_CQ_ERROR(cq)                                                        \
+    do {                                                                        \
+        struct fi_cq_err_entry e = {0};                                         \
+        ssize_t ret = fi_cq_readerr(cq, (void *)&e, 0);                         \
+        if (ret == 1) {                                                         \
+            const char *errmsg = fi_cq_strerror(cq, e.prov_errno, e.err_data,   \
+                                                NULL, 0);                       \
+            RAISE_ERROR_STR(errmsg);                                            \
+        } else {                                                                \
+            RAISE_ERROR_MSG("Unknown error occurred (%zd)\n", ret);             \
+        }                                                                       \
     } while (0)
 
 #ifdef ENABLE_MR_SCALABLE
@@ -204,8 +230,11 @@ typedef int shmem_transport_ct_t;
 struct shmem_transport_ctx_t {
   long                            options;
   struct fid_ep*                  cntr_ep;
+  struct fid_ep*                  cq_ep;
   struct fid_cntr*                put_cntr;
   struct fid_cntr*                get_cntr;
+  struct fid_cq*                  cq;
+  shmem_internal_atomic_uint64_t  pending_cq_cntr;
   shmem_internal_atomic_uint64_t  pending_put_cntr;
   shmem_internal_atomic_uint64_t  pending_get_cntr;
   int id;
@@ -228,54 +257,49 @@ extern size_t SHMEM_Dtsize[FI_DATATYPE_LAST];
 static inline void shmem_transport_get_wait(shmem_transport_ctx_t* ctx);
 
 static inline
-void shmem_transport_ofi_drain_cq(void)
+void shmem_transport_ofi_drain_cq(shmem_transport_ctx_t *ctx)
 {
 
     ssize_t ret = 0;
     struct fi_cq_entry buf;
 
-    if (!shmem_internal_atomic_read(&shmem_transport_ofi_pending_cq_count)) {
+    if (0 == shmem_internal_atomic_read(&ctx->pending_cq_cntr)) {
         return;
     }
 
     do {
-        ret = fi_cq_read(shmem_transport_ofi_put_nb_cqfd,
-                         (void *)&buf, 1);
-        /* Error cases */
-        if (ret < 0 && ret != -FI_EAGAIN ) {
-            if(ret == -FI_EAVAIL) {
-                struct fi_cq_err_entry e = {0};
-                fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd,
-                              (void *)&e, 0);
-                OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
-            } else {
-                if (ret) {
-                    /* Can't call OFI_RET_CHECK because ret is ssize_t */
-                    RAISE_ERROR_MSG("OFI error #%zd: %s\n", ret, fi_strerror(ret));
-                }
-            }
-        }
+        ret = fi_cq_read(ctx->cq, (void *)&buf, 1);
 
-        if(ret == 1) {
+        if (ret == 1) {
             shmem_transport_ofi_frag_t *frag =
                 (shmem_transport_ofi_frag_t *) buf.op_context;
 
-            if(SHMEM_TRANSPORT_OFI_TYPE_BOUNCE == frag->mytype) {
-                shmem_free_list_free(
-                                     shmem_transport_ofi_bounce_buffers,
+            if (SHMEM_TRANSPORT_OFI_TYPE_BOUNCE == frag->mytype) {
+                shmem_free_list_free(shmem_transport_ofi_bounce_buffers,
                                      (shmem_transport_ofi_bounce_buffer_t *) frag);
-            }
-            else {
+            } else {
                 RAISE_ERROR_STR("Unrecognized completion object");
             }
 
-            shmem_internal_atomic_dec(&shmem_transport_ofi_pending_cq_count);
-
+            shmem_internal_atomic_dec(&ctx->pending_cq_cntr);
         }
 
+        else if (ret == -FI_EAGAIN)
+            continue;
 
-    } while(ret > 0);
+        else if (ret < 0) {
+            if (ret == -FI_EAVAIL) {
+                OFI_CQ_ERROR(ctx->cq);
+            } else {
+                RAISE_ERROR_MSG("OFI error %zd: %s\n", ret, fi_strerror(ret));
+            }
+        }
 
+        else {
+            RAISE_ERROR_MSG("fi_cq_read returned too many events (%zd)\n", ret);
+        }
+
+    } while (ret > 0);
 }
 
 static inline
@@ -302,8 +326,8 @@ static inline
 void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
 {
     /* wait until all outstanding queue operations have completed */
-    while (shmem_internal_atomic_read(&shmem_transport_ofi_pending_cq_count)) {
-        shmem_transport_ofi_drain_cq();
+    while (shmem_internal_atomic_read(&ctx->pending_cq_cntr)) {
+        shmem_transport_ofi_drain_cq(ctx);
     }
 
     /* wait for put counter to meet outstanding count value */
@@ -325,9 +349,7 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
         } else if (fail) {
-            struct fi_cq_err_entry e = {0};
-            fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
-            OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
+            OFI_CQ_ERROR(ctx->cq);
         } else {
             return;
         }
@@ -339,9 +361,7 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         int ret = fi_cntr_wait(ctx->put_cntr, cnt, -1);
         cnt_new = shmem_internal_atomic_read(&ctx->pending_put_cntr);
         if (ret) {
-            struct fi_cq_err_entry e = {0};
-            fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
-            OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
+            OFI_CQ_ERROR(ctx->cq);
         }
     } while (cnt < cnt_new);
     shmem_internal_assert(cnt == cnt_new);
@@ -372,17 +392,17 @@ int shmem_transport_fence(shmem_transport_ctx_t* ctx)
 
 /* RM requires polling until space is available */
 static inline
-int try_again(const int ret, uint64_t *polled) {
+int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
 
     if (ret) {
         if (ret == -FI_EAGAIN) {
-            shmem_transport_ofi_drain_cq();
+            shmem_transport_ofi_drain_cq(ctx);
             (*polled)++;
             if ((*polled) <= shmem_transport_ofi_max_poll) {
                 return 1;
             }
         }
-        OFI_RET_CHECK(ret);
+        OFI_CHECK_ERROR(ret);
     }
 
     return 0;
@@ -413,7 +433,7 @@ void shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const v
                               (uint64_t) addr,
                               key);
 
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 
     shmem_internal_assert(ret == 0);
     /* automatically get local completion but need remote completion for
@@ -450,7 +470,7 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
                            frag_source, frag_len, NULL,
                            GET_DEST(dst), frag_target,
                            key, NULL);
-        } while (try_again(ret,&polled));
+        } while (try_again(ctx, ret, &polled));
 
         frag_source += frag_len;
         frag_target += frag_len;
@@ -480,14 +500,14 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
         shmem_transport_ofi_bounce_buffer_t *buff = create_bounce_buffer(source, len);
         polled = 0;
 
-        shmem_internal_atomic_inc(&shmem_transport_ofi_pending_cq_count);
+        shmem_internal_atomic_inc(&ctx->pending_cq_cntr);
 
         do {
-            ret = fi_write(shmem_transport_ofi_epfd,
+            ret = fi_write(ctx->cq_ep,
                            buff->data, len, NULL,
                            GET_DEST(dst), (uint64_t) addr,
                            key, buff);
-        } while(try_again(ret,&polled));
+        } while (try_again(ctx, ret, &polled));
 
     } else {
         shmem_transport_ofi_put_large(ctx, target, source,len, pe);
@@ -545,7 +565,7 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
                           (uint64_t) addr,
                           key,
                           NULL);
-        } while (try_again(ret,&polled));
+        } while (try_again(ctx, ret, &polled));
     }
     else {
         uint8_t *frag_target = (uint8_t *) target;
@@ -564,7 +584,7 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
                               frag_target, frag_len, NULL,
                               GET_DEST(dst), frag_source,
                               key, NULL);
-            } while (try_again(ret,&polled));
+            } while (try_again(ctx, ret, &polled));
 
             frag_source += frag_len;
             frag_target += frag_len;
@@ -595,9 +615,7 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
         } else if (fail) {
-            struct fi_cq_err_entry e = {0};
-            fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
-            OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
+            OFI_CQ_ERROR(ctx->cq);
         } else {
             return;
         }
@@ -609,9 +627,7 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         int ret = fi_cntr_wait(ctx->get_cntr, cnt, -1);
         cnt_new = shmem_internal_atomic_read(&ctx->pending_get_cntr);
         if (ret) {
-            struct fi_cq_err_entry e = {0};
-            fi_cq_readerr(shmem_transport_ofi_put_nb_cqfd, (void *)&e, 0);
-            OFI_CQ_ERROR(shmem_transport_ofi_put_nb_cqfd, &e);
+            OFI_CQ_ERROR(ctx->cq);
         }
     } while (cnt < cnt_new);
     shmem_internal_assert(cnt == cnt_new);
@@ -648,7 +664,7 @@ void shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *
                               datatype,
                               FI_ATOMIC_WRITE,
                               NULL);
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 
 }
 
@@ -685,7 +701,7 @@ void shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void 
                                 datatype,
                                 FI_CSWAP,
                                 NULL);
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -721,7 +737,7 @@ void shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void 
                                 datatype,
                                 FI_MSWAP,
                                 NULL);
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -750,7 +766,7 @@ void shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, cons
                                key,
                                datatype,
                                op);
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -778,7 +794,7 @@ void shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const 
                                key,
                                datatype,
                                FI_ATOMIC_WRITE);
-    } while (try_again(ret, &polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -811,7 +827,7 @@ void shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, cons
                               datatype,
                               FI_ATOMIC_READ,
                               NULL);
-    } while (try_again(ret, &polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -830,7 +846,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
 
     shmem_internal_assert(SHMEM_Dtsize[datatype] * len == full_len);
 
-    ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op,
+    ret = fi_atomicvalid(ctx->cntr_ep, datatype, op,
                          &max_atomic_size);
     max_atomic_size = max_atomic_size * SHMEM_Dtsize[datatype];
     if (max_atomic_size > shmem_transport_ofi_max_msg_size
@@ -857,7 +873,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
                                    key,
                                    datatype,
                                    op);
-        } while(try_again(ret,&polled));
+        } while (try_again(ctx, ret, &polled));
 
     } else if (full_len <=
                MIN(shmem_transport_ofi_bounce_buffer_size, max_atomic_size) && ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
@@ -866,10 +882,10 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
 
         polled = 0;
 
-        shmem_internal_atomic_inc(&shmem_transport_ofi_pending_cq_count);
+        shmem_internal_atomic_inc(&ctx->pending_cq_cntr);
 
         do {
-            ret = fi_atomic(shmem_transport_ofi_epfd,
+            ret = fi_atomic(ctx->cq_ep,
                             buff->data,
                             len,
                             NULL,
@@ -879,7 +895,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
                             datatype,
                             op,
                             buff);
-        } while(try_again(ret,&polled));
+        } while (try_again(ctx, ret, &polled));
 
     } else {
         size_t sent = 0;
@@ -903,7 +919,7 @@ void shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const v
                                 datatype,
                                 op,
                                 NULL);
-            } while(try_again(ret,&polled));
+            } while (try_again(ctx, ret, &polled));
 
             sent += chunksize;
         }
@@ -941,7 +957,7 @@ void shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, cons
                               datatype,
                               op,
                               NULL);
-    } while(try_again(ret,&polled));
+    } while (try_again(ctx, ret, &polled));
 }
 
 
@@ -952,7 +968,8 @@ int shmem_transport_atomic_supported(shm_internal_op_t op,
                                      shm_internal_datatype_t datatype)
 {
     size_t size = 0;
-    int ret = fi_atomicvalid(shmem_transport_ofi_epfd, datatype, op, &size);
+    int ret = fi_atomicvalid(shmem_transport_ctx_default.cntr_ep,
+                             datatype, op, &size);
     return !(ret != 0 || size == 0);
 }
 
@@ -1020,7 +1037,7 @@ void shmem_transport_received_cntr_wait(uint64_t ge_val)
 #ifndef ENABLE_HARD_POLLING
     int ret = fi_cntr_wait(shmem_transport_ofi_target_cntrfd, ge_val, -1);
 
-    OFI_RET_CHECK(ret);
+    OFI_CHECK_ERROR(ret);
 #else
     RAISE_ERROR_STR("OFI transport configured for hard polling");
 #endif


### PR DESCRIPTION
Eliminate sharing of CQs across contexts; this is needed to support the FI_THREAD_COMPLETION model supported by the PSM provider.  Additional changes:

 * Destroy the default context using common destroy routine
 * Add OFI return code checking macros to clean up/simplify return code checks
 * Remove global endpoint (ofi_epfd), replace usage of this with default context CNTR endpoint
 * Clean up / rewrite CQ error event reading/reporting code (usage should be reviewed)
 * TODO: Move bounce buffer pool to context to prevent deadlock from bounce buffer exhaustion and decrease mutex granularity
 * TODO: Add global target endpoint with FI_REMOTE_READ/WRITE and remove these flags from injection-only endpoints in contexts
 * TODO: Move STX into the context to eliminate STX (PSM context) sharing overheads