### PR TITLE
Destroy context upon failure

### DIFF
--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -37,11 +37,11 @@ shmem_ctx_create(long options, shmem_ctx_t *ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_transport_ctx_create(options, (shmem_transport_ctx_t **) ctx);
+    int ret = shmem_transport_ctx_create(options, (shmem_transport_ctx_t **) ctx);
 
     SHMEM_ERR_CHECK_NULL(ctx, 0);
 
-    return 0;
+    return ret;
 }
 
 

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -81,11 +81,11 @@ shmem_transport_fini(void)
 }
 
 static inline
-void
+int
 shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
 {
     *ctx = NULL;
-    return;
+    return 0;
 }
 
 static inline

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1044,8 +1044,14 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 #ifdef USE_CTX_LOCK
     SHMEM_MUTEX_INIT(ctx->lock);
 #endif
-    shmem_internal_atomic_write(&ctx->pending_put_cntr, 0);
-    shmem_internal_atomic_write(&ctx->pending_get_cntr, 0);
+    ctx->cntr_ep = NULL;
+    ctx->cq_ep = NULL;
+    ctx->stx = NULL;
+    ctx->put_cntr = NULL;
+    ctx->get_cntr = NULL;
+    ctx->cq = NULL;
+    ctx->pending_put_cntr =  0;
+    ctx->pending_get_cntr = 0;
 
     ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_put_attr,
                        &ctx->put_cntr, NULL);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1056,6 +1056,9 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     OFI_CHECK_RETURN_MSG(ret, "get_cntr creation failed (%s)\n", fi_strerror(errno));
 
     ret = fi_cq_open(shmem_transport_ofi_domainfd, &cq_attr, &ctx->cq, NULL);
+    if (ret && errno == FI_EMFILE) {
+        DEBUG_STR("Consider increasing the open file limit with 'ulimit' command");
+    }
     OFI_CHECK_RETURN_MSG(ret, "cq_open failed (%s)\n", fi_strerror(errno));
 
     /* TODO: STX contexts should be shared by SHMEM contexts that are private
@@ -1189,11 +1192,6 @@ int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
     int ret;
     int id;
 
-    /* FIXME: Context creation does not do resource cleanup on error, it just
-     * returns. This is consistent with how initialization worked before, but
-     * is worse since context creation is not necessarily do-or-die.
-     */
-
     /* Look for an open slot in the contexts array */
     for (id = 0; id < shmem_transport_ofi_contexts_len; id++)
         if (shmem_transport_ofi_contexts[id] == NULL) break;
