### PR TITLE
Add wrapper for strerror_r

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -132,6 +132,7 @@ void
 shmem_internal_init(int tl_requested, int *tl_provided)
 {
     int ret;
+    char errmsg[256];
 
     int runtime_initialized   = 0;
     int transport_initialized = 0;
@@ -366,7 +367,8 @@ shmem_internal_init(int tl_requested, int *tl_provided)
                     sizeof(shmem_internal_my_hostname))) {
         snprintf(shmem_internal_my_hostname,
                     sizeof(shmem_internal_my_hostname),
-                    "ERR: gethostname '%s'?", strerror(errno));
+                    "ERR: gethostname '%s'?",
+                    shmem_util_strerror(errno, errmsg, 256));
     }
 
     /* finish up */

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -435,6 +435,7 @@ static inline double shmem_internal_wtime(void) {
 
 /* Utility functions */
 char *shmem_util_wrap(const char *str, const size_t wraplen, const char *indent);
+char *shmem_util_strerror(int errnum, char *buf, size_t buflen);
 
 #ifndef MAX
 #define MAX(A,B) (A) > (B) ? (A) : (B)

--- a/src/transport_cma.h
+++ b/src/transport_cma.h
@@ -109,15 +109,9 @@ shmem_transport_cma_put(void *target, const void *source, size_t len,
                         (const struct iovec *)&tgt, 1, 0);
 
         if ( bytes < 0 || (size_t) bytes != len) {
-            char errmsg[128];
-#ifdef _GNU_SOURCE
-            char *errstr = strerror_r(errno, errmsg, 128);
-#else
-            char *errstr = errmsg;
-            int err = strerror_r(errno, errmsg, 128);
-            if (err) RAISE_ERROR_MSG("Error in call to strerr_r (%d)\n", err);
-#endif
-            RAISE_ERROR_MSG("process_vm_writev() failed (%s)\n", errstr);
+            char errmsg[256];
+            RAISE_ERROR_MSG("process_vm_writev() failed (%s)\n",
+                            shmem_util_strerror(errno, errmsg, 256);
         }
 }
 
@@ -144,15 +138,9 @@ shmem_transport_cma_get(void *target, const void *source, size_t len, int pe,
                                 (const struct iovec *)&tgt, 1,
                                 (const struct iovec *)&src, 1, 0);
         if ( bytes < 0 || (size_t) bytes != len) {
-            char errmsg[128];
-#ifdef _GNU_SOURCE
-            char *errstr = strerror_r(errno, errmsg, 128);
-#else
-            char *errstr = errmsg;
-            int err = strerror_r(errno, errmsg, 128);
-            if (err) RAISE_ERROR_MSG("Error in call to strerr_r (%d)\n", err);
-#endif
-            RAISE_ERROR_MSG("process_vm_readv() failed (%s)\n", errstr);
+            char errmsg[256];
+            RAISE_ERROR_MSG("process_vm_readv() failed (%s)\n",
+                            shmem_util_strerror(errno, errmsg, 256);
         }
 }
 

--- a/src/transport_cma.h
+++ b/src/transport_cma.h
@@ -111,7 +111,7 @@ shmem_transport_cma_put(void *target, const void *source, size_t len,
         if ( bytes < 0 || (size_t) bytes != len) {
             char errmsg[256];
             RAISE_ERROR_MSG("process_vm_writev() failed (%s)\n",
-                            shmem_util_strerror(errno, errmsg, 256);
+                            shmem_util_strerror(errno, errmsg, 256));
         }
 }
 
@@ -140,7 +140,7 @@ shmem_transport_cma_get(void *target, const void *source, size_t len, int pe,
         if ( bytes < 0 || (size_t) bytes != len) {
             char errmsg[256];
             RAISE_ERROR_MSG("process_vm_readv() failed (%s)\n",
-                            shmem_util_strerror(errno, errmsg, 256);
+                            shmem_util_strerror(errno, errmsg, 256));
         }
 }
 

--- a/src/transport_xpmem.c
+++ b/src/transport_xpmem.c
@@ -50,13 +50,15 @@ shmem_transport_xpmem_init(void)
     char *base;
     size_t len;
     int ret;
+    char errmsg[256];
 
     /* setup data region */
     base = FIND_BASE(shmem_internal_data_base, page_size);
     len = FIND_LEN(shmem_internal_data_base, shmem_internal_data_length, page_size);
     my_info.data_seg = xpmem_make(base, len, XPMEM_PERMIT_MODE, (void*)0666);
     if (-1 == my_info.data_seg) {
-        RETURN_ERROR_MSG("xpmem_make failed: %s\n", strerror(errno));
+        RETURN_ERROR_MSG("xpmem_make failed: %s\n",
+                         shmem_util_strerror(errno, errmsg, 256));
         return 1;
     }
     my_info.data_off = (char*) shmem_internal_data_base - (char*) base;
@@ -67,7 +69,8 @@ shmem_transport_xpmem_init(void)
     len = FIND_LEN(shmem_internal_heap_base, shmem_internal_heap_length, page_size);
     my_info.heap_seg = xpmem_make(base, len, XPMEM_PERMIT_MODE, (void*)0666);
     if (-1 == my_info.heap_seg) {
-        RETURN_ERROR_MSG("xpmem_make failed: %s\n", strerror(errno));
+        RETURN_ERROR_MSG("xpmem_make failed: %s\n",
+                         shmem_util_strerror(errno, errmsg, 256));
         return 1;
     }
     my_info.heap_off = (char*) shmem_internal_heap_base - (char*) base;
@@ -87,6 +90,7 @@ int
 shmem_transport_xpmem_startup(void)
 {
     int ret, i, peer_num, num_on_node = 0;
+    char errmsg[256];
     struct share_info_t info;
     struct xpmem_addr addr;
 
@@ -121,7 +125,8 @@ shmem_transport_xpmem_startup(void)
             shmem_transport_xpmem_peers[peer_num].data_apid =
                 xpmem_get(info.data_seg, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void*)0666);
             if (shmem_transport_xpmem_peers[peer_num].data_apid < 0) {
-                RETURN_ERROR_MSG("could not get data apid: %s\n", strerror(errno));
+                RETURN_ERROR_MSG("could not get data apid: %s\n",
+                                 shmem_util_strerror(errno, errmsg, 256));
                 return 1;
             }
 
@@ -131,7 +136,8 @@ shmem_transport_xpmem_startup(void)
             shmem_transport_xpmem_peers[peer_num].data_attach_ptr =
                 xpmem_attach(addr, info.data_len, NULL);
             if ((size_t) shmem_transport_xpmem_peers[peer_num].data_ptr == XPMEM_MAXADDR_SIZE) {
-                RETURN_ERROR_MSG("could not get data segment: %s\n", strerror(errno));
+                RETURN_ERROR_MSG("could not get data segment: %s\n",
+                                 shmem_util_strerror(errno, errmsg, 256));
                 return 1;
             }
             shmem_transport_xpmem_peers[peer_num].data_ptr =
@@ -140,7 +146,8 @@ shmem_transport_xpmem_startup(void)
             shmem_transport_xpmem_peers[peer_num].heap_apid =
                 xpmem_get(info.heap_seg, XPMEM_RDWR, XPMEM_PERMIT_MODE, (void*)0666);
             if (shmem_transport_xpmem_peers[peer_num].heap_apid < 0) {
-                RETURN_ERROR_MSG("could not get heap apid: %s\n", strerror(errno));
+                RETURN_ERROR_MSG("could not get heap apid: %s\n",
+                                 shmem_util_strerror(errno, errmsg, 256));
                 return 1;
             }
 
@@ -150,7 +157,8 @@ shmem_transport_xpmem_startup(void)
             shmem_transport_xpmem_peers[peer_num].heap_attach_ptr =
                 xpmem_attach(addr, info.heap_len, NULL);
             if ((size_t) shmem_transport_xpmem_peers[peer_num].heap_ptr == XPMEM_MAXADDR_SIZE) {
-                RETURN_ERROR_MSG("could not get data segment: %s\n", strerror(errno));
+                RETURN_ERROR_MSG("could not get data segment: %s\n",
+                                 shmem_util_strerror(errno, errmsg, 256));
                 return 1;
             }
             shmem_transport_xpmem_peers[peer_num].heap_ptr =


### PR DESCRIPTION
When _GNU_SOURCE is enabled (e.g. in CMA builds), the GNU version of
this function (which has a different prototype) is used.  Wrap it for
portability.

Signed-off-by: James Dinan <james.dinan@intel.com>