### PR TITLE
OFI: Remove get_wait from fence operation

### DIFF
--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -404,12 +404,12 @@ static inline
 int shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
-    /*unordered network model*/
-    return shmem_transport_quiet(ctx);
-#else
-    return 0;
+    /* Communication is unordered; must wait for puts and buffered (injected)
+     * non-fetching atomics to be completed in order to ensure ordering. */
+    shmem_transport_put_quiet(ctx);
 #endif
 
+    return 0;
 }
 
 


### PR DESCRIPTION
We were unnecessarily completing nonblocking gets in fence (fetching
atomics are also tracked on the counter, but are blocking and thus
cannot be pending in a call to shmem_fence).  Closes #202.

Signed-off-by: James Dinan <james.dinan@intel.com>