### PR TITLE
Release the ctx lock while blocked

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1461,6 +1461,15 @@ int shmem_transport_init(void)
     shmem_transport_ofi_put_poll_limit = shmem_internal_params.OFI_TX_POLL_LIMIT;
     shmem_transport_ofi_get_poll_limit = shmem_internal_params.OFI_RX_POLL_LIMIT;
 
+#ifdef USE_CTX_LOCK
+    /* In multithreaded mode, force completion polling so that threads yield
+     * the lock during put/get completion operations */
+    if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE) {
+        shmem_transport_ofi_put_poll_limit = -1;
+        shmem_transport_ofi_get_poll_limit = -1;
+    }
+#endif
+
     shmem_transport_ctx_default.options = SHMEMX_CTX_BOUNCE_BUFFER;
 
     ret = shmem_transport_ofi_ctx_init(&shmem_transport_ctx_default, SHMEM_TRANSPORT_CTX_DEFAULT_ID);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1463,10 +1463,13 @@ int shmem_transport_init(void)
 
 #ifdef USE_CTX_LOCK
     /* In multithreaded mode, force completion polling so that threads yield
-     * the lock during put/get completion operations */
+     * the lock during put/get completion operations.  User can still override
+     * (get blocking behavior) by setting the env vars. */
     if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE) {
-        shmem_transport_ofi_put_poll_limit = -1;
-        shmem_transport_ofi_get_poll_limit = -1;
+        if (!shmem_internal_params.OFI_TX_POLL_LIMIT_provided)
+            shmem_transport_ofi_put_poll_limit = -1;
+        if (!shmem_internal_params.OFI_RX_POLL_LIMIT_provided)
+            shmem_transport_ofi_get_poll_limit = -1;
     }
 #endif
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -446,7 +446,9 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
         shmem_transport_probe();
 
         if (success < cnt && fail == 0) {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
             SPINLOCK_BODY();
+            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
         } else if (fail) {
             RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
         } else {
@@ -749,7 +751,9 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
         shmem_transport_probe();
 
         if (success < cnt && fail == 0) {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
             SPINLOCK_BODY();
+            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
         } else if (fail) {
             RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
         } else {


### PR DESCRIPTION
We may also want to ensure that we perform completion polling when `USE_CTX_LOCK` is enabled and the threading level is `SHMEM_THREAD_MULTIPLE`.