### PR TITLE
Add probe routine for making manual progress

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,11 @@ AS_IF([test "$enable_completion_polling" = "yes"],
        AC_DEFINE([DEFAULT_POLL_LIMIT], [-1], [Poll limit for local/remote completions])],
       [AC_DEFINE([DEFAULT_POLL_LIMIT], [0], [Poll limit for local/remote completions])])
 
+AC_ARG_ENABLE([manual-progress],
+    [AC_HELP_STRING([--enable-manual-progress],
+                    [Enable intermittent progress calls inside transport layer (default:disabled)])])
+AS_IF([test "$enable_manual_progress" = "yes"], [AC_DEFINE([ENABLE_MANUAL_PROGRESS], [1], [Enable manual progress])])
+
 AC_ARG_ENABLE([nonblocking-fence],
     [AC_HELP_STRING([--enable-nonblocking-fence],
                     [When total data ordering is not available, make shmem_fence a non-blocking operation.  shmem_fence will return immediately, but the next communication call will block until all previous communications finish. (default:disabled)])])

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -75,7 +75,9 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_WAIT_POLL(var, value)                      \
     do {                                                 \
-        while (*(var) == value) { SPINLOCK_BODY(); }     \
+        while (*(var) == value) {                        \
+            shmem_transport_probe();                     \
+            SPINLOCK_BODY(); }                           \
     } while(0)
 
 #define SHMEM_WAIT_UNTIL_POLL(var, cond, value)          \
@@ -84,6 +86,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
                                                          \
         COMP(cond, *(var), value, cmpret);               \
         while (!cmpret) {                                \
+            shmem_transport_probe();                     \
             SPINLOCK_BODY();                             \
             COMP(cond, *(var), value, cmpret);           \
         }                                                \

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -81,6 +81,13 @@ shmem_transport_fini(void)
 }
 
 static inline
+void
+shmem_transport_probe(void)
+{
+    return;
+};
+
+static inline
 int
 shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
 {

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -96,6 +96,7 @@ static char                     myephostname[EPHOSTNAMELEN];
 #endif
 #ifdef ENABLE_THREADS
 shmem_internal_mutex_t          shmem_transport_ofi_lock;
+pthread_mutex_t                 shmem_transport_ofi_progress_lock = PTHREAD_MUTEX_INITIALIZER;
 #endif /* ENABLE_THREADS */
 
 /* Need a syscall to gettid() because glibc doesn't provide a wrapper

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -58,7 +58,7 @@ struct fid_fabric*              shmem_transport_ofi_fabfd;
 struct fid_domain*              shmem_transport_ofi_domainfd;
 struct fid_av*                  shmem_transport_ofi_avfd;
 struct fid_ep*                  shmem_transport_ofi_target_ep;
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
 struct fid_cntr*                shmem_transport_ofi_target_cntrfd;
 #endif
 #ifdef ENABLE_MR_SCALABLE
@@ -629,7 +629,7 @@ int allocate_recv_cntr_mr(void)
      * incoming reads/writes and outgoing non-blocking Puts, specifying entire
      * VA range */
 
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
     {
         struct fi_cntr_attr cntr_attr = {0};
 
@@ -655,7 +655,7 @@ int allocate_recv_cntr_mr(void)
     OFI_CHECK_RETURN_STR(ret, "target memory (all) registration failed");
 
     /* Bind counter with target memory region for incoming messages */
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
     ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
                      &shmem_transport_ofi_target_cntrfd->fid,
                      FI_REMOTE_WRITE | FI_REMOTE_READ);
@@ -671,7 +671,7 @@ int allocate_recv_cntr_mr(void)
         OFI_CHECK_RETURN_STR(ret, "target MR enable failed");
     }
 #endif /* ENABLE_MR_RMA_EVENT */
