### PR TITLE
Remove NB fence prototype from Portals transport

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,11 +73,6 @@ AS_IF([test "$enable_completion_polling" = "yes"],
        AC_DEFINE([DEFAULT_POLL_LIMIT], [-1], [Poll limit for local/remote completions])],
       [AC_DEFINE([DEFAULT_POLL_LIMIT], [0], [Poll limit for local/remote completions])])
 
-AC_ARG_ENABLE([nonblocking-fence],
-    [AC_HELP_STRING([--enable-nonblocking-fence],
-                    [When total data ordering is not available, make shmem_fence a non-blocking operation.  shmem_fence will return immediately, but the next communication call will block until all previous communications finish. (default:disabled)])])
-AS_IF([test "$enable_nb_fence" = "yes"], [AC_DEFINE([ENABLE_NONBLOCKING_FENCE], [1], [Enable non-blocking fence])])
-
 
 AC_ARG_WITH([total-data-ordering],
     [AC_HELP_STRING([--with-total-data-ordering],

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -105,10 +105,6 @@ int shmem_transport_portals4_total_data_ordering = 0;
 int shmem_transport_portals4_long_pending = 0;
 #endif
 
-#ifdef ENABLE_NONBLOCKING_FENCE
-int shmem_transport_portals4_fence_pending = 0;
-#endif
-
 static ptl_ni_limits_t ni_limits;
 #if ENABLE_REMOTE_VIRTUAL_ADDRESSING
 static ptl_pt_index_t all_pt = PTL_PT_ANY;

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -118,7 +118,6 @@ shmem_internal_mutex_t shmem_internal_mutex_ptl4_ctx;
 shmem_internal_mutex_t shmem_internal_mutex_ptl4_pt_state;
 shmem_internal_mutex_t shmem_internal_mutex_ptl4_frag;
 shmem_internal_mutex_t shmem_internal_mutex_ptl4_event_slots;
-shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 #endif
 
 static shmem_transport_ctx_t** shmem_transport_portals4_contexts = NULL;
@@ -386,7 +385,6 @@ shmem_transport_init(void)
     SHMEM_MUTEX_INIT(shmem_internal_mutex_ptl4_pt_state);
     SHMEM_MUTEX_INIT(shmem_internal_mutex_ptl4_frag);
     SHMEM_MUTEX_INIT(shmem_internal_mutex_ptl4_event_slots);
-    SHMEM_MUTEX_INIT(shmem_internal_mutex_ptl4_nb_fence);
 
     shmem_transport_portals4_bounce_buffer_size = shmem_internal_params.BOUNCE_SIZE;
     shmem_transport_portals4_bounce_buffers =
@@ -772,7 +770,6 @@ shmem_transport_fini(void)
     SHMEM_MUTEX_DESTROY(shmem_internal_mutex_ptl4_pt_state);
     SHMEM_MUTEX_DESTROY(shmem_internal_mutex_ptl4_frag);
     SHMEM_MUTEX_DESTROY(shmem_internal_mutex_ptl4_event_slots);
-    SHMEM_MUTEX_DESTROY(shmem_internal_mutex_ptl4_nb_fence);
 
     return 0;
 }

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -105,10 +105,6 @@ extern int shmem_transport_portals4_total_data_ordering;
 extern int shmem_transport_portals4_long_pending;
 #endif
 
-#ifdef ENABLE_NONBLOCKING_FENCE
-extern int shmem_transport_portals4_fence_pending;
-#endif
-
 #ifdef ENABLE_THREADS
 extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_ctx;
 extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_pt_state;
@@ -325,51 +321,13 @@ shmem_transport_fence(shmem_transport_ctx_t* ctx)
     int ret = 0;
 
     if (0 == PORTALS4_TOTAL_DATA_ORDERING) {
-#ifdef ENABLE_NONBLOCKING_FENCE
-        /* synchronize the atomic cache, if there is one */
-        PtlAtomicSync();
-
-        /* non-blocking fence.  Always mark and return */
-        SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_nb_fence);
-        shmem_transport_portals4_fence_pending = 1;
-        SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
-#else
         ret = shmem_transport_quiet(ctx);
-#endif
     }
 #if WANT_TOTAL_DATA_ORDERING != 0
     else if (0 != shmem_transport_portals4_long_pending) {
-#ifdef ENABLE_NONBLOCKING_FENCE
-        /* non-blocking fence.  Always mark and return */
-        SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_nb_fence);
-        shmem_transport_portals4_fence_pending = 1;
-        SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
-#else
         ret = shmem_transport_quiet(ctx);
-#endif
         shmem_transport_portals4_long_pending = 0;
     }
