### PR TITLE
Pr/gettid register

### DIFF
--- a/mpp/shmemx_c_func.h4.in
+++ b/mpp/shmemx_c_func.h4.in
@@ -6,6 +6,8 @@ dnl information, see the LICENSE file in the top level directory of the
 dnl distribution.
 dnl
 
+#include <inttypes.h>
+
 #ifndef SHMEM_FUNCTION_ATTRIBUTES
 #  if OPAL_C_HAVE_VISIBILITY == 1
 #     define SHMEM_FUNCTION_ATTRIBUTES __attribute__((visibility("default")))
@@ -26,3 +28,5 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_ct_set(shmemx_ct_t ct, long value);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_ct_wait(shmemx_ct_t ct, long wait_for);
 
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcontrol(int level, ...);
+
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_register_gettid(uint64_t (*gettid_fn)(void));

--- a/src/init.c
+++ b/src/init.c
@@ -378,3 +378,12 @@ shmem_internal_global_exit(int status)
     shmem_internal_global_exit_called = 1;
     shmem_runtime_abort(status, str);
 }
+
+uint64_t (*shmem_internal_gettid_fn)(void);
+int shmem_internal_gettid_registered = 0;
+
+void shmem_internal_register_gettid(uint64_t (*gettid_fn)(void))
+{
+    shmem_internal_gettid_fn = gettid_fn;
+    shmem_internal_gettid_registered = 1;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -380,10 +380,10 @@ shmem_internal_global_exit(int status)
 }
 
 uint64_t (*shmem_internal_gettid_fn)(void);
-int shmem_internal_gettid_registered = 0;
+int shmem_internal_gettid_is_registered = 0;
 
 void shmem_internal_register_gettid(uint64_t (*gettid_fn)(void))
 {
     shmem_internal_gettid_fn = gettid_fn;
-    shmem_internal_gettid_registered = 1;
+    shmem_internal_gettid_is_registered = 1;
 }

--- a/src/init_c.c
+++ b/src/init_c.c
@@ -45,6 +45,9 @@
 #pragma weak shmem_info_get_name = pshmem_info_get_name
 #define shmem_info_get_name pshmem_info_get_name
 
+#pragma weak shmemx_register_gettid = pshmemx_register_gettid
+#define shmemx_register_gettid pshmemx_register_gettid
+
 #endif /* ENABLE_PROFILING */
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -127,4 +130,11 @@ shmem_info_get_name(char *name)
 
     strncpy(name, SHMEM_VENDOR_STRING, SHMEM_MAX_NAME_LEN);
     name[SHMEM_MAX_NAME_LEN-1] = '\0'; /* Ensure string is null terminated */
+}
+
+void SHMEM_FUNCTION_ATTRIBUTES
+shmemx_register_gettid(uint64_t (*gettid_fn)(void))
+{
+    shmem_internal_register_gettid(gettid_fn);
+    return;
 }

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -439,4 +439,9 @@ char *shmem_util_wrap(const char *str, const size_t wraplen, const char *indent)
 #define MAX(A,B) (A) > (B) ? (A) : (B)
 #endif
 
+extern uint64_t (*shmem_internal_gettid_fn)(void);
+extern int shmem_internal_gettid_registered;
+
+extern void shmem_internal_register_gettid(uint64_t (*gettid_fn)(void));
+
 #endif

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -440,7 +440,7 @@ char *shmem_util_wrap(const char *str, const size_t wraplen, const char *indent)
 #endif
 
 extern uint64_t (*shmem_internal_gettid_fn)(void);
-extern int shmem_internal_gettid_registered;
+extern int shmem_internal_gettid_is_registered;
 
 extern void shmem_internal_register_gettid(uint64_t (*gettid_fn)(void));
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -103,17 +103,17 @@ shmem_internal_mutex_t          shmem_transport_ofi_lock;
 /* Need a syscall to gettid() because glibc doesn't provide a wrapper
  * (see gettid manpage in the NOTES section): */
 static inline
