### PR TITLE
Add bandwidth optimal ring all-reduce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,11 @@ env:
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress --enable-hard-polling"
         - >
           SOS_ENABLE_ERROR_TESTS=1
+          SHMEM_REDUCE_ALGORITHM=ring
+          SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
+          SOS_BUILD_OPTS="--enable-error-checking --enable-pmi-simple"
+        - >
+          SOS_ENABLE_ERROR_TESTS=1
           SHMEM_FCOLLECT_ALGORITHM=ring
           SHMEM_OFI_TX_POLL_LIMIT=1 SHMEM_OFI_RX_POLL_LIMIT=1
           SHMEM_OFI_STX_THRESHOLD=1024

--- a/README
+++ b/README
@@ -128,6 +128,10 @@ options.
         For num_pes < SHMEM_COLL_CROSSOVER, collective algorithms are
         serial instead of tree based.
 
+    SHMEM_COLL_SIZE_CROSSOVER (default: 16kiB)
+        For size < SHMEM_COLL_SIZE_CROSSOVER, collective algorithms are
+        optimized for latency, rather than bandwidth.
+
     SHMEM_COLL_RADIX (default: 4)
         Controls the width of the n-ary tree for collectives, such that each
         node will fanout-send to a max of approximately SHMEM_COLL_RADIX

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -198,6 +198,8 @@ shmem_internal_collectives_init(void)
             shmem_internal_reduce_type = AUTO;
         } else if (0 == strcmp(type, "linear")) {
             shmem_internal_reduce_type = LINEAR;
+        } else if (0 == strcmp(type, "ring")) {
+            shmem_internal_reduce_type = RING;
         } else if (0 == strcmp(type, "tree")) {
             shmem_internal_reduce_type = TREE;
         } else if (0 == strcmp(type, "recdbl")) {
@@ -629,6 +631,89 @@ shmem_internal_op_to_all_linear(void *target, const void *source, int count, int
     /* broadcast out */
     shmem_internal_bcast(target, target, count * type_size, 0, PE_start,
                          logPE_stride, PE_size, pSync + 2, 0);
+}
+
+
+void
+shmem_internal_op_to_all_ring(void *target, const void *source, int count, int type_size,
+                              int PE_start, int logPE_stride, int PE_size,
+                              void *pWrk, long *pSync,
+                              shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+    int stride = 1 << logPE_stride;
+    int group_rank = (shmem_internal_my_pe - PE_start) / stride;
+    long zero = 0, one = 1;
+    long completion = 0;
+
+    int peer = PE_start + ((group_rank + 1) % PE_size) * stride;
+    size_t chunk_count = count/PE_size; /* FIXME: cases were count % PE_size > 0 */
+
+    /* One slot for reduce-scatter and another for the allgather */
+    shmem_internal_assert(SHMEM_REDUCE_SYNC_SIZE >= 2);
+
+    if (count == 0) return;
+
+    /* Perform reduce-scatter:
+     *
+     * The source buffer is divided into PE_size chunks.  PEs send data to the
+     * right around the ring, starting with the chunk index equal to the PE id
+     * and decreasing.  For example, with 4 PEs, PE 0 sends chunks 0, 3, 2 and
+     * PE 1 sends chunks 1, 0, 3.  At the end, each PE has the reduced chunk
+     * corresponding to its PE id + 1.
+     */
+    for (int i = 0; i < PE_size - 1; i++) {
+        int chunk_in  = (group_rank - i - 1 + PE_size) % PE_size;
+        int chunk_out = (group_rank - i + PE_size) % PE_size;
+
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT,
+                              ((uint8_t *) target) + chunk_out * chunk_count * type_size,
+                              i == 0 ?
+                              ((uint8_t *) source) + chunk_out * chunk_count * type_size :
+                              ((uint8_t *) target) + chunk_out * chunk_count * type_size,
+                              chunk_count * type_size,
+                              peer, &completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
+        shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
+                              peer, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+
+        /* Wait for chunk */
+        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_GE, i+1);
+
+        shmem_internal_reduce_local(op, datatype, chunk_count,
+                                    ((uint8_t *) source) + chunk_in * chunk_count * type_size,
+                                    ((uint8_t *) target) + chunk_in * chunk_count * type_size);
+    }
+
+    /* Reset reduce-scatter pSync */
+    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+    SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+
+    /* Perform all-gather:
+     *
+     * Initially, each PE has the reduced chunk for PE id + 1.  Forward chunks
+     * around the ring until all PEs have all chunks.
+     */
+    for (int i = 0; i < PE_size - 1; i++) {
+        int chunk_out = (group_rank + 1 - i + PE_size) % PE_size;
+
+        shmem_internal_put_nb(SHMEM_CTX_DEFAULT,
+                              ((uint8_t *) target) + chunk_out * chunk_count * type_size,
+                              ((uint8_t *) target) + chunk_out * chunk_count * type_size,
+                              chunk_count * type_size,
+                              peer, &completion);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+        shmem_internal_fence(SHMEM_CTX_DEFAULT);
+        shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync+1, &one, sizeof(one),
+                              peer, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+
+        /* Wait for chunk */
+        SHMEM_WAIT_UNTIL(pSync+1, SHMEM_CMP_GE, i+1);
+    }
+
+    /* reset pSync */
+    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync+1, &zero, sizeof(zero), shmem_internal_my_pe);
+    SHMEM_WAIT_UNTIL(pSync+1, SHMEM_CMP_EQ, 0);
 }
 
 

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -182,9 +182,14 @@ shmem_internal_op_to_all(void *target, const void *source, int count,
                                                   pWrk, pSync, op, datatype);
                 }
             } else {
-                shmem_internal_op_to_all_recdbl_sw(target, source, count, type_size,
-                                                   PE_start, logPE_stride, PE_size,
-                                                   pWrk, pSync, op, datatype);
+                if (count * type_size < shmem_internal_params.COLL_SIZE_CROSSOVER)
+                    shmem_internal_op_to_all_recdbl_sw(target, source, count, type_size,
+                                                       PE_start, logPE_stride, PE_size,
+                                                       pWrk, pSync, op, datatype);
+                else
+                    shmem_internal_op_to_all_ring(target, source, count, type_size,
+                                                  PE_start, logPE_stride, PE_size,
+                                                  pWrk, pSync, op, datatype);
             }
 
             break;

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -148,9 +148,9 @@ void shmem_internal_op_to_all_linear(void *target, const void *source, int count
                                      void *pWrk, long *pSync,
                                      shm_internal_op_t op, shm_internal_datatype_t datatype);
 void shmem_internal_op_to_all_ring(void *target, const void *source, int count, int type_size,
-                                     int PE_start, int logPE_stride, int PE_size,
-                                     void *pWrk, long *pSync,
-                                     shm_internal_op_t op, shm_internal_datatype_t datatype);
+                                   int PE_start, int logPE_stride, int PE_size,
+                                   void *pWrk, long *pSync,
+                                   shm_internal_op_t op, shm_internal_datatype_t datatype);
 void shmem_internal_op_to_all_tree(void *target, const void *source, int count, int type_size,
                                    int PE_start, int logPE_stride, int PE_size,
                                    void *pWrk, long *pSync,
@@ -169,6 +169,8 @@ shmem_internal_op_to_all(void *target, const void *source, int count,
                          shm_internal_op_t op,
                          shm_internal_datatype_t datatype)
 {
+    shmem_internal_assert(type_size > 0);
+
     switch (shmem_internal_reduce_type) {
         case AUTO:
             if (shmem_transport_atomic_supported(op, datatype)) {

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -147,6 +147,10 @@ void shmem_internal_op_to_all_linear(void *target, const void *source, int count
                                      int PE_start, int logPE_stride, int PE_size,
                                      void *pWrk, long *pSync,
                                      shm_internal_op_t op, shm_internal_datatype_t datatype);
+void shmem_internal_op_to_all_ring(void *target, const void *source, int count, int type_size,
+                                     int PE_start, int logPE_stride, int PE_size,
+                                     void *pWrk, long *pSync,
+                                     shm_internal_op_t op, shm_internal_datatype_t datatype);
 void shmem_internal_op_to_all_tree(void *target, const void *source, int count, int type_size,
                                    int PE_start, int logPE_stride, int PE_size,
                                    void *pWrk, long *pSync,
@@ -194,6 +198,11 @@ shmem_internal_op_to_all(void *target, const void *source, int count,
                                                    PE_start, logPE_stride, PE_size,
                                                    pWrk, pSync, op, datatype);
             }
+            break;
+        case RING:
+            shmem_internal_op_to_all_ring(target, source, count, type_size,
+                                          PE_start, logPE_stride, PE_size,
+                                          pWrk, pSync, op, datatype);
             break;
         case TREE:
             if (shmem_transport_atomic_supported(op, datatype)) {

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -54,7 +54,7 @@ SHMEM_INTERNAL_ENV_DEF(TRAP_ON_ABORT, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
 SHMEM_INTERNAL_ENV_DEF(COLL_CROSSOVER, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Crossover between linear and tree collectives (num. PEs)")
 SHMEM_INTERNAL_ENV_DEF(COLL_SIZE_CROSSOVER, size, 16384, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
-                       "Crossover between linear and tree collectives (msg. size)")
+                       "Crossover between latency and bandwidth optimized collectives (msg. size)")
 SHMEM_INTERNAL_ENV_DEF(COLL_RADIX, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Radix for tree-based collectives")
 SHMEM_INTERNAL_ENV_DEF(BARRIER_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -52,7 +52,9 @@ SHMEM_INTERNAL_ENV_DEF(TRAP_ON_ABORT, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Generate trap if the program aborts or calls shmem_global_exit")
 
 SHMEM_INTERNAL_ENV_DEF(COLL_CROSSOVER, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
-                       "Crossover between linear and tree collectives")
+                       "Crossover between linear and tree collectives (num. PEs)")
+SHMEM_INTERNAL_ENV_DEF(COLL_SIZE_CROSSOVER, size, 16384, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
+                       "Crossover between linear and tree collectives (msg. size)")
 SHMEM_INTERNAL_ENV_DEF(COLL_RADIX, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Radix for tree-based collectives")
 SHMEM_INTERNAL_ENV_DEF(BARRIER_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -20,7 +20,6 @@ check_PROGRAMS = \
 	max_reduction \
 	big_reduction \
 	to_all \
-	sum_to_all \
 	strided_put \
 	barrier \
 	bcast \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -20,6 +20,7 @@ check_PROGRAMS = \
 	max_reduction \
 	big_reduction \
 	to_all \
+	sum_to_all \
 	strided_put \
 	barrier \
 	bcast \


### PR DESCRIPTION
Notes:
 * This algorithm also does not use one-sided atomics (yay!)
 * This algorithm can be used back-to-back with the same psync and active set

Note for review: We should re-evaluate auto selection of the reduction algorithm to determine when AMO-based reductions versus SW reductions should be used and how to account for scale and message size.