-#endif /* ndef ENABLE_HARD_POLLING */
+#endif /* ENABLE_TARGET_CNTR */
 
 #else
     /* Register separate data and heap segments using keys 0 and 1,
@@ -690,7 +690,7 @@ int allocate_recv_cntr_mr(void)
     OFI_CHECK_RETURN_STR(ret, "target memory (data) registration failed");
 
     /* Bind counter with target memory region for incoming messages */
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
     ret = fi_mr_bind(shmem_transport_ofi_target_heap_mrfd,
                      &shmem_transport_ofi_target_cntrfd->fid,
                      FI_REMOTE_WRITE | FI_REMOTE_READ);
@@ -714,7 +714,7 @@ int allocate_recv_cntr_mr(void)
         OFI_CHECK_RETURN_STR(ret, "target heap MR enable failed");
     }
 #endif /* ENABLE_MR_RMA_EVENT */
-#endif /* ndef ENABLE_HARD_POLLING */
+#endif /* ENABLE_TARGET_CNTR */
 #endif
 
     return ret;
@@ -1141,9 +1141,9 @@ int query_for_fabric(struct fabric_info *info)
     hints.caps   = FI_RMA |     /* request rma capability
                                    implies FI_READ/WRITE FI_REMOTE_READ/WRITE */
         FI_ATOMICS;  /* request atomics capability */
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
     hints.caps |= FI_RMA_EVENT; /* want to use remote counters */
-#endif /* ndef ENABLE_HARD_POLLING */
+#endif /* ENABLE_TARGET_CNTR */
     hints.addr_format         = FI_FORMAT_UNSPEC;
     domain_attr.data_progress = FI_PROGRESS_AUTO;
     domain_attr.resource_mgmt = FI_RM_ENABLED;
@@ -1683,7 +1683,7 @@ int shmem_transport_fini(void)
     OFI_CHECK_ERROR_MSG(ret, "Target data MR close failed (%s)\n", fi_strerror(errno));
 #endif
 
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
     ret = fi_close(&shmem_transport_ofi_target_cntrfd->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target CT close failed (%s)\n", fi_strerror(errno));
 #endif

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -32,8 +32,9 @@
 #include <sys/types.h>
 
 
+#define ENABLE_TARGET_CNTR (!defined(ENABLE_HARD_POLLING) || defined(ENABLE_MANUAL_PROGRESS))
 
-#ifndef ENABLE_HARD_POLLING
+#if ENABLE_TARGET_CNTR
 extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;
 #endif
 #ifndef ENABLE_MR_SCALABLE
@@ -312,11 +313,15 @@ extern struct fid_ep* shmem_transport_ofi_target_ep;
 
 static inline
 void shmem_transport_probe(void) {
-#if defined(ENABLE_MANUAL_PROGRESS) && !defined(HARD_POLLING)
+#if defined(ENABLE_MANUAL_PROGRESS)
+#  ifdef USE_THREAD_COMPLETION
     if (0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
+#  endif
         fi_cntr_read(shmem_transport_ofi_target_cntrfd);
+#  ifdef USE_THREAD_COMPLETION
         pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
     }
+#  endif
 #endif
     return;
 }

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -270,6 +270,8 @@ int shmem_transport_fini(void);
 
 static inline void shmem_transport_get_wait(shmem_transport_ctx_t*);
 
+static inline void shmem_transport_probe(void){ return; };
+
 static inline
 int
 shmem_transport_quiet(shmem_transport_ctx_t* ctx)
@@ -1318,7 +1320,6 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
         RAISE_ERROR(ret);
     }
 }
-
 
 static inline
 uint64_t shmem_transport_received_cntr_get(void)


### PR DESCRIPTION
Adds a static inline `shmem_transport_probe()` routine for making manual-progress and the `--enable-manual-progress` configure option to enable intermittently calling the routine.  In the OFI transport, the probe reads the target (RX) counter.  In other transports, a probe does nothing.

If enabling manual progress, the OFI probe routine is called in "put_quiet", and "get_wait" and the various "shmem_wait" routines.  We might want to think about placing the probe elsewhere as well, especially for the case with multiple STX's on the libfabric PSM2 provider.