### PR TITLE
Fix inline assembly for SPINLOCK_BODY for aarch64.

### DIFF
--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -20,6 +20,8 @@
 
 #if defined(__i386__) || defined(__x86_64__)
 # define SPINLOCK_BODY() do { __asm__ __volatile__ ("pause" ::: "memory"); } while (0)
+#elif defined(__aarch64__)
+# define SPINLOCK_BODY() do { __asm__ __volatile__ ("dsb ld" ::: "memory"); } while (0)
 #else
 # define SPINLOCK_BODY() do { __asm__ __volatile__ ("" ::: "memory"); } while (0)
 #endif


### PR DESCRIPTION
Signed-off-by: Srđan Milaković <sm108@rice.edu>