### PR TITLE
Configury updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
         - secure: "luxfwDy26Pva+A58T/vPP7+Zek4rBEbpB2TpdXuLdIu/MJ2laoUkaZj/ouT6YgdSxUoiyLUlGIzLnByxnrVgWqYELsWHiV9hzsXZCNfgQDdUHV8UITCqSYVcd5WGNoVdC0QohKuIj47y6bP5ttcv1sIfpV74ztPJZE1dbb2QzgvWcIKWN8Abj55364ZnIidW7ErYLrAiKlBzSxZXCKiKD6qOUbpOBN8yuzaX9diXYJViest7iBC+BfwzXO8Shuouh6QrQhJ1T4oG6u6YJn17fnOwXKJCdkeQYr/E8ka4JRf8vZm7CNO1YdwNhtGtFNEzTJaP2XFLAQGCB9vffCxcqRbpWv+lpsFRsH+eiF/zp/xKGr5qzB9sPUxNANJyhphXK0VfIqDan7nz9di99NFBEF94Jl33E+KODTCAeHb6+a7yboR5B4BalM4jXKrcn/2A4pYrk45YF5IdLLOEvzTaOyVSgHoNIzXRZvHEL2AeYuvz5qLukzMB+QClbA1EeCBNyokuXK/TemeTvveXpQpCaVKNQ8zp/v30u8eiaV8R/dFa2evlJ6kwSaeXlXpXifeXd5Px0x6HF4FT9HLOtPVQ3rZXyfL2Eh92egu15GiTqMNkdVlVGUC20+iddLjtbPqRnVw0WnZkekh62A6rGuT4cTfAbZ2GVPD+IMqzokO1IGg="
     matrix:
         - # Defaults
-        - SOS_BUILD_OPTS="--disable-mr-scalable --enable-av-map --disable-cxx --enable-memcpy"
+        - SOS_BUILD_OPTS="--enable-ofi-mr=basic --enable-av-map --disable-cxx --enable-memcpy"
         - >
           SOS_DISABLE_FORTRAN=1
           SOS_BUILD_OPTS="--disable-fortran --enable-error-checking --enable-remote-virtual-addressing --disable-aslr-check"
@@ -29,7 +29,7 @@ env:
           SOS_ENABLE_ERROR_TESTS=1 SHMEM_SYMMETRIC_HEAP_USE_MALLOC=1
           SOS_BUILD_OPTS="--disable-threads --enable-error-checking"
         - >
-          SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --disable-mr-scalable --enable-av-map --enable-remote-virtual-addressing"
+          SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-ofi-mr=basic --enable-av-map --enable-remote-virtual-addressing"
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1 SHMEM_BOUNCE_SIZE=0

--- a/README
+++ b/README
@@ -68,7 +68,7 @@ Options to configure include:
                           shmem_fence() to the next put-like call,
                           which can help improve overlap in some
                           cases.
