### PR TITLE
If context is invalid, return immediately from fence, quiet, destroy

### DIFF
--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -54,6 +54,9 @@ shmem_ctx_destroy(shmem_ctx_t ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
+    if (ctx == NULL)
+        return;
+
     if (ctx == SHMEM_CTX_DEFAULT) {
         fprintf(stderr, "ERROR: %s(): SHMEM_CTX_DEFAULT cannot be destroyed\n",
                 __func__);

--- a/src/contexts_c.c
+++ b/src/contexts_c.c
@@ -54,7 +54,7 @@ shmem_ctx_destroy(shmem_ctx_t ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    if (ctx == NULL)
+    if (ctx == SHMEMX_CTX_INVALID)
         return;
 
     if (ctx == SHMEM_CTX_DEFAULT) {

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -25,6 +25,9 @@ shmem_internal_quiet(shmem_ctx_t ctx)
 {
     int ret;
 
+    if (ctx == NULL)
+        return;
+
     ret = shmem_transport_quiet((shmem_transport_ctx_t *)ctx);
     if (0 != ret) { RAISE_ERROR(ret); }
 
@@ -42,6 +45,9 @@ static inline void
 shmem_internal_fence(shmem_ctx_t ctx)
 {
     int ret;
+
+    if (ctx == NULL)
+        return;
 
     ret = shmem_transport_fence((shmem_transport_ctx_t *)ctx);
     if (0 != ret) { RAISE_ERROR(ret); }

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -25,7 +25,7 @@ shmem_internal_quiet(shmem_ctx_t ctx)
 {
     int ret;
 
-    if (ctx == NULL)
+    if (ctx == SHMEMX_CTX_INVALID)
         return;
 
     ret = shmem_transport_quiet((shmem_transport_ctx_t *)ctx);
@@ -46,7 +46,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
 {
     int ret;
 
-    if (ctx == NULL)
+    if (ctx == SHMEMX_CTX_INVALID)
         return;
 
     ret = shmem_transport_fence((shmem_transport_ctx_t *)ctx);


### PR DESCRIPTION
This addresses a change from https://github.com/openshmem-org/specification/pull/222 : shmem_ctx_destroy, fence, and quiet perform no operation when the input context is invalid.


Signed-off-by: David M. Ozog <david.m.ozog@intel.com>