### PR TITLE
Don't deref null fi_cntr pointer in debug msg

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1600,9 +1600,11 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
                   RAISE_PE_PREFIX "pending_bb_cntr  = %9"PRIu64", completed_bb_cntr  = %9"PRIu64"\n",
                   ctx->id, (unsigned long) ctx->options, ctx->stx_idx,
                   shmem_internal_my_pe,
-                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr), fi_cntr_read(ctx->put_cntr),
+                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr),
+                  ctx->put_cntr ? fi_cntr_read(ctx->put_cntr) : 0,
                   shmem_internal_my_pe,
-                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr), fi_cntr_read(ctx->get_cntr),
+                  SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr),
+                  ctx->get_cntr ? fi_cntr_read(ctx->get_cntr) : 0,
                   shmem_internal_my_pe,
                   ctx->pending_bb_cntr, ctx->completed_bb_cntr
                  );


### PR DESCRIPTION
When `ctx_destroy` is called to clean up a failed `ctx_init` operation, the debug message could dereference null pointers to the FI cntrs on the context.  Add check before dereferencing these pointers.