-pid_t shmem_transport_ofi_gettid(void)
+struct shmem_internal_tid shmem_transport_ofi_gettid(void)
 {
     struct shmem_internal_tid tid;
 
     if (shmem_internal_gettid_registered) {
         tid.tid_t = UINT64_T;
-        tid.shmem_internal_uint64_t = (*shmem_internal_gettid_fn)();
+        tid.uint64_val = (*shmem_internal_gettid_fn)();
         return tid;
     } else {
         tid.tid_t = PID_T;
-        tid.shmem_internal_pid_t = syscall(SYS_gettid);
+        tid.pid_val = syscall(SYS_gettid);
         return tid;
     }
 }
@@ -127,12 +127,12 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
     tid.tid_t = UINT64_T;
 
     if (shmem_internal_gettid_registered) {
-        tid.shmem_internal_uint64_t = (*shmem_internal_gettid_fn)();
+        tid.uint64_val = (*shmem_internal_gettid_fn)();
         return tid;
     } else {
         static uint64_t tid_val = 0;
         tid_val++;
-        tid.shmem_internal_uint64_t = tid_val;
+        tid.uint64_val = tid_val;
         return tid;
     }
 }
@@ -145,11 +145,11 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
     tid.tid_t = UINT64_T;
 
     if (shmem_internal_gettid_registered) {
-        tid.shmem_internal_uint64_t = (*shmem_internal_gettid_fn)();
+        tid.uint64_val = (*shmem_internal_gettid_fn)();
         return tid;
     } else {
         int ret;
-        ret = pthread_threadid_np(NULL, &tid.shmem_internal_uint64_t);
+        ret = pthread_threadid_np(NULL, &tid.uint64_val);
         if (ret != 0)
             RAISE_ERROR_MSG("Error getting thread ID: %s\n", strerror(ret));
         return tid;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -233,11 +233,16 @@ typedef struct shmem_transport_ofi_bounce_buffer_t shmem_transport_ofi_bounce_bu
 
 typedef int shmem_transport_ct_t;
 
-#ifdef __APPLE__
-#define TID_TYPE uint64_t
-#else
-#define TID_TYPE pid_t
-#endif
+enum shmem_internal_tid_t { PID_T, UINT64_T };
+struct shmem_internal_tid
+{
+  enum shmem_internal_tid_t tid_t;
+  union
+  {
+    pid_t shmem_internal_pid_t;
+    uint64_t shmem_internal_uint64_t;
+  };
+};
 
 struct shmem_transport_ctx_t {
     int                             id;
@@ -260,7 +265,7 @@ struct shmem_transport_ctx_t {
 #endif
     shmem_free_list_t              *bounce_buffers;
     int                             stx_idx;
-    TID_TYPE                        tid;
+    struct shmem_internal_tid       tid;
 };
 
 typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -239,8 +239,8 @@ struct shmem_internal_tid
   enum shmem_internal_tid_t tid_t;
   union
   {
-    pid_t shmem_internal_pid_t;
-    uint64_t shmem_internal_uint64_t;
+    pid_t pid_val;
+    uint64_t uint64_val;
   };
 };
 

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -145,6 +145,7 @@ if HAVE_PTHREADS
 check_PROGRAMS += \
     mt_a2a \
     mt_contention \
+    gettid_register \
     threading \
     web \
     thread_wait

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -183,6 +183,10 @@ mt_contention_LDFLAGS = $(PTHREAD_LIBS)
 mt_contention_CFLAGS = -I$(top_srcdir)/test/unit $(PTHREAD_CFLAGS)
 mt_contention_LDADD = $(LDADD) $(PTHREAD_CFLAGS)
 
+gettid_register_LDFLAGS = $(PTHREAD_LIBS)
+gettid_register_CFLAGS = -I$(top_srcdir)/test/unit $(PTHREAD_CFLAGS)
+gettid_register_LDADD = $(LDADD) $(PTHREAD_CFLAGS)
+
 threading_LDFLAGS = $(PTHREAD_LIBS)
 threading_CFLAGS = -I$(top_srcdir)/test/unit $(PTHREAD_CFLAGS)
 threading_LDADD = $(LDADD) $(PTHREAD_CFLAGS)

--- a/test/unit/gettid_register.c
+++ b/test/unit/gettid_register.c
@@ -1,0 +1,118 @@
+/*
+ *  Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* Multithreaded Contention Test: Overlapping AMO/quiet on a shared (default)
+ * context */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <pthread.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+#define T 8
+
+int dest;
+
+int me, npes;
+int errors = 0;
+
+
+uint64_t my_gettid(void) {
+    static uint64_t tid_val = 100;
+    return tid_val++;
+}
+
+
+static void * thread_main(void *arg) {
+    int tid = * (int *) arg;
+    int i;
+
+    shmem_ctx_t ctx;
+    int ret = shmem_ctx_create(SHMEM_CTX_PRIVATE, &ctx);
+
+    for (i = 1; i <= npes; i++)
+        shmem_ctx_int_atomic_add(ctx, &dest, tid, (me + i) % npes);
+
+    shmem_quiet();
+
+    shmem_ctx_destroy(ctx);
+
+    return NULL;
+}
+
+
+int main(int argc, char **argv) {
+    int tl, i, ret;
+    pthread_t threads[T];
+    int       t_arg[T];
+
+    shmemx_register_gettid( &my_gettid );
+
+    ret = shmem_init_thread(SHMEM_THREAD_MULTIPLE, &tl);
+
+    if (tl != SHMEM_THREAD_MULTIPLE || ret != 0) {
+        printf("Init failed (requested thread level %d, got %d, ret %d)\n",
+               SHMEM_THREAD_MULTIPLE, tl, ret);
+
+        if (ret == 0) {
+            shmem_global_exit(1);
+        } else {
+            return ret;
+        }
+    }
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+
+    if (me == 0) printf("Starting multithreaded test on %d PEs, %d threads/PE\n", npes, T);
+
+    for (i = 0; i < T; i++) {
+        int err;
+        t_arg[i] = i;
+        err = pthread_create(&threads[i], NULL, thread_main, (void*) &t_arg[i]);
+        assert(0 == err);
+    }
+
+    for (i = 0; i < T; i++) {
+        int err;
+        err = pthread_join(threads[i], NULL);
+        assert(0 == err);
+    }
+
+    shmem_sync_all();
+
+    if (dest != ((T-1)*T/2)*npes) {
+        printf("%d: dest = %d, expected %d\n", me, dest, ((T-1)*T/2)*npes);
+        errors++;
+    }
+
+    shmem_finalize();
+    return (errors == 0) ? 0 : 1;
+}

--- a/test/unit/gettid_register.c
+++ b/test/unit/gettid_register.c
@@ -25,8 +25,7 @@
  * SOFTWARE.
  */
 
-/* Multithreaded Contention Test: Overlapping AMO/quiet on a shared (default)
- * context */
+/* Gettid Register Test: Register a custom gettid function pointer  */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -55,6 +54,10 @@ static void * thread_main(void *arg) {
 
     shmem_ctx_t ctx;
     int ret = shmem_ctx_create(SHMEM_CTX_PRIVATE, &ctx);
+    if (ret != 0) {
+        printf("Error creating context (%d)\n", ret);
+        shmem_global_exit(2);
+    }
 
     for (i = 1; i <= npes; i++)
         shmem_ctx_int_atomic_add(ctx, &dest, tid, (me + i) % npes);


### PR DESCRIPTION
Addresses issue #578:

* Adds the `shmemx_register_gettid()` function, which allows user to pass a function pointer for setting thread IDs.
* Removes the `TID_T` definition in favor of the `shmem_internal_pid_t` structure, which currently supports either `pid_t` (from gettid syscall) or `uint64_t` TID values.
* Adds a simple unit test, `gettid_register` as a smoke test for creating/using private contexts with a custom gettid routine.