### PR TITLE
Fix start_pes error check

### DIFF
--- a/src/init_c.c
+++ b/src/init_c.c
@@ -53,11 +53,9 @@
 void SHMEM_FUNCTION_ATTRIBUTES
 start_pes(int npes)
 {
-    if (shmem_internal_initialized) {
-        RAISE_ERROR_STR("attempt to reinitialize library");
+    if (!shmem_internal_initialized) {
+        shmem_internal_start_pes(npes);
     }
-
-    shmem_internal_start_pes(npes);
 }
 
 


### PR DESCRIPTION
OpenSHMEM specifies that "Calling start_pes more than once has no
subsequent effect."

Signed-off-by: James Dinan <james.dinan@intel.com>