### PR TITLE
Fix global_exit seg fault when no backtracing method is available.

### DIFF
--- a/src/backtrace.c
+++ b/src/backtrace.c
@@ -181,6 +181,8 @@ void backtrace_gdb(void) {
 void shmem_util_backtrace(void) {
     char *method = shmem_internal_params.BACKTRACE;
 
+    if (!method) return;
+
     if (0 == strcmp(method, "execinfo")) {
 #if defined(USE_BT_EXECINFO)
         backtrace_execinfo();


### PR DESCRIPTION
This is a quick fix for #866.