-  --with-total-data-ordering=<yes|no|check>
+  --enable-total-data-ordering=<yes|no|check>
                           If a network supports total data ordering
                           (that is, ordering guarantees to two
                           different addresses on the same target

--- a/configure.ac
+++ b/configure.ac
@@ -192,13 +192,13 @@ AS_IF([test "$enable_long_fortran_header" = "yes"], [FORTRAN_LONG_HEADER=" "], [
 AC_SUBST([FORTRAN_LONG_HEADER])
 AM_CONDITIONAL([HAVE_LONG_FORTRAN_HEADER], [test "$enable_long_fortran_header" = "yes"])
 
-AC_ARG_WITH([ofi-mr],
-    [AC_HELP_STRING([--with-ofi-mr],
+AC_ARG_ENABLE([ofi-mr],
+    [AC_HELP_STRING([--enable-ofi-mr=MODE],
                     [OFI memory registration mode: basic, scalable, or rma-event (default: scalable)])])
 
-AS_IF([test -z "$with_ofi_mr"], [with_ofi_mr="scalable"])
+AS_IF([test -z "$enable_ofi_mr"], [enable_ofi_mr="scalable"])
 
-AS_CASE([$with_ofi_mr],
+AS_CASE([$enable_ofi_mr],
         [basic],
             [],
         [scalable],
@@ -206,7 +206,7 @@ AS_CASE([$with_ofi_mr],
         [rma*event],
             [AC_DEFINE([ENABLE_MR_RMA_EVENT], [1], [If defined, the OFI transport will use FI_MR_RMA_EVENT])
              AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
-        [AC_MSG_ERROR([Invalid OFI memory registration mode: $with_ofi_mr])])
+        [AC_MSG_ERROR([Invalid OFI memory registration mode: $enable_ofi_mr])])
 
 
 AC_ARG_ENABLE([av-map],
@@ -829,7 +829,7 @@ echo ""
 
 if test "$transport_ofi" = "yes"; then
     echo "OFI Transport:"
-    echo "  Memory reg.:    $with_ofi_mr"
+    echo "  Memory reg.:    $enable_ofi_mr"
 
     if test "$enable_av_map" = "yes"; then
         echo "  Addr. vector:   map"

--- a/configure.ac
+++ b/configure.ac
@@ -79,14 +79,14 @@ AS_IF([test "$enable_manual_progress" = "yes"],
       [AC_DEFINE([ENABLE_MANUAL_PROGRESS], [1], [Enable manual progress])
        AC_DEFINE([DEFAULT_POLL_LIMIT], [-1], [Poll limit for local/remote completions])])
 
-AC_ARG_WITH([total-data-ordering],
-    [AC_HELP_STRING([--with-total-data-ordering],
+AC_ARG_ENABLE([total-data-ordering],
+    [AC_HELP_STRING([--enable-total-data-ordering],
        [Configure handling of total data ordering option.  "no" or "never" to build with the assumption total data ordering will never be available.  "yes" or "always" to build with the assumption total data ordering will always be available (if not, applications will abort in start_pes()).  "check" to build with no assumptions, which may lead to a slight performance decrease on high performance networks.  (default: disabled)])])
-AS_CASE([x$with_total_data_ordering],
+AS_CASE([x$enable_total_data_ordering],
   [xyes|xalways], [ordering=1; msg="assume always available"],
   [xno|xnever|x], [ordering=0; msg="assume never available"],
   [xcheck], [ordering=2; msg="runtime check"],
-  [AC_MSG_ERROR([Unknown ordering requirement $with_total_data_ordering])])
+  [AC_MSG_ERROR([Unknown ordering requirement $enable_total_data_ordering])])
 AC_DEFINE_UNQUOTED([WANT_TOTAL_DATA_ORDERING], [$ordering], [0 if never check for total data ordering, 1 if always assume total data ordering, 2 to check])
 AC_MSG_CHECKING([For total data ordering behavior])
 AC_MSG_RESULT([$msg])

--- a/configure.ac
+++ b/configure.ac
@@ -665,6 +665,9 @@ fi
 if test -n "$with_pmi" -a "$with_pmi" != "no" -a "$with_pmi" != "yes" ; then
   DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --with-pmi=${with_pmi}"
 fi
+if test "$enable_pmi_simple" = "yes" ; then
+  DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS --enable-pmi-simple"
+fi
 if test -n "$FCFLAGS" ; then
   DISTCHECK_CONFIGURE_FLAGS="$DISTCHECK_CONFIGURE_FLAGS FCFLAGS=\"$FCFLAGS\""
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -192,17 +192,22 @@ AS_IF([test "$enable_long_fortran_header" = "yes"], [FORTRAN_LONG_HEADER=" "], [
 AC_SUBST([FORTRAN_LONG_HEADER])
 AM_CONDITIONAL([HAVE_LONG_FORTRAN_HEADER], [test "$enable_long_fortran_header" = "yes"])
 
-AC_ARG_ENABLE([mr-scalable],
-    [AC_HELP_STRING([--disable-mr-scalable],
-                    [Disable the use of scalable memory regions in the OFI transport.  Required by some providers. (default: enabled)])])
-AS_IF([test "$enable_mr_scalable" != "no"],
-      [AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE.  Otherwise, FI_MR_BASIC is used.])])
+AC_ARG_WITH([ofi-mr],
+    [AC_HELP_STRING([--with-ofi-mr],
+                    [OFI memory registration mode: basic, scalable, or rma-event (default: scalable)])])
 
-AC_ARG_ENABLE([mr-rma-event],
-    [AC_HELP_STRING([--enable-mr-rma-event],
-                    [Enable FI_MR_RMA_EVENT memory registration support in OFI transport.  Required by some providers. (default: disabled)])])
-AS_IF([test "$enable_mr_rma_event" = "yes"],
-      [AC_DEFINE([ENABLE_MR_RMA_EVENT], [1], [If defined, the OFI transport will enable support for FI_MR_RMA_EVENT.])])
+AS_IF([test -z "$with_ofi_mr"], [with_ofi_mr="scalable"])
+
+AS_CASE([$with_ofi_mr],
+        [basic],
+            [],
+        [scalable],
+            [AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
+        [rma*event],
+            [AC_DEFINE([ENABLE_MR_RMA_EVENT], [1], [If defined, the OFI transport will use FI_MR_RMA_EVENT])
+             AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
+        [AC_MSG_ERROR([Invalid OFI memory registration mode: $with_ofi_mr])])
+
 
 AC_ARG_ENABLE([av-map],
     [AC_HELP_STRING([--enable-av-map],
@@ -801,3 +806,33 @@ echo "  XPMEM:          $transport_xpmem"
 echo "  CMA:            $transport_cma"
 echo "  memcpy:         $transport_memcpy"
 echo ""
+echo "Global Options:"
+if test "$enable_remote_virtual_addressing" = "yes"; then
+    echo "  Remote VA:      yes"
+else
+    echo "  Remote VA:      no"
+fi
+if test "$enable_threads" != "no"; then
+    echo "  Thread support: yes"
+else
+    echo "  Thread support: no"
+fi
+if test "$enable_error_checking" != "yes"; then
+    echo "  Error checking: no"
+else
+    echo "  Error checking: yes"
+fi
+echo ""
+
+if test "$transport_ofi" = "yes"; then
+    echo "OFI Transport:"
+    echo "  Memory reg.:    $with_ofi_mr"
+
+    if test "$enable_av_map" = "yes"; then
+        echo "  Addr. vector:   map"
+    else
+        echo "  Addr. vector:   table"
+    fi
+
+    echo ""
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -203,7 +203,7 @@ AS_CASE([$enable_ofi_mr],
             [],
         [scalable],
             [AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
-        [rma*event],
+        [rma?event],
             [AC_DEFINE([ENABLE_MR_RMA_EVENT], [1], [If defined, the OFI transport will use FI_MR_RMA_EVENT])
              AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
         [AC_MSG_ERROR([Invalid OFI memory registration mode: $enable_ofi_mr])])

--- a/pmi-simple/Makefile.am
+++ b/pmi-simple/Makefile.am
@@ -11,7 +11,7 @@
 # information, see the LICENSE file in the top level directory of the
 # distribution.
 
-AM_CPPFLAGS= -I$(top_builddir)/../src
+AM_CPPFLAGS= -I$(top_srcdir)/src
 
 if USE_PMI_SIMPLE
 lib_LTLIBRARIES = libpmi_simple.la


### PR DESCRIPTION
* Removes `--disable-mr-scalable` and `--enable-mr-rma-event` and replaces with `--enable-ofi-mr={basic, scalable, rma-event}`
* Fixes `make distcheck` target with simple PMI
* Improves build configuration output from configure
* Renames `--with-total-data-ordering` to `--enable-total-data-ordering`