### PR TITLE
Manual progress should also do completion polling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,9 @@ AS_IF([test "$enable_completion_polling" = "yes"],
 AC_ARG_ENABLE([manual-progress],
     [AC_HELP_STRING([--enable-manual-progress],
                     [Enable intermittent progress calls inside transport layer (default:disabled)])])
-AS_IF([test "$enable_manual_progress" = "yes"], [AC_DEFINE([ENABLE_MANUAL_PROGRESS], [1], [Enable manual progress])])
+AS_IF([test "$enable_manual_progress" = "yes"],
+      [AC_DEFINE([ENABLE_MANUAL_PROGRESS], [1], [Enable manual progress])
+       AC_DEFINE([DEFAULT_POLL_LIMIT], [-1], [Poll limit for local/remote completions])])
 
 AC_ARG_WITH([total-data-ordering],
     [AC_HELP_STRING([--with-total-data-ordering],


### PR DESCRIPTION
Manual progress should enable completion polling so that `shmem_transport_probe()` is called in `put_quiet` and `get_wait`, as described in issue #715.

FWIW, I tested the performance of this change using the PSM2 provider in our uni-directional throughput and halo exchange benchmarks, and I didn't notice any substantial difference.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>