### PR TITLE
Fix preinit error message output

### DIFF
--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -49,8 +49,9 @@ extern unsigned int shmem_internal_rand_seed;
 #define SHMEM_INTERNAL_DIAG_WRAPLEN 72
 
 /* Note: must be accompanied by shmem_internal_my_pe in arguments */
-#define RAISE_PE_PREFIX "[%04d]        "
-#define RAISE_PREFIX    "              "
+#define RAISE_PE_PREFIX      "[%04d]        "
+#define RAISE_PREINIT_PREFIX "[????]        "
+#define RAISE_PREFIX         "              "
 
 
 #define RAISE_WARN(ret)                                                 \
@@ -134,8 +135,7 @@ extern unsigned int shmem_internal_rand_seed;
         size_t off;                                                     \
         off = snprintf(str, sizeof(str), "[????] ERROR: %s:%d: %s\n",   \
                        __FILE__, __LINE__, __func__);                   \
-        off+= snprintf(str+off, sizeof(str)-off, RAISE_PE_PREFIX,       \
-                       shmem_internal_my_pe);                           \
+        off+= snprintf(str+off, sizeof(str)-off, RAISE_PREINIT_PREFIX); \
         off+= snprintf(str+off, sizeof(str)-off, __VA_ARGS__);          \
         fprintf(stderr, "%s", str);                                     \
     } while (0)


### PR DESCRIPTION
Don't print the PE id before it's been set.  This error macro is used during PMIx startup.

Before:
```
[????] ERROR: ../../src/init.c:174: shmem_internal_init
[-001]        Something bad happened
```
After:
```
[????] ERROR: ../../src/init.c:174: shmem_internal_init
[????]        Something bad happened
```