-#endif
-
-    return ret;
-}
-
-
-/* internal call: call at the start of all communication calls to deal with delayed fence */
-static inline
-int
-shmem_transport_portals4_fence_complete(void)
-{
-    int ret = 0;
-
-#ifdef ENABLE_NONBLOCKING_FENCE
-    /* If a fence is pending, complete */
-    SHMEM_MUTEX_LOCK(shmem_internal_mutex_ptl4_nb_fence);
-    if (0 != shmem_transport_portals4_fence_pending) {
-        ret = shmem_transport_quiet(ctx);
-        shmem_transport_portals4_fence_pending = 0;
-    }
-    SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_ptl4_nb_fence);
 #endif
 
     return ret;
@@ -444,7 +402,6 @@ shmem_transport_put_small(shmem_transport_ctx_t* ctx, void *target, const void *
 
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
     ret = PtlPut(ctx->put_volatile_md,
@@ -478,8 +435,6 @@ shmem_transport_portals4_put_nb_internal(shmem_transport_ctx_t* ctx, void *targe
 #else
     PORTALS4_GET_REMOTE_ACCESS_TWOPT(target, pt, offset, data_pt, heap_pt);
 #endif
-
-    shmem_transport_portals4_fence_complete();
 
     if (len <= shmem_transport_portals4_max_volatile_size) {
         shmem_internal_atomic_inc(&ctx->pending_put_cntr);
@@ -599,7 +554,6 @@ shmem_transport_portals4_put_nbi_internal(shmem_transport_ctx_t* ctx, void *targ
     PORTALS4_GET_REMOTE_ACCESS_TWOPT(target, pt, offset, data_pt, heap_pt);
 #endif
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
     if (len <= shmem_transport_portals4_max_volatile_size) {
@@ -800,7 +754,6 @@ shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *sourc
     shmem_internal_assert(len <= sizeof(long double _Complex));
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     /* note: No ack is generated on the ct associated with the
@@ -841,7 +794,6 @@ shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
     shmem_internal_assert(len <= sizeof(long double _Complex));
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     /* note: No ack is generated on the ct associated with the
@@ -882,7 +834,6 @@ shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
     shmem_internal_assert(len <= sizeof(long double _Complex));
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     /* note: No ack is generated on the ct associated with the
@@ -916,14 +867,11 @@ shmem_transport_atomic_small(shmem_transport_ctx_t* ctx, void *target, const voi
     long offset;
     ptl_process_t peer;
 
-    shmem_transport_portals4_fence_complete();
-
     peer.rank = pe;
     PORTALS4_GET_REMOTE_ACCESS(target, pt, offset);
 
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_put_cntr);
 
     ret = PtlAtomic(ctx->put_volatile_md,
@@ -954,12 +902,8 @@ shmem_transport_atomic_nb(shmem_transport_ctx_t* ctx, void *target, const void *
 
     shmem_internal_assert(completion != NULL);
 
-    shmem_transport_portals4_fence_complete();
-
     peer.rank = pe;
     PORTALS4_GET_REMOTE_ACCESS(target, pt, offset);
-
-    shmem_transport_portals4_fence_complete();
 
     if (len <= shmem_transport_portals4_max_volatile_size) {
         shmem_internal_atomic_inc(&ctx->pending_put_cntr);
@@ -1089,7 +1033,6 @@ shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const voi
     shmem_internal_assert(len <= shmem_transport_portals4_max_fetch_atomic_size);
     shmem_internal_assert(len <= shmem_transport_portals4_max_volatile_size);
 
-    shmem_transport_portals4_fence_complete();
     shmem_internal_atomic_inc(&ctx->pending_get_cntr);
 
     /* note: No ack is generated on the ct associated with the

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -110,7 +110,6 @@ extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_ctx;
 extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_pt_state;
 extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_frag;
 extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_event_slots;
-extern shmem_internal_mutex_t shmem_internal_mutex_ptl4_nb_fence;
 #endif
 
 #define SHMEM_TRANSPORT_PORTALS4_TYPE_BOUNCE  0x01


### PR DESCRIPTION
NB fence is an interesting optimization that automatically delays fence operations to improve overlap.  However, the implementation has poor threading performance, is unmaintained, and is poorly tested.  Users can also achieve this optimization at the application layer (and arguably, this is preferred anyway since the optimization becomes portable across SHMEM libraries) by delaying fences as follows:
```
shmem_put(...);
shmem_fence();
compute(...);
shmem_put(...);
```
Into this:
```
shmem_put(...);
compute(...);
shmem_fence();
shmem_put(...);
```