### PR TITLE
Reduce OFI_STX_MAX default value to 1 (for PSM2)

### DIFF
--- a/README
+++ b/README
@@ -212,7 +212,7 @@ options.
         polling (i.e. there is no polling limit).  The default behavior is to
         call fi_cntr_wait without polling.
 
-    SHMEM_OFI_STX_MAX (default: 16)
+    SHMEM_OFI_STX_MAX (default: 1)
         Sets the maximum number of sharable transmit contexts (STXs) per PE.
         STXs are the underlying transmit resources that are allocated to
         OpenSHMEM contexts and they are allocated using the algorithm specified

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -88,7 +88,7 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERN
                        "Put completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
-SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 16, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of STX contexts")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_THRESHOLD, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum number of shared contexts per STX before allocating a new STX resource")


### PR DESCRIPTION
Set the default value of `SHMEM_OFI_STX_MAX` to 1 instead of 16 so that users do not have to worry about saturating HFI contexts sooner than expected on the PSM2 provider.