### PR TITLE
Add weak symbol definition for shmem_global_exit

### DIFF
--- a/src/init_c.c
+++ b/src/init_c.c
@@ -45,6 +45,9 @@
 #pragma weak shmem_query_thread = pshmem_query_thread
 #define shmem_query_thread pshmem_query_thread
 
+#pragma weak shmem_global_exit = pshmem_global_exit
+#define shmem_global_exit pshmem_global_exit
+
 #endif /* ENABLE_PROFILING */
 
 void SHMEM_FUNCTION_ATTRIBUTES


### PR DESCRIPTION
This fixes an undefined reference to `pshmem_global_exit`, due to a missing weak symbol declaration.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>