### PR TITLE
Fix missing ".val" & add static to my_gettid test

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -128,7 +128,7 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
 #else
         tid.tid_t = tid_is_uint64_t;
         int ret;
-        ret = pthread_threadid_np(NULL, &tid.uint64_val);
+        ret = pthread_threadid_np(NULL, &tid.val.uint64_val);
         if (ret != 0)
             RAISE_ERROR_MSG("Error getting thread ID: %s\n", strerror(ret));
 #endif /* APPLE */

--- a/test/unit/gettid_register.c
+++ b/test/unit/gettid_register.c
@@ -43,7 +43,7 @@ int errors = 0;
 
 pthread_key_t key;
 
-uint64_t my_gettid(void) {
+static uint64_t my_gettid(void) {
     uint64_t tid_val = 0;
 
     tid_val = * (uint64_t*) pthread_getspecific(key);


### PR DESCRIPTION
Signed-off-by: David M. Ozog <david.m.ozog@intel.com>