### PR TITLE
Add target CQ and use for manual progress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,36 +26,41 @@ env:
     matrix:
         ## Portals Builds
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-cxx --enable-memcpy --enable-pmi-simple"
         - >
-          SOS_DISABLE_FORTRAN=1
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--enable-pmi-mpi CC=mpicc"
         - >
-          SOS_DISABLE_FORTRAN=1
+          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-fortran --enable-error-checking --enable-remote-virtual-addressing --disable-aslr-check --enable-pmi-simple"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_ENABLE_ERROR_TESTS=1 SHMEM_SYMMETRIC_HEAP_USE_MALLOC=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-threads --enable-error-checking --enable-pmi-simple"
         - >
-          SOS_DISABLE_FORTRAN=1
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-error-checking --enable-pmi-simple"
         - >
-          SOS_ENABLE_ERROR_TESTS=1
+          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
           SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1 SHMEM_BOUNCE_SIZE=0
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-ofi-fence"
@@ -112,7 +117,7 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress"
         - >
-          SOS_ENABLE_ERROR_TESTS=1
+          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
           SHMEM_BARRIER_ALGORITHM=dissem SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
           SHMEM_OFI_STX_AUTO=1
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
@@ -296,7 +301,7 @@ script:
     ###
     ### Portals builds stop here
     ###
-    - if [[ $SOS_TRANSPORT_OPTS = *"with-portals4"* ]]; then travis_terminate $TRAVIS_TEST_RESULT; fi
+    - if [ -n "SOS_DISABLE_EXTERNAL_TESTS" ]; then travis_terminate $TRAVIS_TEST_RESULT; fi
     ###
     ### Run the UH test suite
     ###

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,13 +110,13 @@ env:
           SHMEM_BARRIER_ALGORITHM=tree SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
           SHMEM_OFI_STX_MAX=0
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
-          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
+          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress"
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SHMEM_BARRIER_ALGORITHM=dissem SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
           SHMEM_OFI_STX_AUTO=1
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
-          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
+          SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress --enable-hard-polling"
         - >
           SOS_ENABLE_ERROR_TESTS=1
           SHMEM_FCOLLECT_ALGORITHM=ring

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1216,7 +1216,7 @@ static int shmem_transport_ofi_target_ep_init(void)
 #if ENABLE_TARGET_CNTR
     info->p_info->caps |= FI_RMA_EVENT;
 #endif
-    info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+    info->p_info->tx_attr->op_flags = 0;
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -328,14 +328,10 @@ void shmem_transport_probe(void)
 #  ifdef USE_THREAD_COMPLETION
     if (0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
 #  endif
-#  if ENABLE_TARGET_CNTR
-        fi_cntr_read(shmem_transport_ofi_target_cntrfd);
-#  else
         struct fi_cq_entry buf;
         int ret = fi_cq_read(shmem_transport_ofi_target_cq, &buf, 1);
         if (ret == 1)
             RAISE_WARN_STR("Unexpected event");
-#  endif
 #  ifdef USE_THREAD_COMPLETION
         pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
     }

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -41,7 +41,8 @@
 
 #if ENABLE_TARGET_CNTR
 extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;
-#else
+#endif
+#if ENABLE_MANUAL_PROGRESS
 extern struct fid_cq*                   shmem_transport_ofi_target_cq;
 #endif
 #ifndef ENABLE_MR_SCALABLE


### PR DESCRIPTION
With this patch, manual progress no longer requires the target cntr and can be independent of hard polling in wait operations.