### PR TITLE
travis: misc prrte related changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,14 +155,6 @@ before_install:
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
     - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
-    ## Build Libevent
-    - cd $TRAVIS_SRC
-    - wget https://github.com/libevent/libevent/releases/download/release-2.1.8-stable/libevent-2.1.8-stable.tar.gz
-    - tar -xzvf libevent-2.1.8-stable.tar.gz
-    - cd libevent-2.1.8-stable
-    - ./autogen.sh
-    - ./configure --prefix=$TRAVIS_INSTALL/libevent
-    - make install
     ## Build hwloc
     - cd $TRAVIS_SRC
     - wget https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.3.tar.gz
@@ -175,14 +167,14 @@ before_install:
     - git clone --depth 10 https://github.com/pmix/pmix pmix
     - cd pmix
     - ./autogen.pl
-    - ./configure --prefix=$TRAVIS_INSTALL/pmix --with-libevent=$TRAVIS_INSTALL/libevent --with-platform=optimized
+    - ./configure --prefix=$TRAVIS_INSTALL/pmix --with-platform=optimized
     - make install
     ## Build PRRTE
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/pmix/prrte prrte
     - cd prrte
     - ./autogen.pl
-    - ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --with-libevent=$TRAVIS_INSTALL/libevent --with-hwloc=$TRAVIS_INSTALL/hwloc --without-slurm
+    - ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --with-hwloc=$TRAVIS_INSTALL/hwloc --without-slurm
     - make install
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ script:
     - ../configure --prefix=$PWD/install --with-ofi=$TRAVIS_INSTALL/libfabric --with-pmix=$TRAVIS_INSTALL/pmix
     - make $TRAVIS_PAR_MAKE
     - make $TRAVIS_PAR_MAKE check TESTS=
-    - prte &
+    - prte --daemonize
     - make VERBOSE=1 TEST_RUNNER="prun -host localhost -oversubscribe -np 2" check
     - prun -terminate
     - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ addons:
             - mpich
             - libmpich-dev
             - cargo
+            - libevent-dev
+            - libhwloc-dev
 before_install:
     ## Set up the environment
     - mkdir $HOME/travis
@@ -155,13 +157,6 @@ before_install:
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
     - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
-    ## Build hwloc
-    - cd $TRAVIS_SRC
-    - wget https://download.open-mpi.org/release/hwloc/v2.0/hwloc-2.0.3.tar.gz
-    - tar xvzf hwloc-2.0.3.tar.gz
-    - cd hwloc-2.0.3
-    - ./configure --prefix=$TRAVIS_INSTALL/hwloc
-    - make install
     ## Build PMIx
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/pmix/pmix pmix
@@ -174,7 +169,7 @@ before_install:
     - git clone --depth 10 https://github.com/pmix/prrte prrte
     - cd prrte
     - ./autogen.pl
-    - ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --with-hwloc=$TRAVIS_INSTALL/hwloc --without-slurm
+    - ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --without-slurm
     - make install
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -239,7 +239,7 @@ script:
     - make $TRAVIS_PAR_MAKE check TESTS=
     - prte &
     - make VERBOSE=1 TEST_RUNNER="prun -host localhost -oversubscribe -np 2" check
-    - killall prte
+    - prun -terminate
     - make install
     ###
     ### Run the UH test suite (Portals)


### PR DESCRIPTION
- use distro provided `libevent` and `hwloc` to reduce build time
- use `prun -terminate` in order to kill the `prte` daemon (instead of `killall prte`)
- use `prun --daemonize` in order to start the `prte` daemon (instead of `prte&; sleep2`)