### PR TITLE
TESTS: added external tests build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,6 @@ AC_C_INLINE
 AC_PROG_CXX dnl required even with --disable-cxx due to automake conditionals
 m4_ifdef([AM_PROG_AR],[AM_PROG_AR])
 AC_PATH_PROG([PERL],[perl])
-AM_CONDITIONAL([EXTERNAL_TESTS], [false])
 AM_CONDITIONAL([SHMEMX_TESTS], [true])
 
 dnl C++ bindings require std::is_same, which is part of C++11
@@ -390,6 +389,11 @@ AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
        AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
+
+AC_ARG_ENABLE([external-tests], [AC_HELP_STRING([--enable-external-tests],
+              [Build tests using external SHMEM infrastructure (default: disabled)]),
+              [], [enable_external_tests=no]])
+AM_CONDITIONAL([EXTERNAL_TESTS], [test "$enable_external_tests" = "yes"])
 
 AC_ARG_ENABLE([pmi-simple], [AC_HELP_STRING([--enable-pmi-simple],
               [Use MPICH simple PMI-1 library for process management])])

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -11,6 +11,9 @@
 # information, see the LICENSE file in the top level directory of the
 # distribution.
 
+tests: all-am
+	$(MAKE) $(AM_MAKEFLAGS) $(check_PROGRAMS)
+
 check_PROGRAMS = \
 	hello \
 	pi \
@@ -182,10 +185,9 @@ else
 AM_CPPFLAGS = -I$(top_builddir)/mpp -I$(top_srcdir)/test/include
 AM_FCFLAGS = -I$(top_builddir)/mpp
 LDADD = $(top_builddir)/src/libsma.la
-endif
-
 if USE_PMI_SIMPLE
 LDADD += $(top_builddir)/pmi-simple/libpmi_simple.la
+endif
 endif
 
 # C Tests with special flags


### PR DESCRIPTION
- added configure switch --enable-external-tests to enable build of unit
  tests using external infrastructure
- added build target to unit tests to build tests only, without
  test run

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>