### PR TITLE
Comment out test-mellanox's basic:static test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -334,7 +334,7 @@ script:
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:get
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:put
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:barrier
-    - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:static
+    #- oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:static
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:heap
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=basic:fence
     - oshrun -np 4 $PWD/install/bin/oshmem_test exec --task=coll


### PR DESCRIPTION
There is an issue with `tests-mellanox` that is causing our test suite to report failures.  A fix to that issue is here: https://github.com/openshmem-org/tests-mellanox/pull/38

We should just comment out this test for now, and bring it back after the fix is merged.