### PR TITLE
Update RPM Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -393,11 +393,16 @@ script:
     - >
       if [ ! -z "$SOS_CHECK_TARBALL_RPM" ]; then
           cd $SOS_SRC
+          ./configure --with-ofi=$TRAVIS_INSTALL/libfabric/ --enable-pmi-simple --enable-rpm-prefix
+          make dist
+          rpmbuild -ta ./sandia-openshmem-*.tar.gz --define "configargs --with-ofi=$TRAVIS_INSTALL/libfabric/ --enable-pmi-simple" --define "_prefix /usr/shmem"
+          make clean
           ./configure --with-ofi=$TRAVIS_INSTALL/libfabric/ --enable-pmi-simple
           make dist
-          rpmbuild -ta ./sos-*.tar.gz --define "configargs --with-ofi=$TRAVIS_INSTALL/libfabric/ --enable-pmi-simple"
-          tar zxvf sos-*.tar.gz
-          cd sos-*
+          rpmbuild -ta ./sandia-openshmem-*.tar.gz --define "configargs --with-ofi=$TRAVIS_INSTALL/libfabric/ --enable-pmi-simple"
+          # Sanity check distribution tarball
+          tar zxvf sandia-openshmem-*.tar.gz
+          cd sandia-openshmem-*
           ./autogen.sh
           mkdir build
           cd build

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,8 @@
 
 ACLOCAL_AMFLAGS = -I config
 
-EXTRA_DIST = README NEWS LICENSE sandia-openshmem.spec autogen.sh pmi-simple man
+EXTRA_DIST = sandia-openshmem.spec autogen.sh pmi-simple man
+dist_doc_DATA = README NEWS LICENSE
 
 SUBDIRS = bindings man mpp pmi-simple src test
 

--- a/configure.ac
+++ b/configure.ac
@@ -187,6 +187,12 @@ AS_IF([test "$enable_long_fortran_header" = "yes"], [FORTRAN_LONG_HEADER=" "], [
 AC_SUBST([FORTRAN_LONG_HEADER])
 AM_CONDITIONAL([HAVE_LONG_FORTRAN_HEADER], [test "$enable_long_fortran_header" = "yes"])
 
+AC_ARG_ENABLE([rpm-prefix],
+    [AC_HELP_STRING([--enable-rpm-prefix],
+                    [Generate RPM spec file that supports an alternate installation prefix (default:disabled)])])
+AS_IF([test "$enable_rpm_prefix" = "yes"], [SOS_RPM_PREFIXED=""], [SOS_RPM_PREFIXED="# DISABLED: "])
+AC_SUBST([SOS_RPM_PREFIXED])
+
 AC_ARG_ENABLE([mr-scalable],
     [AC_HELP_STRING([--disable-mr-scalable],
                     [Disable the use of scalable memory regions in the OFI transport.  Required by some providers. (default: enabled)])])

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.4.1], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sos], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.4.1], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])
@@ -738,7 +738,7 @@ AC_CONFIG_FILES([Makefile
   mpp/shmemx_c_func.h4
   mpp/shmemx.h4
   src/Makefile
-  src/sos.pc
+  src/sandia-openshmem.pc
   test/Makefile
   test/unit/Makefile
   test/shmemx/Makefile

--- a/sandia-openshmem.spec.in
+++ b/sandia-openshmem.spec.in
@@ -35,9 +35,9 @@ Tests programs for Sandia OpenSHMEM
 
 %build
 %configure %{configargs}
-make %{?_smp_mflags}
+make -j 4 %{?_smp_mflags}
 # Build tests
-make check TESTS=
+make -j 4 check TESTS=
 
 %install
 rm -rf %{buildroot}
@@ -45,6 +45,8 @@ rm -rf %{buildroot}
 # remove unpackaged files from the buildroot
 rm -f %{buildroot}%{_libdir}/*.la
 # Prepare tests
+# FIXME: It would be better to configure with --disable-libtool-wrapper so we
+#        can pull from the standard dirs instead of .libs
 install -d %{testdir}/unit
 install test/unit/.libs/* %{testdir}/unit
 install -d %{testdir}/shmemx
@@ -64,13 +66,25 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+@SOS_RPM_PREFIXED@%dir %{_prefix}
+@SOS_RPM_PREFIXED@%dir %{_bindir}
+@SOS_RPM_PREFIXED@%dir %{_libdir}
+@SOS_RPM_PREFIXED@%dir %{_libdir}/pkgconfig
+@SOS_RPM_PREFIXED@%dir %{_docdir}
+@SOS_RPM_PREFIXED@%dir %{_datadir}
+%{_docdir}/*
 %{_bindir}/oshrun
 %{_libdir}/lib*.so.*
 %{_libdir}/pkgconfig/*.pc
-%doc LICENSE README NEWS
 
 %files devel
 %defattr(-,root,root)
+@SOS_RPM_PREFIXED@%dir %{_prefix}
+@SOS_RPM_PREFIXED@%dir %{_bindir}
+@SOS_RPM_PREFIXED@%dir %{_libdir}
+@SOS_RPM_PREFIXED@%dir %{_includedir}
+@SOS_RPM_PREFIXED@%dir %{_mandir}
+@SOS_RPM_PREFIXED@%dir %{_mandir}/man[1-3]
 %{_bindir}/*
 %{_libdir}/lib*.so
 %{_libdir}/*.a
@@ -80,7 +94,9 @@ rm -rf %{buildroot}
 
 %files tests
 %defattr(-,root,root)
+@SOS_RPM_PREFIXED@%dir %{_prefix}
+@SOS_RPM_PREFIXED@%dir %{_datadir}
+@SOS_RPM_PREFIXED@%dir %{_datadir}/%{name}-%{version}
 %{_datadir}/%{name}-%{version}/tests
-
 
 %changelog

--- a/sandia-openshmem.spec.in
+++ b/sandia-openshmem.spec.in
@@ -1,7 +1,7 @@
 %{!?configargs: %global configargs %{nil}}
 %{!?testdir: %global testdir %{buildroot}%{_datadir}/%{name}-%{version}/tests}
 
-Name: sos
+Name: sandia-openshmem
 Version: @VERSION@
 Release: 1%{?dist}
 Summary: Sandia OpenSHMEM.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,7 +130,7 @@ libsma_la_SOURCES += \
 	runtime-pmix.c
 endif
 
-pkgconfig_DATA = sos.pc
+pkgconfig_DATA = sandia-openshmem.pc
 
 bin_SCRIPTS = oshcc oshrun
 CLEANFILES += oshcc oshrun

--- a/src/sandia-openshmem.pc.in
+++ b/src/sandia-openshmem.pc.in
@@ -6,7 +6,7 @@ exec_prefix=@exec_prefix@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: sos
+Name: sandia-openshmem
 Description: @PACKAGE_NAME@
 URL: @PACKAGE_URL@
 Version: @VERSION@


### PR DESCRIPTION
* Update RPM build to cleanly uninstall when `%{_prefix} != /usr`
* Installs docs (README, LICENSE, etc.) under /usr/share as part of standard installation (simplifies RPM)
* Rename packaging from sos to sandia-openshmem to avoid name conflict with https://github.com/sosreport/sos