### PR TITLE
Wrap affinity debug message

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -183,11 +183,6 @@ shmem_internal_init(int tl_requested, int *tl_provided)
 #endif
     int randr_initialized     = 0;
 
-#ifdef HAVE_SCHED_GETAFFINITY
-    cpu_set_t my_set;
-    int core_count = 0;
-#endif
-
     /* set up threading */
     SHMEM_MUTEX_INIT(shmem_internal_mutex_alloc);
 #ifdef ENABLE_THREADS
@@ -339,24 +334,37 @@ shmem_internal_init(int tl_requested, int *tl_provided)
 
 #ifdef HAVE_SCHED_GETAFFINITY
     if (shmem_internal_params.DEBUG) {
+        cpu_set_t my_set;
+
         CPU_ZERO(&my_set);
 
         ret = sched_getaffinity(0, sizeof(my_set), &my_set);
 
         if (ret == 0) {
-            char *cores_str = malloc(sizeof(char) * CPU_SETSIZE * 5 + 2);
-            if (NULL == cores_str) goto cleanup;
+            char cores_str[SHMEM_INTERNAL_DIAG_STRLEN];
+            char *cores_str_wrap;
+            int core_count = 0;
 
-            strcpy(cores_str," ");
-            size_t off = 1; /* start after " " */
+            for (int i = 0; i < CPU_SETSIZE; i++) {
+                if (CPU_ISSET(i, &my_set))
+                    core_count++;
+            }
+
+            size_t off = snprintf(cores_str, sizeof(cores_str),
+                                  "Affinity to %d processor cores: { ", core_count);
+
             for (int i = 0; i < CPU_SETSIZE; i++) {
                 if (CPU_ISSET(i, &my_set)) {
-                    core_count++;
-                    off += snprintf(cores_str+off, CPU_SETSIZE*5+2-off, "%d ", i);
+                    off += snprintf(cores_str+off, sizeof(cores_str)-off, "%d ", i);
+                    if (off >= sizeof(cores_str)) break;
                 }
             }
-            DEBUG_MSG("affinity to %d processor cores: {%s}\n", core_count, cores_str);
-            free(cores_str);
+            if (off < sizeof(cores_str)-1)
+                off += snprintf(cores_str+off, sizeof(cores_str)-off, "}");
+
+            cores_str_wrap = shmem_util_wrap(cores_str, 72, "              ");
+            DEBUG_MSG("%s\n", cores_str_wrap);
+            free(cores_str_wrap);
         }
     }
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -362,7 +362,8 @@ shmem_internal_init(int tl_requested, int *tl_provided)
             if (off < sizeof(cores_str)-1)
                 off += snprintf(cores_str+off, sizeof(cores_str)-off, "}");
 
-            cores_str_wrap = shmem_util_wrap(cores_str, 72, "              ");
+            cores_str_wrap = shmem_util_wrap(cores_str, SHMEM_INTERNAL_DIAG_WRAPLEN,
+                                             RAISE_PREFIX);
             DEBUG_MSG("%s\n", cores_str_wrap);
             free(cores_str_wrap);
         }

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -44,9 +44,11 @@ extern unsigned int shmem_internal_rand_seed;
 
 #define SHMEM_INTERNAL_HEAP_OVERHEAD (1024*1024)
 #define SHMEM_INTERNAL_DIAG_STRLEN 1024
+#define SHMEM_INTERNAL_DIAG_WRAPLEN 72
 
 /* Note: must be accompanied by shmem_internal_my_pe in arguments */
 #define RAISE_PE_PREFIX "[%04d]        "
+#define RAISE_PREFIX    "              "
 
 
 #define RAISE_WARN(ret)                                                 \


### PR DESCRIPTION
A few updates to build the full affinity message into the string buffer so it can be wrapped.

```
Sandia OpenSHMEM 1.4.2
Build information:
  Git Version           v1.4.2-104-gcd14f8e2 (master)
  Configure Args        '--enable-pmi-simple'
                        '--with-ofi=/home/dinanjam/opt/libfabric-dev'
                        '--disable-libtool-wrapper' '--enable-picky'
                        '--enable-manual-progress'
                        '--prefix=/home/dinanjam/opt/sos-dev'
  Build Date            Tue Dec 18 12:28:08 CST 2018
  Build CC              gcc -std=gnu99
  Build CFLAGS          -g -O2 -Wall -Wno-long-long -Wmissing-prototypes
                        -Wstrict-prototypes -Wcomment -pedantic -rdynamic 

[0000] DEBUG: ../../src/init.c:333: shmem_internal_init
[0000]        Thread level=SINGLE, Num. PEs=1
[0000]        Sym. heap=0x80000000 len=537919488 -- data=0x601050 len=8
[0000] DEBUG: ../../src/init.c:366: shmem_internal_init
[0000]        Affinity to 72 processor cores: { 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
              16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39
              40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63
              64 65 66 67 68 69 70 71 }
[0000] DEBUG: ../../src/transport_ofi.c:1217: query_for_fabric
[0000]        OFI provider: psm2, fabric: psm2, domain: psm2
[0000]        max_inject: 16, max_msg: 4294967295
[0000] DEBUG: ../../src/transport_ofi.c:1060: allocate_fabric_resources
[0000]        OFI version: built 1.7, cur. 1.7; provider version: 1.7
[0000] DEBUG: ../../src/transport_ofi.c:523: shmem_transport_ofi_stx_allocate
[0000]        STX[1] = [ 1S ]
Hello World from 0 of 1
[0000] DEBUG: ../../src/transport_ofi.c:1554: shmem_transport_ctx_destroy
[0000]        id = -1, options = 0x80000000, stx_idx = 0
[0000]        pending_put_cntr =         0, completed_put_cntr =         0
[0000]        pending_get_cntr =         0, completed_get_cntr =         0
[0000]        pending_bb_cntr  =         0, completed_bb_cntr  =         0
```