### PR TITLE
Add env var to disable private contexts in OFI

### DIFF
--- a/README
+++ b/README
@@ -231,6 +231,12 @@ options.
        available for private use (i.e., with contexts that enable the
        SHMEM_CTX_PRIVATE option).
 
+    SHMEM_OFI_STX_DISABLE_PRIVATE (default: 0)
+       Disallow private contexts from having exclusive STX access.  Setting this
+       to 1 may improve performance for applications using many private
+       contexts, especially if the number of threads that use private contexts
+       is greater than SHMEM_OFI_STX_MAX.
+
   Debugging Environment variables:
 
     SHMEM_DEBUG (default: off)

--- a/README
+++ b/README
@@ -231,11 +231,10 @@ options.
        available for private use (i.e., with contexts that enable the
        SHMEM_CTX_PRIVATE option).
 
-    SHMEM_OFI_STX_DISABLE_PRIVATE (default: 0)
-       Disallow private contexts from having exclusive STX access.  Setting this
-       to 1 may improve performance for applications using many private
-       contexts, especially if the number of threads that use private contexts
-       is greater than SHMEM_OFI_STX_MAX.
+    SHMEM_OFI_STX_DISABLE_PRIVATE (default: off)
+       Disable STX privatization. Enabling this may improve load balance across
+       transmit resources, especially in scenarios where the number of contexts
+       exceeds the number of STXs.
 
   Debugging Environment variables:
 

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -94,4 +94,6 @@ SHMEM_INTERNAL_ENV_DEF(OFI_STX_THRESHOLD, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Maximum number of shared contexts per STX before allocating a new STX resource")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_ALLOCATOR, string, "round-robin", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Algorithm for allocating STX resources to contexts")
+SHMEM_INTERNAL_ENV_DEF(OFI_STX_DISABLE_PRIVATE, bool, false, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Disallow private contexts from having exclusive STX access")
 #endif

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -359,11 +359,10 @@ static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
         DEBUG_MSG("STX[%ld] = [ %s ]\n", shmem_transport_ofi_stx_max, stx_str);                 \
     } while (0)
 
-static int shmem_transport_ofi_disable_private;
-
 static inline
