### PR TITLE
Add name to internal tid_t union for non-c11

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -107,12 +107,12 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
 
     if (shmem_internal_gettid_fn) {
         tid.tid_t = tid_is_uint64_t;
-        tid.uint64_val = (*shmem_internal_gettid_fn)();
+        tid.val.uint64_val = (*shmem_internal_gettid_fn)();
     } else {
 #ifndef __APPLE__
 #ifdef HAVE_SYS_GETTID
         tid.tid_t = tid_is_pid_t;
-        tid.pid_val = syscall(SYS_gettid);
+        tid.val.pid_val = syscall(SYS_gettid);
 #else
         /* Cannot query the tid with a syscall, so instead assume each tid
          * query corresponds to a unique thread. */
@@ -123,7 +123,7 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
             tid_cnt_start = 1;
         else
             tid_val++;
-        tid.uint64_val = tid_val;
+        tid.val.uint64_val = tid_val;
 #endif /* HAVE_SYS_GETTID */
 #else
         tid.tid_t = tid_is_uint64_t;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -241,7 +241,7 @@ struct shmem_internal_tid
     {
         pid_t pid_val;
         uint64_t uint64_val;
-    };
+    } val;
 };
 
 struct shmem_transport_ctx_t {


### PR DESCRIPTION
Non C11 compilers do not allow unnamed union fields (as exposed with `-pedantic`).  I've added the name `val` for the TID value within the `shmem_internal_tid` struct.