### PR TITLE
More efficient STX control/sharing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ env:
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing"
-          SHMEM_OFI_STX_MAX=8 SHMEM_OFI_STX_SHARE_ALGORITHM=random
+          SHMEM_OFI_STX_MAX=8 SHMEM_OFI_STX_ALLOCATOR=random
 os:
     - linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ before_install:
     - make install
     ## Build libfabric
     - cd $TRAVIS_SRC
-    - git clone -b v1.5.1 --depth 10 https://github.com/ofiwg/libfabric.git libfabric
+    - git clone --depth 10 https://github.com/ofiwg/libfabric.git libfabric
     - cd libfabric
     - ./autogen.sh
     - ./configure --prefix=$TRAVIS_INSTALL/libfabric

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,10 @@ env:
           SMA_FCOLLECT_ALGORITHM=ring
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing"
           SMA_OFI_TX_POLL_LIMIT=1 SMA_OFI_RX_POLL_LIMIT=1
+        - >
+          SOS_ENABLE_ERROR_TESTS=1
+          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing"
+          SHMEM_OFI_STX_MAX=8 SHMEM_OFI_STX_SHARE_ALGORITHM=random
 os:
     - linux
 

--- a/README
+++ b/README
@@ -208,7 +208,7 @@ options.
         polling (i.e. there is no polling limit).  The default behavior is to
         call fi_cntr_wait without polling.
 
-    SHMEM_OFI_STX_MAX (default: 128)
+    SHMEM_OFI_STX_MAX (default: 16)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
         After reaching the maximum, PEs share the available STXs using the
         SHMEM_OFI_STX_SHARE_HEURISTIC parameter.

--- a/README
+++ b/README
@@ -211,7 +211,8 @@ options.
     SHMEM_OFI_STX_MAX (default: 16)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
         STXs are the underlying transmit resources that are allocated to
-        OpenSHMEM contexts, according to the SHMEM_OFI_STX_ALLOCATOR parameter.
+        OpenSHMEM contexts and they are allocated using the algorithm specified
+        by the SHMEM_OFI_STX_ALLOCATOR parameter.
 
     SHMEM_OFI_STX_ALLOCATOR (default: round-robin)
         Algorithm for allocating STX resources to OpenSHMEM contexts.  In

--- a/README
+++ b/README
@@ -210,13 +210,13 @@ options.
 
     SHMEM_OFI_STX_MAX (default: 16)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
-        After reaching the maximum, PEs share the available STXs using the
-        SHMEM_OFI_STX_SHARE_ALGORITHM parameter.
+        STXs are the underlying transmit resources that are allocated to
+        OpenSHMEM contexts, according to the SHMEM_OFI_STX_ALLOCATOR parameter.
 
-    SHMEM_OFI_STX_SHARE_ALGORITHM (default: round-robin)
-        Algorithm to share the available STX contexts after reaching the value
-        of SHMEM_OFI_STX_SHARE_MAX.  The default option is round-robin, which
-        uses STXs in increasing circular order.  Options are: round-robin,
+    SHMEM_OFI_STX_ALLOCATOR (default: round-robin)
+        Algorithm for allocating STX resources to OpenSHMEM contexts.  In
+        particular, the algorithm determines how resources are shared by
+        contexts once all STXs have been allocated.  Options are: round-robin,
         random.
 
   Debugging Environment variables:

--- a/README
+++ b/README
@@ -208,6 +208,17 @@ options.
         polling (i.e. there is no polling limit).  The default behavior is to
         call fi_cntr_wait without polling.
 
+    SHMEM_OFI_STX_MAX (default: 256)
+        Sets the maximum number of sharable transmit contexts (STXs) per PE.
+        After reaching the maximum, PEs share the available STXs using the
+        SHMEM_OFI_STX_SHARE_HEURISTIC parameter.
+
+    SHMEM_OFI_STX_SHARE_ALGORITHM (default: round-robin)
+        Algorithm to share the available STX contexts after reaching the value
+        of SHMEM_OFI_STX_SHARE_MAX.  The default option is round-robin, which
+        uses STXs in increasing circular order.  Options are: round-robin,
+        random.
+
   Debugging Environment variables:
 
     SHMEM_DEBUG (default: off)

--- a/README
+++ b/README
@@ -211,7 +211,7 @@ options.
     SHMEM_OFI_STX_MAX (default: 16)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
         After reaching the maximum, PEs share the available STXs using the
