### PR TITLE
Check for sched_getaffinity, and include in DEBUG

### DIFF
--- a/config/check_sched_getaffinity.m4
+++ b/config/check_sched_getaffinity.m4
@@ -1,0 +1,19 @@
+#CHECK_SCHED_GETAFFINITY([action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if sched_getaffinity is available.
+AC_DEFUN([CHECK_SCHED_GETAFFINITY], [
+    AC_MSG_CHECKING([sched_getaffinity definition])
+    AC_LANG_PUSH([C])
+    AC_COMPILE_IFELSE([
+       AC_LANG_SOURCE([[
+#define _GNU_SOURCE
+#include <sched.h>
+cpu_set_t my_set;
+int main() {CPU_ZERO(&my_set); sched_getaffinity(0, sizeof(my_set), &my_set);}
+]])],
+       [sched_getaffinity_happy="yes"],
+       [sched_getaffinity_happy="no"])
+    AC_LANG_POP([C])
+    AC_MSG_RESULT([$sched_getaffinity_happy])
+    AS_IF([test "$sched_getaffinity_happy" = "yes"], [$1], [$2])
+])

--- a/config/check_sched_getaffinity.m4
+++ b/config/check_sched_getaffinity.m4
@@ -9,7 +9,7 @@ AC_DEFUN([CHECK_SCHED_GETAFFINITY], [
 #define _GNU_SOURCE
 #include <sched.h>
 cpu_set_t my_set;
-int main() {CPU_ZERO(&my_set); sched_getaffinity(0, sizeof(my_set), &my_set);}
+int main() {CPU_ZERO(&my_set); sched_getaffinity(0, sizeof(my_set), &my_set); return 0;}
 ]])],
        [sched_getaffinity_happy="yes"],
        [sched_getaffinity_happy="no"])

--- a/configure.ac
+++ b/configure.ac
@@ -312,6 +312,9 @@ AC_CACHE_SAVE
 AC_SEARCH_LIBS([clock_gettime], [rt],
                [AC_DEFINE([HAVE_CLOCK_GETTIME], [1], [define if clock_gettime is available]) ])
 
+CHECK_SCHED_GETAFFINITY(
+    [AC_DEFINE([HAVE_SCHED_GETAFFINITY], [1], [define if sched_getaffinity is available])], [])
+
 dnl check for libraries
 
 OMPI_CHECK_PORTALS4([portals4],

--- a/src/init.c
+++ b/src/init.c
@@ -313,12 +313,11 @@ shmem_internal_init(int tl_requested, int *tl_provided)
         if (ret == 0) {
             char *cores_str = malloc(sizeof(char) * CPU_SETSIZE * 5 + 2);
             strcpy(cores_str," ");
+            size_t off = 1; /* start after " " */
             for (int i = 0; i < CPU_SETSIZE; i++) {
                 if (CPU_ISSET(i, &my_set)) {
                     core_count++;
-                    char cpunum[5];
-                    sprintf(cpunum, "%d ", i);
-                    strcat(cores_str, cpunum);
+                    off += snprintf(cores_str+off, CPU_SETSIZE*5+2-off, "%d ", i);
                 }
             }
             DEBUG_MSG("affinity to %d processor cores: {%s}\n", core_count, cores_str);


### PR DESCRIPTION
I found this output useful for understanding what exactly is happening when passing process affinity options to the launcher such as `--bind-to core:2` or `--bind-to socket:1`.  Because it depends on `sched_getaffinity`, it'll only work in Linux.