### PR TITLE
Revert 09f8bfad, change from data_start to etext

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -35,7 +35,7 @@
 #ifdef __APPLE__
 #include <mach-o/getsect.h>
 #else
-extern char etext;
+extern char data_start;
 extern char end;
 #endif
 
@@ -209,8 +209,8 @@ shmem_internal_init(int tl_requested, int *tl_provided)
     shmem_internal_data_base = (void*) get_etext();
     shmem_internal_data_length = get_end() - get_etext();
 #else
-    shmem_internal_data_base = &etext;
-    shmem_internal_data_length = (unsigned long) &end  - (unsigned long) &etext;
+    shmem_internal_data_base = &data_start;
+    shmem_internal_data_length = (unsigned long) &end  - (unsigned long) &data_start;
 #endif
 
     /* create symmetric heap */


### PR DESCRIPTION
Can't use etext, since it may be within read-only text pages.  Can't use
data_start because it breaks library interposition.  Reverting to
data_start until we figure out a solution that works for both.

Closes #555 

Signed-off-by: James Dinan <james.dinan@intel.com>