-        SHMEM_OFI_STX_SHARE_HEURISTIC parameter.
+        SHMEM_OFI_STX_SHARE_ALGORITHM parameter.
 
     SHMEM_OFI_STX_SHARE_ALGORITHM (default: round-robin)
         Algorithm to share the available STX contexts after reaching the value

--- a/README
+++ b/README
@@ -208,7 +208,7 @@ options.
         polling (i.e. there is no polling limit).  The default behavior is to
         call fi_cntr_wait without polling.
 
-    SHMEM_OFI_STX_MAX (default: 256)
+    SHMEM_OFI_STX_MAX (default: 128)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
         After reaching the maximum, PEs share the available STXs using the
         SHMEM_OFI_STX_SHARE_HEURISTIC parameter.

--- a/config/check_cma.m4
+++ b/config/check_cma.m4
@@ -14,7 +14,7 @@ AC_DEFUN([CHECK_CMA], [
              AC_LANG_PUSH([C])
              AC_COMPILE_IFELSE([
                 AC_LANG_SOURCE([[#include <sys/syscall.h>]],
-                               [[int cma=__NR_process_vm_readv;]])],
+                               [[long cma=__NR_process_vm_readv;]])],
                 [cma_happy="yes"],
                 [cma_happy="no"])
              AC_LANG_POP([C])

--- a/config/check_gettid.m4
+++ b/config/check_gettid.m4
@@ -1,0 +1,15 @@
+#CHECK_GETTID([action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if SYS_gettid is available.
+AC_DEFUN([CHECK_GETTID], [
+    AC_MSG_CHECKING([gettid() syscall definitions])
+    AC_LANG_PUSH([C])
+    AC_COMPILE_IFELSE([
+       AC_LANG_SOURCE([[#include <sys/syscall.h>]],
+                      [[int tid = SYS_gettid;]])],
+       [gettid_happy="yes"],
+       [gettid_happy="no"])
+    AC_LANG_POP([C])
+    AC_MSG_RESULT([$gettid_happy])
+    AS_IF([test "$gettid_happy" = "yes"], [$1], [$2])
+])

--- a/config/check_gettid.m4
+++ b/config/check_gettid.m4
@@ -6,7 +6,7 @@ AC_DEFUN([CHECK_GETTID], [
     AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
        AC_LANG_SOURCE([[#include <sys/syscall.h>]],
-                      [[int tid = SYS_gettid;]])],
+                      [[long tid = SYS_gettid;]])],
        [gettid_happy="yes"],
        [gettid_happy="no"])
     AC_LANG_POP([C])

--- a/config/check_gettid.m4
+++ b/config/check_gettid.m4
@@ -2,10 +2,11 @@
 # --------------------------------------------------------
 # check if SYS_gettid is available.
 AC_DEFUN([CHECK_GETTID], [
-    AC_MSG_CHECKING([gettid() syscall definitions])
+    AC_MSG_CHECKING([SYS_gettid syscall definitions])
     AC_LANG_PUSH([C])
     AC_COMPILE_IFELSE([
        AC_LANG_SOURCE([[#include <sys/syscall.h>]],
+                      [[#define _GNU_SOURCE]],
                       [[long tid = SYS_gettid;]])],
        [gettid_happy="yes"],
        [gettid_happy="no"])

--- a/configure.ac
+++ b/configure.ac
@@ -108,8 +108,7 @@ AS_IF([test "$enable_threads" != "no"], [
        AC_DEFINE([ENABLE_THREADS], [1], [Enable threads])
        AC_CHECK_HEADERS([stdatomic.h])
        CHECK_GETTID(
-           [AC_DEFINE([_GNU_SOURCE], [1], [Use of syscall from libc requires _GNU_SOURCE feature macro])
-            AC_DEFINE([HAVE_SYS_GETTID], [1], [Have support for SYS_gettid syscall])],
+           [AC_DEFINE([HAVE_SYS_GETTID], [1], [Have support for SYS_gettid syscall])],
            [AC_MSG_WARN([No support for SYS_gettid syscall])])
        AS_IF([test "$enable_thread_completion" = "yes"],
              [AC_DEFINE([USE_CTX_LOCK], [1], [Enable per-context locks])

--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,8 @@ AS_IF([test "$enable_threads" != "no"], [
        AC_DEFINE([ENABLE_THREADS], [1], [Enable threads])
        AC_CHECK_HEADERS([stdatomic.h])
        CHECK_GETTID(
-           [AC_DEFINE([HAVE_SYS_GETTID], [1], [Have support for SYS_gettid syscall])],
+           [AC_DEFINE([_GNU_SOURCE], [1], [Use of syscall from libc requires _GNU_SOURCE feature macro])
+            AC_DEFINE([HAVE_SYS_GETTID], [1], [Have support for SYS_gettid syscall])],
            [AC_MSG_WARN([No support for SYS_gettid syscall])])
        AS_IF([test "$enable_thread_completion" = "yes"],
              [AC_DEFINE([USE_CTX_LOCK], [1], [Enable per-context locks])

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,9 @@ AS_IF([test "$enable_threads" != "no"], [
        fi
        AC_DEFINE([ENABLE_THREADS], [1], [Enable threads])
        AC_CHECK_HEADERS([stdatomic.h])
+       CHECK_GETTID(
+           [AC_DEFINE([HAVE_SYS_GETTID], [1], ["Have SYS_gettid"])],
+           [AC_MSG_WARN([Do not have SYS_gettid])])
        ])
 AM_CONDITIONAL([HAVE_PTHREADS], [test "$HAVE_POSIX_THREADS" = "1"])
 

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -65,7 +65,7 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Put completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
-SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 256, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 128, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of STX contexts per PE")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_SHARE_ALGORITHM, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Algorithm for sharing the STX contexts after reaching OFI_STX_MAX")

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -81,7 +81,7 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSP
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 16, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
-                       "Maximum number of STX contexts per PE")
-SHMEM_INTERNAL_ENV_DEF(OFI_STX_SHARE_ALGORITHM, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
-                       "Algorithm for sharing the STX contexts after reaching OFI_STX_MAX")
+                       "Maximum number of STX contexts")
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_ALLOCATOR, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Algorithm for allocating STX resources to contexts")
 #endif

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -65,7 +65,7 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Put completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
-SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 128, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 16, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of STX contexts per PE")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_SHARE_ALGORITHM, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Algorithm for sharing the STX contexts after reaching OFI_STX_MAX")

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -65,4 +65,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Put completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 256, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Maximum number of STX contexts per PE")
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_SHARE_ALGORITHM, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Algorithm for sharing the STX contexts after reaching OFI_STX_MAX")
 #endif

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -82,6 +82,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 16, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of STX contexts")
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_THRESHOLD, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Maximum number of shared contexts per STX before allocating a new STX resource")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_ALLOCATOR, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Algorithm for allocating STX resources to contexts")
 #endif

--- a/src/transport_cma.h
+++ b/src/transport_cma.h
@@ -16,14 +16,16 @@
 #ifndef SHMEM_TRANSPORT_CMA_H
 #define SHMEM_TRANSPORT_CMA_H
 
+#ifdef HAVE_LIBC_CMA
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
-#include <unistd.h>
-
-#ifndef HAVE_LIBC_CMA
+#endif
+#include <sys/uio.h>
+#else
 #include <sys/syscall.h>
 #endif
 
-#include <sys/uio.h>
+#include <unistd.h>
 #include <sys/types.h>
 #include <string.h>
 #include <errno.h>

--- a/src/transport_cma.h
+++ b/src/transport_cma.h
@@ -19,10 +19,7 @@
 #define _GNU_SOURCE
 #include <unistd.h>
 
-#ifdef HAVE_LIBC_CMA
-#define _GNU_SOURCE
-#include <sys/uio.h>
-#else
+#ifndef HAVE_LIBC_CMA
 #include <sys/syscall.h>
 #endif
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -341,6 +341,7 @@ typedef struct shmem_transport_ofi_stx_kvs_t shmem_transport_ofi_stx_kvs_t;
 static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
 
 
+#ifdef ENABLE_THREADS
 static inline
 void shmem_transport_ofi_stx_pool_search(shmem_transport_ctx_t *ctx)
 {
@@ -427,6 +428,7 @@ void shmem_transport_ofi_stx_pool_get_next(shmem_transport_ctx_t *ctx)
     }
     return;
 }
+#endif
 
 #define OFI_MAJOR_VERSION 1
 #ifdef ENABLE_MR_RMA_EVENT
@@ -1234,7 +1236,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         stx_start_idx = 0;
     }
 #else
-    stx_idx = 0;
+    stx_start_idx = 0;
 #endif
     ctx->stx_idx = stx_start_idx;
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -338,6 +338,19 @@ struct shmem_transport_ofi_stx_kvs_t {
 typedef struct shmem_transport_ofi_stx_kvs_t shmem_transport_ofi_stx_kvs_t;
 static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
 
+#define SHMEM_TRANSPORT_OFI_DUMP_STX()                                                          \
+    do {                                                                                        \
+        char stx_str[256];                                                                      \
+        int i, offset;                                                                          \
+                                                                                                \
+        for (i = offset = 0; i < shmem_transport_ofi_stx_max; i++)                              \
+            offset += snprintf(stx_str+offset, 256-offset,                                      \
+                               (i == shmem_transport_ofi_stx_max-1) ? "%ld%s" : "%ld%s ",       \
+                               shmem_transport_ofi_stx_pool[i].ref_cnt,                         \
+                               shmem_transport_ofi_stx_pool[i].is_private ? "P" : "S");         \
+                                                                                                \
+        DEBUG_MSG("STX[%ld] = [ %s ]\n", shmem_transport_ofi_stx_max, stx_str);                 \
+    } while (0)
 
 /* This uses a slightly modified version of the Fisher-Yates shuffle algorithm
  * (or Knuth Shuffle).  It selects a random element from the so-far
@@ -513,6 +526,8 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
         ctx->stx_idx = stx_idx;
         shmem_transport_ofi_stx_pool[ctx->stx_idx].ref_cnt++;
     }
+
+    SHMEM_TRANSPORT_OFI_DUMP_STX();
 
     return;
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1104,7 +1104,6 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     /* After reaching the STX limit, share STXs by selecting an array index
      * according to the "stx_share_algorithm". */
-    /* TODO: Use tid for more effective sharing */
     uint32_t stx_idx = 0;
 #ifdef ENABLE_THREADS
     if (shmem_internal_thread_level > SHMEM_THREAD_FUNNELED) {
@@ -1236,7 +1235,6 @@ int shmem_transport_init(void)
         shmem_transport_ofi_bounce_buffer_size = shmem_internal_params.BOUNCE_SIZE;
         shmem_transport_ofi_max_bounce_buffers = shmem_internal_params.MAX_BOUNCE_BUFFERS;
     }
-
 
     shmem_transport_ofi_put_poll_limit = shmem_internal_params.OFI_TX_POLL_LIMIT;
     shmem_transport_ofi_get_poll_limit = shmem_internal_params.OFI_RX_POLL_LIMIT;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -503,15 +503,14 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
             ctx->stx_idx = stx_idx;
             stx->ref_cnt++;
 
-            shmem_transport_ofi_stx_kvs_t *e = malloc(sizeof(shmem_transport_ofi_stx_kvs_t));
-            if (e == NULL) {
-                RAISE_ERROR_STR("out of memory when allocating STX KVS entry");
-            }
-            e->tid     = ctx->tid;
-            e->stx_idx = ctx->stx_idx;
-
             if (is_unused) {
                 stx->is_private = 1;
+                shmem_transport_ofi_stx_kvs_t *e = malloc(sizeof(shmem_transport_ofi_stx_kvs_t));
+                if (e == NULL) {
+                    RAISE_ERROR_STR("out of memory when allocating STX KVS entry");
+                }
+                e->tid     = ctx->tid;
+                e->stx_idx = ctx->stx_idx;
                 HASH_ADD_INT(shmem_transport_ofi_stx_kvs, tid, e);
             } else {
                 ctx->options &= ~SHMEM_CTX_PRIVATE;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -92,7 +92,7 @@ shmem_internal_mutex_t          shmem_transport_ofi_lock;
 #ifndef __APPLE__
 #ifdef HAVE_SYS_GETTID
 static inline
-TID_TYPE shmem_transport_ofi_gettid()
+TID_TYPE shmem_transport_ofi_gettid(void)
 {
     return syscall(SYS_gettid);
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1190,11 +1190,6 @@ int shmem_transport_init(void)
     ret = allocate_fabric_resources(&shmem_transport_ofi_info);
     if (ret != 0) return ret;
 
-    shmem_transport_ofi_avail_ctx = shmem_transport_ofi_grow_size;
-
-    shmem_transport_ofi_contexts = malloc(shmem_transport_ofi_avail_ctx
-                                          * sizeof(shmem_transport_ctx_t*));
-
     /* STX max settings */
     shmem_transport_ofi_stx_max = shmem_internal_params.OFI_STX_MAX;
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -376,7 +376,7 @@ int bind_enable_cntr_ep_resources(shmem_transport_ctx_t *ctx)
            HASH_ADD_INT(shmem_transport_ofi_stx_kvs, tid, e);
         }
 
-        free(e); free(f);
+        free(f);
     } else {
         /* Attach the shared context */
         ret = fi_ep_bind(ctx->cntr_ep, &shmem_transport_ofi_stx_pool[ctx->stx_idx].stx->fid, 0);
@@ -1373,7 +1373,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     if (ctx->options & SHMEM_CTX_PRIVATE) {
-        shmem_transport_ofi_stx_kvs_t *f = malloc(sizeof(shmem_transport_ofi_stx_kvs_t));
+        shmem_transport_ofi_stx_kvs_t *f;
         HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, f);
         if (f) {
           f->ref_cnt--;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -291,7 +291,7 @@ static stx_share_alg_t shmem_transport_ofi_stx_share_alg;
 
 static long shmem_transport_ofi_stx_max;
 
-struct shmem_transport_stx_t {
+struct shmem_transport_ofi_stx_t {
     struct fid_stx*   stx;
     long              ref_cnt;
     bool              private;   /* true if private, false if shared */
@@ -301,8 +301,8 @@ struct shmem_transport_stx_t {
     pid_t             owner_tid;
 #endif
 };
-typedef struct shmem_transport_stx_t shmem_transport_stx_t;
-static shmem_transport_stx_t* shmem_transport_ofi_stx_pool;
+typedef struct shmem_transport_ofi_stx_t shmem_transport_ofi_stx_t;
+static shmem_transport_ofi_stx_t* shmem_transport_ofi_stx_pool;
 
 
 #define OFI_MAJOR_VERSION 1
@@ -1216,7 +1216,7 @@ int shmem_transport_init(void)
 
     /* Allocate STX array with max length */
     shmem_transport_ofi_stx_pool = malloc(shmem_transport_ofi_stx_max *
-                                          sizeof(shmem_transport_stx_t));
+                                          sizeof(shmem_transport_ofi_stx_t));
 
     for (i = 0; i < shmem_transport_ofi_stx_max; i++) {
         ret = fi_stx_context(shmem_transport_ofi_domainfd, NULL,

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -95,6 +95,8 @@ static char                     myephostname[EPHOSTNAMELEN];
 #endif
 #ifdef ENABLE_THREADS
 shmem_internal_mutex_t          shmem_transport_ofi_lock;
+#endif /* ENABLE_THREADS */
+
 #ifndef __APPLE__
 #ifdef HAVE_SYS_GETTID
 /* Need a syscall to gettid() because glibc doesn't provide a wrapper
@@ -127,7 +129,6 @@ uint64_t shmem_transport_ofi_gettid(void)
     }
 }
 #endif /* APPLE */
-#endif /* ENABLE_THREADS */
 
 struct fabric_info shmem_transport_ofi_info = {0};
 
@@ -1598,7 +1599,7 @@ int shmem_transport_fini(void)
 
     for (i = 0; i < shmem_transport_ofi_stx_max; ++i) {
         if (shmem_transport_ofi_stx_pool[i].ref_cnt != 0)
-            RAISE_WARN_MSG("Closing STX %zu with nonzero ref. count (%d)\n", i,
+            RAISE_WARN_MSG("Closing STX %zu with nonzero ref. count (%ld)\n", i,
                            shmem_transport_ofi_stx_pool[i].ref_cnt);
         ret = fi_close(&shmem_transport_ofi_stx_pool[i].stx->fid);
         OFI_CHECK_ERROR_MSG(ret, "STX context close failed (%s)\n", fi_strerror(errno));

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1404,7 +1404,7 @@ int shmem_transport_init(void)
          shmem_internal_params.OFI_STX_MAX > 1) {
         if (shmem_internal_params.OFI_STX_MAX_provided) {
             /* We need only 1 STX per PE with SHMEM_THREAD_SINGLE or SHMEM_THREAD_FUNNELED */
-            RAISE_WARN_MSG("Ignoring invalid STX max setting '%ld' w/THREAD_SINGLE, using 1\n",
+            RAISE_WARN_MSG("Ignoring invalid STX max setting '%ld'; using 1 STX in single-threaded mode",
                            shmem_internal_params.OFI_STX_MAX);
         }
         shmem_transport_ofi_stx_max = 1;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -107,6 +107,8 @@ pid_t shmem_transport_ofi_gettid(void)
     return syscall(SYS_gettid);
 }
 #else
+/* Cannot query the tid with a syscall, so instead assume each tid
+ * query corresponds to a unique thread. */
 static inline
 uint64_t shmem_transport_ofi_gettid(void)
 {
@@ -121,12 +123,9 @@ uint64_t shmem_transport_ofi_gettid(void)
     int ret;
     uint64_t tid;
     ret = pthread_threadid_np(NULL, &tid);
-    if (ret == 0) {
-      return tid;
-    } else {
+    if (ret != 0)
         RAISE_ERROR_MSG("Error geting thread ID: %s\n", strerror(ret));
-        return -1;
-    }
+    return tid;
 }
 #endif /* APPLE */
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -248,7 +248,7 @@ struct shmem_transport_ctx_t {
   shmem_internal_atomic_uint64_t  pending_put_cntr;
   shmem_internal_atomic_uint64_t  pending_get_cntr;
   shmem_free_list_t              *bounce_buffers;
-  int                             stx_idx;
+  uint32_t                        stx_idx;
 };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -242,13 +242,13 @@ struct shmem_transport_ctx_t {
   long                            options;
   struct fid_ep*                  cntr_ep;
   struct fid_ep*                  cq_ep;
-  struct fid_stx*                 stx;
   struct fid_cntr*                put_cntr;
   struct fid_cntr*                get_cntr;
   struct fid_cq*                  cq;
   shmem_internal_atomic_uint64_t  pending_put_cntr;
   shmem_internal_atomic_uint64_t  pending_get_cntr;
   shmem_free_list_t              *bounce_buffers;
+  int                             stx_idx;
 };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -255,7 +255,7 @@ struct shmem_transport_ctx_t {
   shmem_internal_atomic_uint64_t  pending_put_cntr;
   shmem_internal_atomic_uint64_t  pending_get_cntr;
   shmem_free_list_t              *bounce_buffers;
-  uint32_t                        stx_idx;
+  int                             stx_idx;
   TID_TYPE                        tid;
 };
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -33,6 +33,13 @@
 #include "shmem_free_list.h"
 #include "shmem_internal.h"
 #include "shmem_atomic.h"
+#include <sys/types.h>
+
+#ifdef HAVE_SYS_GETTID
+#define _GNU_SOURCE
+#include <sys/syscall.h>
+#endif
+
 
 #ifndef ENABLE_HARD_POLLING
 extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -31,10 +31,6 @@
 #include "shmem_atomic.h"
 #include <sys/types.h>
 
-#ifdef HAVE_SYS_GETTID
-#define _GNU_SOURCE
-#include <sys/syscall.h>
-#endif
 
 
 #ifndef ENABLE_HARD_POLLING
@@ -243,7 +239,6 @@ typedef int shmem_transport_ct_t;
 #define TID_TYPE pid_t
 #endif
 
-
 struct shmem_transport_ctx_t {
     int                             id;
 #ifdef USE_CTX_LOCK
@@ -266,7 +261,6 @@ typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 extern struct fid_ep* shmem_transport_ofi_target_ep;
-
 
 #ifdef USE_CTX_LOCK
 #define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx)                                       \

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -234,6 +234,13 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 
 typedef int shmem_transport_ct_t;
 
+#ifdef __APPLE__
+#define TID_TYPE uint64_t
+#else
+#define TID_TYPE pid_t
+#endif
+
+
 struct shmem_transport_ctx_t {
   int                             id;
 #ifdef USE_CTX_LOCK
@@ -249,6 +256,7 @@ struct shmem_transport_ctx_t {
   shmem_internal_atomic_uint64_t  pending_get_cntr;
   shmem_free_list_t              *bounce_buffers;
   uint32_t                        stx_idx;
+  TID_TYPE                        tid;
 };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -256,6 +256,7 @@ extern shmem_transport_ctx_t shmem_transport_ctx_default;
 
 extern struct fid_ep* shmem_transport_ofi_target_ep;
 
+
 #ifdef USE_CTX_LOCK
 #define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx) SHMEM_MUTEX_LOCK((ctx)->lock);
 #define SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx) SHMEM_MUTEX_UNLOCK((ctx)->lock);


### PR DESCRIPTION
This is a WIP that allocates an array of STXs, with the goal of sharing them based on the thread model and OpenSHMEM context options. It introduces parameters for the maximum array size, as well as the heuristic/algorithm for sharing STXs. Infrastructure is in place for further optimization (based on tid and a private/shared context), and I would appreciate any feedback you can offer before going further. Thanks!