### PR TITLE
Fix several communication/tracking completion races in Portals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ v1.4.0rc2
   and SHMEM_OFI_STX_THRESHOLD.  See README for details.
 - Added support for returning gracefully when context creation is unsuccessful.
 - Updated data segment exposure method to improve compatibility with tools.
+- Updated thread safety support in Portals, eliminating several possible races
+  in communication tracking/completion code.
 
 v1.4.0rc1
 ---------

--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -158,6 +158,8 @@ shmem_internal_membar_store(void) {
 
 #    if (defined(__STDC_NO_ATOMICS__) || !defined(HAVE_STDATOMIC_H))
 
+#include <stdint.h>
+
 typedef uint64_t shmem_internal_atomic_uint64_t;
 
 static inline

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -23,6 +23,8 @@
 #include <inttypes.h>
 
 #include "shmem_free_list.h"
+#include "shmem_internal.h"
+#include "shmem_atomic.h"
 
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))

--- a/test/unit/shmem_ctx.c
+++ b/test/unit/shmem_ctx.c
@@ -92,6 +92,9 @@ int main(void) {
     shmem_long_sum_to_all(&total_done, &tasks_done, 1, 0, 0, npes, pwrk, psync);
 
     int result = (total_done != ntasks * npes);
+    if (me == 0 && result)
+        printf("Error: total_done is %ld, expected %ld\n", total_done, ntasks * npes);
+
     shmem_finalize();
     return result;
 }


### PR DESCRIPTION
Fix several communication tracking/completion races in ```SHMEM_THREAD_MULTIPLE``` mode in the Portals transport.