### PR TITLE
Minor README patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# ![SOS logo](https://raw.githubusercontent.com/davidozog/sandia-shmem/pr/readme_markdown/extra/SOS.png) Sandia OpenSHMEM ![SOS logo](https://raw.githubusercontent.com/davidozog/sandia-shmem/pr/readme_markdown/extra/SOS.png)
-<!-- TODO: update davidozog/pr/readme_markdown -> Sandia-OpenSHMEM/SOS -->
-[![GitHub version](https://badge.fury.io/gh/Sandia-OpenSHMEM%2FSOS.svg)](https://badge.fury.io/gh/Sandia-OpenSHMEM%2FSOS)
+# ![SOS logo](https://raw.githubusercontent.com/Sandia-OpenSHMEM/SOS/master/extra/SOS.png) Sandia OpenSHMEM ![SOS logo](https://raw.githubusercontent.com/Sandia-OpenSHMEM/SOS/master/extra/SOS.png)
+[![SOS release version](https://img.shields.io/github/release/Sandia-OpenSHMEM/SOS.svg)](https://github.com/Sandia-OpenSHMEM/SOS/releases/latest)
 [![Build Status](https://travis-ci.org/Sandia-OpenSHMEM/SOS.svg?branch=master)](https://travis-ci.org/Sandia-OpenSHMEM/SOS)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/9375/badge.svg)](https://scan.coverity.com/projects/9375)
 


### PR DESCRIPTION
This links the SOS logo to the official master-branch location and changes the version badge to use [img.shields.io](https://img.shields.io), which appears to be less finicky than [badge.fury.io](https://badge.fury.io).

Side note: the landing page for the Travis badge (which defaults to the latest PR, not the latest master build) appears to be a "won't fix" issue that's been closed years ago:
https://github.com/travis-ci/travis-ci/issues/655
https://github.com/certbot/certbot/issues/927

I think our valid options are to 1) leave it as is, 2) remove it, 3) link to the ["branches" page](https://travis-ci.org/Sandia-OpenSHMEM/SOS/branches), or 4) link to the ["builds" page](https://travis-ci.org/Sandia-OpenSHMEM/SOS/builds).  I don't see any way to link to the latest master build...