### PR TITLE
Eliminate locking, when possible

### DIFF
--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -346,22 +346,22 @@ typedef pthread_mutex_t shmem_internal_mutex_t;
 
 #   define SHMEM_MUTEX_INIT(_mutex)                                     \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             pthread_mutex_init(&_mutex, NULL);                          \
     } while (0)
 #   define SHMEM_MUTEX_DESTROY(_mutex)                                  \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             pthread_mutex_destroy(&_mutex);                             \
     } while (0)
 #   define SHMEM_MUTEX_LOCK(_mutex)                                     \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             pthread_mutex_lock(&_mutex);                                \
     } while (0)
 #   define SHMEM_MUTEX_UNLOCK(_mutex)                                   \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             pthread_mutex_unlock(&_mutex);                              \
     } while (0)
 
@@ -371,22 +371,22 @@ typedef shmem_spinlock_t shmem_internal_mutex_t;
 
 #   define SHMEM_MUTEX_INIT(_mutex)                                     \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             shmem_spinlock_init(&_mutex);                               \
     } while (0)
 #   define SHMEM_MUTEX_DESTROY(_mutex)                                  \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             shmem_spinlock_fini(&_mutex);                               \
     } while (0)
 #   define SHMEM_MUTEX_LOCK(_mutex)                                     \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             shmem_spinlock_lock(&_mutex);                               \
     } while (0)
 #   define SHMEM_MUTEX_UNLOCK(_mutex)                                   \
     do {                                                                \
-        if (shmem_internal_thread_level > SHMEM_THREAD_SINGLE)          \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE)       \
             shmem_spinlock_unlock(&_mutex);                             \
     } while (0)
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -257,8 +257,12 @@ extern shmem_transport_ctx_t shmem_transport_ctx_default;
 extern struct fid_ep* shmem_transport_ofi_target_ep;
 
 #ifdef USE_CTX_LOCK
-#define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx) SHMEM_MUTEX_LOCK((ctx)->lock);
-#define SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx) SHMEM_MUTEX_UNLOCK((ctx)->lock);
+#define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx)                               \
+    if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED))) \
+        SHMEM_MUTEX_LOCK((ctx)->lock);
+#define SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx)                             \
+    if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED))) \
+         SHMEM_MUTEX_UNLOCK((ctx)->lock);
 #else
 #define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx)
 #define SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx)
@@ -317,7 +321,8 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 {
     shmem_transport_ofi_bounce_buffer_t *buff;
 
-    shmem_free_list_lock(ctx->bounce_buffers);
+    if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+        shmem_free_list_lock(ctx->bounce_buffers);
 
     while (ctx->bounce_buffers->nalloc >= shmem_transport_ofi_max_bounce_buffers) {
         shmem_transport_ofi_drain_cq(ctx);
@@ -325,7 +330,8 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 
     buff = (shmem_transport_ofi_bounce_buffer_t*) shmem_free_list_alloc(ctx->bounce_buffers);
 
-    shmem_free_list_unlock(ctx->bounce_buffers);
+    if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+        shmem_free_list_unlock(ctx->bounce_buffers);
 
     if (NULL == buff)
         RAISE_ERROR_STR("Bounce buffer allocation failed");
@@ -344,13 +350,15 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
 
     /* Wait for bounce buffered operations to complete */
     if (ctx->cq_ep) {
-        shmem_free_list_lock(ctx->bounce_buffers);
+        if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+            shmem_free_list_lock(ctx->bounce_buffers);
 
         while (ctx->bounce_buffers->nalloc > 0) {
             shmem_transport_ofi_drain_cq(ctx);
         }
 
-        shmem_free_list_unlock(ctx->bounce_buffers);
+        if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+            shmem_free_list_unlock(ctx->bounce_buffers);
     }
 
     /* wait for put counter to meet outstanding count value */
@@ -424,9 +432,11 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled) {
     if (ret) {
         if (ret == -FI_EAGAIN) {
             if (ctx->cq_ep) {
-                shmem_free_list_lock(ctx->bounce_buffers);
+                if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+                    shmem_free_list_lock(ctx->bounce_buffers);
                 shmem_transport_ofi_drain_cq(ctx);
-                shmem_free_list_unlock(ctx->bounce_buffers);
+                if (!((ctx)->options & (SHMEM_CTX_PRIVATE | SHMEM_CTX_SERIALIZED)))
+                    shmem_free_list_unlock(ctx->bounce_buffers);
             }
             else {
                 /* Poke CQ for errors to encourage progress */


### PR DESCRIPTION
Eliminate locks in FUNNELED and SERIALIZED threading modes and in MULTIPLE mode when the context is PRIAVATE or SERIALIZED.