### PR TITLE
Add bb performance counters

### DIFF
--- a/mpp/shmem.h4.in
+++ b/mpp/shmem.h4.in
@@ -87,9 +87,9 @@ typedef struct { int dummy; } * shmem_ctx_t;
 #else
   extern shmem_ctx_t SHMEM_CTX_DEFAULT;
 #endif
-#define SHMEM_CTX_PRIVATE       (1<<0)
-#define SHMEM_CTX_SERIALIZED    (1<<1)
-#define SHMEM_CTX_NOSTORE       (1<<2)
+#define SHMEM_CTX_PRIVATE       (1l<<0)
+#define SHMEM_CTX_SERIALIZED    (1l<<1)
+#define SHMEM_CTX_NOSTORE       (1l<<2)
 
 define(`SHPRE', `')dnl
 include(shmem_c_func.h4)dnl

--- a/mpp/shmemx.h4.in
+++ b/mpp/shmemx.h4.in
@@ -33,6 +33,6 @@ define(`SHPRE', `')dnl
 include(shmemx_c_func.h4)dnl
 
 /* Option to enable bounce buffering on a given context */
-#define SHMEMX_CTX_BOUNCE_BUFFER  (1<<31)
+#define SHMEMX_CTX_BOUNCE_BUFFER  (1l<<31)
 
 #endif /* SHMEMX_H */

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1572,6 +1572,25 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 {
     int ret;
 
+    if(shmem_internal_params.DEBUG) {
+        SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        SHMEM_TRANSPORT_OFI_CTX_BB_LOCK(ctx);
+        DEBUG_MSG("id = %d, options = %#0lx, stx_idx = %d\n"
+                  RAISE_PE_PREFIX "pending_put_cntr = %9"PRIu64", completed_put_cntr = %9"PRIu64"\n"
+                  RAISE_PE_PREFIX "pending_get_cntr = %9"PRIu64", completed_get_cntr = %9"PRIu64"\n"
+                  RAISE_PE_PREFIX "pending_bb_cntr  = %9"PRIu64", completed_bb_cntr  = %9"PRIu64"\n",
+                  ctx->id, (unsigned long) ctx->options, ctx->stx_idx,
+                  shmem_internal_my_pe,
+                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr), fi_cntr_read(ctx->put_cntr),
+                  shmem_internal_my_pe,
+                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr), fi_cntr_read(ctx->get_cntr),
+                  shmem_internal_my_pe,
+                  ctx->pending_bb_cntr, ctx->completed_bb_cntr
+                 );
+        SHMEM_TRANSPORT_OFI_CTX_BB_UNLOCK(ctx);
+        SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+    }
+
     if (ctx->cntr_ep) {
         ret = fi_close(&ctx->cntr_ep->fid);
         OFI_CHECK_ERROR_MSG(ret, "Context CNTR endpoint close failed (%s)\n", fi_strerror(errno));


### PR DESCRIPTION
 * Add bounce buffer performance counters
 * Add debug message to print diagnostic info upon context destruction
 * Fix type issue with SHMEM_CTX_* constants (int implicitly promoted to long)