### PR TITLE
Clean up OFI contexts array

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1073,7 +1073,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     ret = bind_enable_cntr_ep_resources(ctx);
     OFI_CHECK_RETURN_MSG(ret, "context bind/enable CNTR endpoint failed (%s)\n", fi_strerror(errno));
 
-    if (ctx->options | SHMEMX_CTX_BOUNCE_BUFFER &&
+    if (ctx->options & SHMEMX_CTX_BOUNCE_BUFFER &&
         shmem_transport_ofi_bounce_buffer_size > 0 &&
         shmem_transport_ofi_max_bounce_buffers > 0)
     {


### PR DESCRIPTION
Clean up the contexts array code and stop leaking array slots when contexts are freed.