### PR TITLE
Add FI_THREAD_COMPLETION support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SMA_BARRIER_ALGORITHM=auto SMA_BCAST_ALGORITHM=auto SMA_REDUCE_ALGORITHM=auto SMA_COLLECT_ALGORITHM=auto SMA_FCOLLECT_ALGORITHM=auto
-          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing"
+          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-thread-completion"
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SMA_BARRIER_ALGORITHM=linear SMA_BCAST_ALGORITHM=linear SMA_REDUCE_ALGORITHM=linear SMA_COLLECT_ALGORITHM=linear SMA_FCOLLECT_ALGORITHM=linear

--- a/README
+++ b/README
@@ -112,6 +112,9 @@ options.
         underlying network but greater than this threshold will be
         copied into a bounce buffer and then sent.
 
+    SHMEM_MAX_BOUNCE_BUFFERS (default: 128)
+        The maximum number of bounce buffers that can be created per context.
+
     SHMEM_COLL_CROSSOVER (default: 4)
         For num_pes < SHMEM_COLL_CROSSOVER, collective algorithms are
         serial instead of tree based.

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AM_CONDITIONAL([HAVE_OPENMP], [test "$enable_threads" != "no" -a "$enable_openmp
 
 AC_ARG_ENABLE([pthread-mutexes],
     [AC_HELP_STRING([--enable-pthread-mutexes],
-                    [Use pthread mutexes to support threading (used in conjunction with --enable-threads) (default:disabled)])])
+                    [Use pthread mutexes instead of spinlocks (used in conjunction with --enable-threads) (default:disabled)])])
 AS_IF([test "$enable_pthread_mutexes" = "yes"], [AC_DEFINE([ENABLE_PTHREAD_MUTEX], [1], [Enable pthread mutexes])])
 
 AC_ARG_ENABLE([remote-virtual-addressing],

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,13 @@ AC_ARG_ENABLE([pthread-mutexes],
                     [Use pthread mutexes instead of spinlocks (used in conjunction with --enable-threads) (default:disabled)])])
 AS_IF([test "$enable_pthread_mutexes" = "yes"], [AC_DEFINE([ENABLE_PTHREAD_MUTEX], [1], [Enable pthread mutexes])])
 
