### PR TITLE
Configury: Update data segment check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -600,7 +600,12 @@ extern int __data_start;
 extern int _end;
 #endif
 
-int data;
+/* Ensure data segment is not empty.  Anything simpler gets optimized
+ * away by the compiler. */
+int ensure_nonempty_data(void) {
+    static int ncall = 0;
+    return ncall++;
+}
 
 int main(void) {
     void *base;


### PR DESCRIPTION
GCC 7 was optimizing away the entries in the configury data segment
check, causing the non-empty check to fail.  Update data segment check
to include a static variable in a function to prevent this from
happening.

Signed-off-by: James Dinan <james.dinan@intel.com>