### PR TITLE
Fix typo to init min_psync[] in unit test

### DIFF
--- a/test/unit/reduce_active_set.c
+++ b/test/unit/reduce_active_set.c
@@ -58,7 +58,7 @@ int main(void)
 
     for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
         max_psync[i] = SHMEM_SYNC_VALUE;
-        max_psync[i] = SHMEM_SYNC_VALUE;
+        mix_psync[i] = SHMEM_SYNC_VALUE;
     }
 
     if (me == 0)

--- a/test/unit/reduce_active_set.c
+++ b/test/unit/reduce_active_set.c
@@ -58,7 +58,7 @@ int main(void)
 
     for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
         max_psync[i] = SHMEM_SYNC_VALUE;
-        mix_psync[i] = SHMEM_SYNC_VALUE;
+        min_psync[i] = SHMEM_SYNC_VALUE;
     }
 
     if (me == 0)


### PR DESCRIPTION
Signed-off-by: Thomas Naughton <naughtont@ornl.gov>