+AC_ARG_ENABLE([thread-completion],
+    [AC_HELP_STRING([--enable-thread-completion],
+        [Support SHMEM_THREAD_MULTIPLE using FI_THREAD_COMPLETION thread safety model instead of FI_THREAD_SAFE (default: disabled)])])
+AS_IF([test "$enable_thread_completion" = "yes"],
+      [AC_DEFINE([USE_CTX_LOCK], [1], [Enable per-context locks])
+       AC_DEFINE([USE_THREAD_COMPLETION], [1], [Support SHMEM_THREAD_MULTIPLE using FI_THREAD_COMPLETION instead of FI_THREAD_SAFE])])
+
 AC_ARG_ENABLE([remote-virtual-addressing],
     [AC_HELP_STRING([--enable-remote-virtual-addressing],
                     [Enable optimizations assuming the symmetric heap is always symmetric with regards to virtual address.  This may cause applications to abort during start_pes() if such a symmetric heap can not be created, but will reduce the instruction count for some operations.  This optimization also requires that the Portals 4 implementation support BIND_INACCESSIBLE on LEs. (default: disabled)])])

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -23,6 +23,8 @@ SHMEM_INTERNAL_ENV_DEF(SYMMETRIC_HEAP_USE_MALLOC, bool, false, SHMEM_INTERNAL_EN
                         "Allocate the symmetric heap using malloc")
 SHMEM_INTERNAL_ENV_DEF(BOUNCE_SIZE, size, DEFAULT_BOUNCE_SIZE, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum message size to bounce buffer")
+SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, long, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "Maximum number of bounce buffers per context")
 SHMEM_INTERNAL_ENV_DEF(TRAP_ON_ABORT, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Generate trap if the program aborts or calls shmem_global_exit")
 

--- a/src/shmem_free_list.c
+++ b/src/shmem_free_list.c
@@ -33,6 +33,7 @@ shmem_free_list_init(unsigned int element_size,
 
     fl->element_size = element_size;
     fl->init_fn = init_fn;
+    fl->nalloc = 0;
     SHMEM_MUTEX_INIT(fl->lock);
     ret = shmem_free_list_more(fl);
     if (0 != ret) {

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -347,7 +347,7 @@ typedef pthread_mutex_t shmem_internal_mutex_t;
 #   define SHMEM_MUTEX_INIT(_mutex)                                     \
     do {                                                                \
         if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
-            pthread_mutex_init(&_mutex, NULL); \
+            pthread_mutex_init(&_mutex, NULL);                          \
     } while (0)
 #   define SHMEM_MUTEX_DESTROY(_mutex)                                  \
     do {                                                                \

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1068,7 +1068,9 @@ int shmem_transport_init(void)
 {
     int ret = 0;
 
-    shmem_transport_ofi_info.npes      = shmem_runtime_get_size();
+    SHMEM_MUTEX_INIT(shmem_transport_ofi_lock);
+
+    shmem_transport_ofi_info.npes = shmem_runtime_get_size();
 
     if (shmem_internal_params.OFI_PROVIDER_provided)
         shmem_transport_ofi_info.prov_name = shmem_internal_params.OFI_PROVIDER;
@@ -1295,6 +1297,8 @@ int shmem_transport_fini(void)
 #endif
 
     fi_freeinfo(shmem_transport_ofi_info.fabrics);
+
+    SHMEM_MUTEX_DESTROY(shmem_transport_ofi_lock);
 
     return 0;
 }

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -238,6 +238,7 @@ struct shmem_transport_ctx_t {
   long                            options;
   struct fid_ep*                  cntr_ep;
   struct fid_ep*                  cq_ep;
+  struct fid_stx*                 stx;
   struct fid_cntr*                put_cntr;
   struct fid_cntr*                get_cntr;
   struct fid_cq*                  cq;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -72,7 +72,7 @@ extern long                             shmem_transport_ofi_max_bounce_buffers;
             if (ret == 1) {                                                     \
                 const char *errmsg = fi_cq_strerror((ctx)->cq, e.prov_errno,    \
                                                     e.err_data, NULL, 0);       \
-                RAISE_ERROR_STR(errmsg);                                        \
+                RAISE_ERROR_MSG("Error in operation: %s\n", errmsg);            \
             } else {                                                            \
                 RAISE_ERROR_MSG("Error reading from CQ (%zd)\n", ret);          \
             }                                                                   \
@@ -370,8 +370,7 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
         } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ").  Aborting.\n",
-                            fail);
+            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
         } else {
             SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
             return;
@@ -434,7 +433,7 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
                 if (ret == 1) {
                     const char *errmsg = fi_cq_strerror(ctx->cq, e.prov_errno,
                                                         e.err_data, NULL, 0);
-                    RAISE_ERROR_STR(errmsg);
+                    RAISE_ERROR_MSG("Error in operation: %s\n", errmsg);
                 } else if (ret && ret != -FI_EAGAIN) {
                     RAISE_ERROR_MSG("Error reading from CQ (%zd)\n", ret);
                 }
@@ -446,7 +445,7 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
                 return 1;
             }
             else {
-                RAISE_ERROR_MSG("Operation retry limit exceeded (%" PRIu64 ").  Aborting.\n",
+                RAISE_ERROR_MSG("Operation retry limit exceeded (%" PRIu64 ")\n",
                                 shmem_transport_ofi_max_poll);
             }
         }
@@ -672,8 +671,7 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         if (success < cnt && fail == 0) {
             SPINLOCK_BODY();
         } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ").  Aborting.\n",
-                            fail);
+            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
         } else {
             SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
             return;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -64,7 +64,7 @@ extern long                             shmem_transport_ofi_max_bounce_buffers;
         }                                                                       \
     } while (0)
 
-#define OFI_CTX_CHECK_ERROR(ctx, err)                                           \
+#define OFI_CTX_CHECK_ERROR(ctx, /* ssize_t */ err)                             \
     do {                                                                        \
         if ((err) == -FI_EAVAIL) {                                              \
             struct fi_cq_err_entry e = {0};                                     \
@@ -380,7 +380,7 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
     cnt_new = shmem_internal_atomic_read(&ctx->pending_put_cntr);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->put_cntr, cnt, -1);
+        ssize_t ret = fi_cntr_wait(ctx->put_cntr, cnt, -1);
         cnt_new = shmem_internal_atomic_read(&ctx->pending_put_cntr);
         OFI_CTX_CHECK_ERROR(ctx, ret);
     } while (cnt < cnt_new);
@@ -450,7 +450,7 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
             }
         }
         else {
-            OFI_CTX_CHECK_ERROR(ctx, ret);
+            OFI_CTX_CHECK_ERROR(ctx, (ssize_t) ret);
         }
     }
 
@@ -681,7 +681,7 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
     cnt_new = shmem_internal_atomic_read(&ctx->pending_get_cntr);
     do {
         cnt = cnt_new;
-        int ret = fi_cntr_wait(ctx->get_cntr, cnt, -1);
+        ssize_t ret = fi_cntr_wait(ctx->get_cntr, cnt, -1);
         cnt_new = shmem_internal_atomic_read(&ctx->pending_get_cntr);
         OFI_CTX_CHECK_ERROR(ctx, ret);
     } while (cnt < cnt_new);

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -317,7 +317,7 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 
     shmem_free_list_lock(ctx->bounce_buffers);
 
