### PR TITLE
Add name to shmem_ctx_t dummy struct for C++ fix

### DIFF
--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -73,7 +73,7 @@ extern "C" {
 #define SHMEM_THREAD_MULTIPLE   3
 
 /* Contexts */
-typedef struct { int dummy; } * shmem_ctx_t;
+typedef struct shmem_impl_ctx_t { int dummy; } * shmem_ctx_t;
 
 #if SHMEM_HAVE_ATTRIBUTE_VISIBILITY == 1
   __attribute__((visibility("default"))) extern shmem_ctx_t SHMEM_CTX_DEFAULT;


### PR DESCRIPTION
A developer/collegue reported a C++ error in regards to our `shmem_ctx_t` dummy struct:
`...<unnamed struct> declared using unnamed type, is used but never defined`.
C++ apparently does not support anonymous structs, so we might need to give it a name.

Note: this name is technically not allowed by the OpenSHMEM specification - perhaps we should propose a sub-namespace such as `shmem_impl_*` to address this?  See [this ticket](https://github.com/openshmem-org/specification/issues/262).

