### PR TITLE
Fix FI_MR_RMA_EVENT used with FI_MR_SCALABLE.

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1163,7 +1163,7 @@ int query_for_fabric(struct fabric_info *info)
 #ifdef ENABLE_MR_SCALABLE
     domain_attr.mr_mode       = FI_MR_SCALABLE; /* VA space-doesn't have to be pre-allocated */
 #  if !defined(ENABLE_HARD_POLLING) && defined(ENABLE_MR_RMA_EVENT)
-    domain_attr.mr_mode      |= FI_MR_RMA_EVENT; /* can support RMA_EVENT on MR */
+    domain_attr.mr_mode       = FI_MR_RMA_EVENT; /* can support RMA_EVENT on MR */
 #  endif
 #else
     domain_attr.mr_mode       = FI_MR_BASIC; /* VA space is pre-allocated */


### PR DESCRIPTION
FI_MR_SCALABLE is "old" (pre v1.5) OFI mr_mode
(still supported for backward compatibility)
that must not be mixed with new API mr_mode bits.

Signed-off-by: Matias Cabral <matias.a.cabral@intel.com>