-    while (ctx->bounce_buffers->nalloc > shmem_transport_ofi_max_bounce_buffers) {
+    while (ctx->bounce_buffers->nalloc >= shmem_transport_ofi_max_bounce_buffers) {
         shmem_transport_ofi_drain_cq(ctx);
     }
 
@@ -426,7 +426,7 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
                 shmem_transport_ofi_drain_cq(ctx);
                 shmem_free_list_unlock(ctx->bounce_buffers);
             }
-            else if (0) {
+            else {
                 /* Poke CQ for errors to encourage progress */
                 struct fi_cq_err_entry e = {0};
                 ssize_t ret = fi_cq_readerr(ctx->cq, (void *)&e, 0);

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -371,8 +371,10 @@ shmem_transport_portals4_drain_eq(void)
     if (SHMEM_TRANSPORT_PORTALS4_TYPE_BOUNCE == frag->type) {
          /* it's a short send completing */
          SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_frag);
+         shmem_free_list_lock(shmem_transport_portals4_bounce_buffers);
          shmem_free_list_free(shmem_transport_portals4_bounce_buffers,
                               frag);
+         shmem_free_list_unlock(shmem_transport_portals4_bounce_buffers);
     } else {
          /* it's one of the long messages we're waiting for */
          shmem_transport_portals4_long_frag_t *long_frag =
@@ -382,8 +384,10 @@ shmem_transport_portals4_drain_eq(void)
          if (0 >= --long_frag->reference) {
               long_frag->reference = 0;
               SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_frag);
+              shmem_free_list_lock(shmem_transport_portals4_long_frags);
               shmem_free_list_free(shmem_transport_portals4_long_frags,
                                    frag);
+              shmem_free_list_unlock(shmem_transport_portals4_long_frags);
          } else {
               SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_frag);
          }
@@ -465,8 +469,10 @@ shmem_transport_portals4_put_nb_internal(shmem_transport_ctx_t* ctx, void *targe
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
+        shmem_free_list_lock(shmem_transport_portals4_bounce_buffers);
         buff = (shmem_transport_portals4_bounce_buffer_t*)
             shmem_free_list_alloc(shmem_transport_portals4_bounce_buffers);
+        shmem_free_list_unlock(shmem_transport_portals4_bounce_buffers);
         if (NULL == buff) RAISE_ERROR(-1);
 
         shmem_internal_assert(buff->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_BOUNCE);
@@ -505,8 +511,10 @@ shmem_transport_portals4_put_nb_internal(shmem_transport_ctx_t* ctx, void *targe
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
+        shmem_free_list_lock(shmem_transport_portals4_long_frags);
         long_frag = (shmem_transport_portals4_long_frag_t*)
             shmem_free_list_alloc(shmem_transport_portals4_long_frags);
+        shmem_free_list_unlock(shmem_transport_portals4_long_frags);
         if (NULL == long_frag) { RAISE_ERROR(-1); }
 
         shmem_internal_assert(long_frag->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_LONG);
@@ -929,8 +937,10 @@ shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *
         }
         SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_event_slots);
 
+        shmem_free_list_lock(shmem_transport_portals4_bounce_buffers);
         buff = (shmem_transport_portals4_bounce_buffer_t*)
             shmem_free_list_alloc(shmem_transport_portals4_bounce_buffers);
+        shmem_free_list_unlock(shmem_transport_portals4_bounce_buffers);
         if (NULL == buff) RAISE_ERROR(-1);
 
         shmem_internal_assert(buff->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_BOUNCE);
@@ -959,8 +969,10 @@ shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *
         ptl_size_t base_offset;
         shmem_transport_portals4_long_frag_t *long_frag;
 
+        shmem_free_list_lock(shmem_transport_portals4_long_frags);
         long_frag = (shmem_transport_portals4_long_frag_t*)
              shmem_free_list_alloc(shmem_transport_portals4_long_frags);
+        shmem_free_list_unlock(shmem_transport_portals4_long_frags);
         if (NULL == long_frag) { RAISE_ERROR(-1); }
 
         shmem_internal_assert(long_frag->frag.type == SHMEM_TRANSPORT_PORTALS4_TYPE_LONG);


### PR DESCRIPTION
* Establish upper limit on bounce buffer pool size
  * Adds SHMEM_MAX_BOUNCE_BUFFERS env var
  * Cleans up RMA operation error handling and incorrect CQ usage
  * Clean up CQ drain loop
* Move STX into the context (future work, improve STX resource usage)
* Add support for FI_THREAD_COMPLETION via --enable-thread-completion (maybe not the best name, I'm open to suggestions)