@@ -1226,8 +1224,7 @@ int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
     ret = shmem_transport_ofi_ctx_init(ctxp, id);
 
     if (ret) {
-        shmem_transport_ofi_contexts[id] = NULL;
-        free(ctxp);
+        shmem_transport_ctx_destroy(ctxp);
     } else {
         shmem_transport_ofi_contexts[id] = ctxp;
         *ctx = ctxp;
@@ -1242,8 +1239,10 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 {
     int ret;
 
-    ret = fi_close(&ctx->cntr_ep->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Context CNTR endpoint close failed (%s)\n", fi_strerror(errno));
+    if (ctx->cntr_ep) {
+        ret = fi_close(&ctx->cntr_ep->fid);
+        OFI_CHECK_ERROR_MSG(ret, "Context CNTR endpoint close failed (%s)\n", fi_strerror(errno));
+    }
 
     if (ctx->cq_ep) {
         ret = fi_close(&ctx->cq_ep->fid);
@@ -1252,17 +1251,25 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
         shmem_free_list_destroy(ctx->bounce_buffers);
     }
 
-    ret = fi_close(&ctx->stx->fid);
-    OFI_CHECK_ERROR_MSG(ret, "STX context close failed (%s)\n", fi_strerror(errno));
+    if (ctx->stx) {
+        ret = fi_close(&ctx->stx->fid);
+        OFI_CHECK_ERROR_MSG(ret, "STX context close failed (%s)\n", fi_strerror(errno));
+    }
 
-    ret = fi_close(&ctx->put_cntr->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
+    if (ctx->put_cntr) {
+        ret = fi_close(&ctx->put_cntr->fid);
+        OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
+    }
 
-    ret = fi_close(&ctx->get_cntr->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
+    if (ctx->get_cntr) {
+        ret = fi_close(&ctx->get_cntr->fid);
+        OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
+    }
 
-    ret = fi_close(&ctx->cq->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
+    if (ctx->cq) {
+        ret = fi_close(&ctx->cq->fid);
+        OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
+    }
 
 #ifdef USE_CTX_LOCK
     SHMEM_MUTEX_DESTROY(ctx->lock);

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -129,9 +129,9 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 shmem_transport_ctx_t shmem_transport_ctx_default;
 shmem_ctx_t SHMEM_CTX_DEFAULT = (shmem_ctx_t) &shmem_transport_ctx_default;
 
-void shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx) {
+int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx) {
   *ctx = NULL;
-  return;
+  return 0;
 }
 
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx) {

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -163,7 +163,7 @@ struct shmem_transport_ctx_t { int dummy; };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
 extern shmem_transport_ctx_t shmem_transport_ctx_default;
-void shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx);
+int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
 /*

--- a/test/unit/many-ctx.c
+++ b/test/unit/many-ctx.c
@@ -59,7 +59,7 @@ int main(int argc, char **argv) {
         if (err) {
             printf("%d: Unable to create context #%d (%d)\n", me, max_num_ctx, err);
             /* Need to free up some resources to avoid the open file limit: */
-            for (i=1; i<npes; i++) {
+            for (i=1; i<=npes; i++) {
                 shmem_ctx_destroy(ctx[max_num_ctx-i]);
             }
             break;
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
 
     /* Destroy ~1/2 the contexts to free up resources for the atomics below: */
     new_max = min_num_ctx / 2;
-    for (i=max_num_ctx-npes; i>new_max; i--) {
+    for (i=max_num_ctx-npes-1; i>new_max; i--) {
         shmem_ctx_destroy(ctx[i]);
     }
 
@@ -88,6 +88,8 @@ int main(int argc, char **argv) {
     if (data != new_max) {
         printf("%d: error expected %d, got %ld\n", me, new_max, data);
         ++errors;
+    } else {
+        printf("PE:%d success!\n", me);
     }
 
     shmem_finalize();

--- a/test/unit/many-ctx.c
+++ b/test/unit/many-ctx.c
@@ -29,39 +29,64 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define NUM_CTX 32
+#define UPPER_LIMIT_NUM_CTX 1024
+
+#define MAX(a,b) ((a)>(b))?(b):(a)
+#define WRK_SIZE MAX(2, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
 
 long data = 0;
+int min_num_ctx = 0;
+int max_num_ctx = 0;
+
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
+int pWrk[WRK_SIZE];
 
 int main(int argc, char **argv) {
     int me, npes, i;
     int errors = 0;
-    shmem_ctx_t ctx[NUM_CTX];
+    shmem_ctx_t ctx[UPPER_LIMIT_NUM_CTX];
+
+    int new_max = 0;
 
     shmem_init();
 
     me = shmem_my_pe();
     npes = shmem_n_pes();
 
-    for (i = 0; i < NUM_CTX; i++) {
-        int err = shmem_ctx_create(0, &ctx[i]);
-
+    /* Create as many contexts as possible until a failure occurs: */
+    while (max_num_ctx < UPPER_LIMIT_NUM_CTX) {
+        int err = shmem_ctx_create(0, &ctx[max_num_ctx]);
         if (err) {
-            printf("%d: Error creating context %d (%d)\n", me, i, err);
-            shmem_global_exit(1);
+            printf("%d: Unable to create context #%d (%d)\n", me, max_num_ctx, err);
+            /* Need to free up some resources to avoid the open file limit: */
+            for (i=1; i<npes; i++) {
+                shmem_ctx_destroy(ctx[max_num_ctx-i]);
+            }
+            break;
+        } else {
+            max_num_ctx++;
         }
     }
 
-    for (i = 0; i < NUM_CTX; i++)
+    /* Some processes might have failed earlier than others - find minimum: */
+    shmem_int_min_to_all(&min_num_ctx, &max_num_ctx, 1, 0, 0, npes, pWrk, pSync);
+
+    /* Destroy ~1/2 the contexts to free up resources for the atomics below: */
+    new_max = min_num_ctx / 2;
+    for (i=max_num_ctx-npes; i>new_max; i--) {
+        shmem_ctx_destroy(ctx[i]);
+    }
+
+    for (i = 0; i < new_max; i++)
         shmem_ctx_long_atomic_inc(ctx[i], &data, (me+1) % npes);
 
-    for (i = 0; i < NUM_CTX; i++)
+    for (i = 0; i < new_max; i++)
         shmem_ctx_quiet(ctx[i]);
 
     shmem_sync_all();
 
-    if (data != NUM_CTX) {
-        printf("%d: error expected %d, got %ld\n", me, NUM_CTX, data);
+    if (data != new_max) {
+        printf("%d: error expected %d, got %ld\n", me, new_max, data);
         ++errors;
     }
 


### PR DESCRIPTION
This adds the return value to `shmem_ctx_create`, and calls `shmem_transport_ctx_destroy` if a non-zero return value is encountered during the OFI initializations.

The `many-ctx` unit test attempts to initialize as many contexts as possible.  When it does, it destroys some contexts, freeing enough resources to recover for some tests of the atomics (this is needed for the sockets provider, at least).

Note: the `many-ctx` test seems to work fine in Linux, but I've just noticed a seg. fault in OSX that I'm investigating now...