### PR TITLE
Use DEFAULT_POLL_LIMIT in shmem_env_defs.h

### DIFF
--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -13,6 +13,10 @@
  *
  */
 
+/* This header depends on 'config.h', which cannot be included here. Please
+ * include 'config.h' before including this file, 'shmem_env_defs.h'
+ */
+
 /* SOS_ENV( name, kind, default, category, short description )
  *
  * Kinds: long, size, bool, string

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -76,9 +76,9 @@ SHMEM_INTERNAL_ENV_DEF(OFI_FABRIC, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Fabric that should be used by the OFI transport")
 SHMEM_INTERNAL_ENV_DEF(OFI_DOMAIN, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Fabric domain that should be used by the OFI transport")
-SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Put completion poll limit")
-SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 16, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of STX contexts")


### PR DESCRIPTION
This must have been an oversight when breaking apart the TX and RX poll limits.  We need to set the poll limit value to either 0 or -1, depending on whether the user passes `--enable-completion-polling` or not.
  
Signed-off-by: David M. Ozog <david.m.ozog@intel.com>