-int shmem_transport_ofi_is_private(long options, int disable) {
-    if (!disable && (options & SHMEM_CTX_PRIVATE)) {
+int shmem_transport_ofi_is_private(long options) {
+    if (!shmem_internal_params.OFI_STX_DISABLE_PRIVATE &&
+        (options & SHMEM_CTX_PRIVATE)) {
         return 1;
     } else {
         return 0;
@@ -487,7 +486,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
 {
     /* SHMEM contexts that are private to the same thread (i.e. have
      * SHMEM_CTX_PRIVATE option set) share the same STX.  */
-    if (shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
+    if (shmem_transport_ofi_is_private(ctx->options)) {
 
         shmem_transport_ofi_stx_kvs_t *f;
         HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, f);
@@ -1348,7 +1347,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     /* Allocate STX from the pool */
     if (shmem_internal_thread_level > SHMEM_THREAD_FUNNELED &&
-        shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
+        shmem_transport_ofi_is_private(ctx->options)) {
             ctx->tid = shmem_transport_ofi_gettid();
     }
     shmem_transport_ofi_stx_allocate(ctx);
@@ -1441,12 +1440,6 @@ int shmem_transport_init(void)
     } else {
         RAISE_WARN_MSG("Ignoring bad STX share algorithm '%s', using 'round-robin'\n", type);
         shmem_transport_ofi_stx_allocator = ROUNDROBIN;
-    }
-
-    if (shmem_internal_params.OFI_STX_DISABLE_PRIVATE) {
-        shmem_transport_ofi_disable_private = 1;
-    } else {
-        shmem_transport_ofi_disable_private = 0;
     }
 
     /* Allocate STX array with max length */
@@ -1588,7 +1581,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     if (ctx->stx_idx >= 0) {
-        if (shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
+        if (shmem_transport_ofi_is_private(ctx->options)) {
             shmem_transport_ofi_stx_kvs_t *e;
             HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, e);
             if (e) {
@@ -1651,8 +1644,7 @@ int shmem_transport_fini(void)
 
     for (i = 0; i < shmem_transport_ofi_contexts_len; ++i) {
         if (shmem_transport_ofi_contexts[i]) {
-            if (shmem_transport_ofi_is_private(shmem_transport_ofi_contexts[i]->options,
-                                                  shmem_transport_ofi_disable_private))
+            if (shmem_transport_ofi_is_private(shmem_transport_ofi_contexts[i]->options))
                 RAISE_WARN_MSG("Shutting down with unfreed private context (%zd)\n", i);
             shmem_transport_quiet(shmem_transport_ofi_contexts[i]);
             shmem_transport_ctx_destroy(shmem_transport_ofi_contexts[i]);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -362,7 +362,7 @@ static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
 static int shmem_transport_ofi_disable_private;
 
 static inline
-int shmem_transport_ofi_check_private(long options, int disable) {
+int shmem_transport_ofi_is_private(long options, int disable) {
     if (!disable && (options & SHMEM_CTX_PRIVATE)) {
         return 1;
     } else {
@@ -487,7 +487,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
 {
     /* SHMEM contexts that are private to the same thread (i.e. have
      * SHMEM_CTX_PRIVATE option set) share the same STX.  */
-    if (shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
+    if (shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
 
         shmem_transport_ofi_stx_kvs_t *f;
         HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, f);
@@ -1348,7 +1348,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     /* Allocate STX from the pool */
     if (shmem_internal_thread_level > SHMEM_THREAD_FUNNELED &&
-        shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
+        shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
             ctx->tid = shmem_transport_ofi_gettid();
     }
     shmem_transport_ofi_stx_allocate(ctx);
@@ -1588,7 +1588,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     if (ctx->stx_idx >= 0) {
-        if (shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
+        if (shmem_transport_ofi_is_private(ctx->options, shmem_transport_ofi_disable_private)) {
             shmem_transport_ofi_stx_kvs_t *e;
             HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, e);
             if (e) {
@@ -1651,7 +1651,7 @@ int shmem_transport_fini(void)
 
     for (i = 0; i < shmem_transport_ofi_contexts_len; ++i) {
         if (shmem_transport_ofi_contexts[i]) {
-            if (shmem_transport_ofi_check_private(shmem_transport_ofi_contexts[i]->options,
+            if (shmem_transport_ofi_is_private(shmem_transport_ofi_contexts[i]->options,
                                                   shmem_transport_ofi_disable_private))
                 RAISE_WARN_MSG("Shutting down with unfreed private context (%zd)\n", i);
             shmem_transport_quiet(shmem_transport_ofi_contexts[i]);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -359,6 +359,17 @@ static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
         DEBUG_MSG("STX[%ld] = [ %s ]\n", shmem_transport_ofi_stx_max, stx_str);                 \
     } while (0)
 
+static int shmem_transport_ofi_disable_private;
+
+static inline
+int shmem_transport_ofi_check_private(long options, int disable) {
+    if (!disable && (options & SHMEM_CTX_PRIVATE)) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 /* This uses a slightly modified version of the Fisher-Yates shuffle algorithm
  * (or Knuth Shuffle).  It selects a random element from the so-far
  * unselected subset of the STX pool.  The top_idx should be reset before each
@@ -476,7 +487,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
 {
     /* SHMEM contexts that are private to the same thread (i.e. have
      * SHMEM_CTX_PRIVATE option set) share the same STX.  */
-    if (ctx->options & SHMEM_CTX_PRIVATE) {
+    if (shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
 
         shmem_transport_ofi_stx_kvs_t *f;
         HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, f);
@@ -1337,7 +1348,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     /* Allocate STX from the pool */
     if (shmem_internal_thread_level > SHMEM_THREAD_FUNNELED &&
-        ctx->options & SHMEM_CTX_PRIVATE) {
+        shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
             ctx->tid = shmem_transport_ofi_gettid();
     }
     shmem_transport_ofi_stx_allocate(ctx);
@@ -1430,6 +1441,12 @@ int shmem_transport_init(void)
     } else {
         RAISE_WARN_MSG("Ignoring bad STX share algorithm '%s', using 'round-robin'\n", type);
         shmem_transport_ofi_stx_allocator = ROUNDROBIN;
+    }
+
+    if (shmem_internal_params.OFI_STX_DISABLE_PRIVATE) {
+        shmem_transport_ofi_disable_private = 1;
+    } else {
+        shmem_transport_ofi_disable_private = 0;
     }
 
     /* Allocate STX array with max length */
@@ -1571,7 +1588,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     if (ctx->stx_idx >= 0) {
-        if (ctx->options & SHMEM_CTX_PRIVATE) {
+        if (shmem_transport_ofi_check_private(ctx->options, shmem_transport_ofi_disable_private)) {
             shmem_transport_ofi_stx_kvs_t *e;
             HASH_FIND_INT(shmem_transport_ofi_stx_kvs, &ctx->tid, e);
             if (e) {
@@ -1634,7 +1651,8 @@ int shmem_transport_fini(void)
 
     for (i = 0; i < shmem_transport_ofi_contexts_len; ++i) {
         if (shmem_transport_ofi_contexts[i]) {
-            if (shmem_transport_ofi_contexts[i]->options & SHMEM_CTX_PRIVATE)
+            if (shmem_transport_ofi_check_private(shmem_transport_ofi_contexts[i]->options,
+                                                  shmem_transport_ofi_disable_private))
                 RAISE_WARN_MSG("Shutting down with unfreed private context (%zd)\n", i);
             shmem_transport_quiet(shmem_transport_ofi_contexts[i]);
             shmem_transport_ctx_destroy(shmem_transport_ofi_contexts[i]);


### PR DESCRIPTION
This adds an environment variable that disallows private contexts from claiming exclusive access to an STX in the OFI layer.  This may improve performance for multi-threaded apps that use more exclusive thread-private contexts than available STXs.