### PR TITLE
Use nonzero exit values in wait/test any/all/some tests

### DIFF
--- a/test/shmemx/shmemx_test_some.c
+++ b/test/shmemx/shmemx_test_some.c
@@ -79,20 +79,20 @@ int main(void)
     /* Check the flags array */
     for (int i = 0; i < npes; i++) {
         if (flags[i] != 1)
-            shmem_global_exit(0);
+            shmem_global_exit(1);
     }
 
     /* check result */
     int M = N * npes - 1;
     if (total_sum != M * (M + 1) / 2) {
-        shmem_global_exit(1);
+        shmem_global_exit(2);
     }
 
     /* Sanity check case with NULL status array */
     ncompleted = shmemx_int_test_some(flags, npes, indices, NULL, SHMEM_CMP_EQ, 1);
 
     if (ncompleted != npes)
-        shmem_global_exit(2);
+        shmem_global_exit(3);
 
     shmem_finalize();
     return 0;

--- a/test/shmemx/shmemx_wait_until_any.c
+++ b/test/shmemx/shmemx_wait_until_any.c
@@ -70,20 +70,20 @@ int main(void)
     /* Check the flags array */
     for (int i = 0; i < npes; i++) {
         if (flags[i] != 1)
-            shmem_global_exit(0);
+            shmem_global_exit(1);
     }
 
     /* check result */
     int M = N * npes - 1;
     if (total_sum != M * (M + 1) / 2) {
-        shmem_global_exit(1);
+        shmem_global_exit(2);
     }
 
     /* Sanity check the case with NULL status array */
     completed_idx = shmemx_int_wait_until_any(flags, npes, NULL, SHMEM_CMP_EQ, 1);
 
     if (completed_idx >= npes)
-        shmem_global_exit(2);
+        shmem_global_exit(3);
 
     shmem_finalize();
     return 0;

--- a/test/shmemx/shmemx_wait_until_some.c
+++ b/test/shmemx/shmemx_wait_until_some.c
@@ -42,20 +42,20 @@ int main(void)
     /* Check the flags array */
     for (int i = 0; i < npes; i++) {
         if (flags[i] != 1)
-            shmem_global_exit(0);
+            shmem_global_exit(1);
     }
 
     /* check result */
     int M = N * npes - 1;
     if (total_sum != M * (M + 1) / 2) {
-        shmem_global_exit(1);
+        shmem_global_exit(2);
     }
 
     /* Sanity check the case with NULL status array */
     ncompleted = shmemx_int_wait_until_some(flags, npes, indices, NULL, SHMEM_CMP_EQ, 1);
 
     if (ncompleted != npes)
-        shmem_global_exit(2);
+        shmem_global_exit(3);
 
     shmem_finalize();
     return 0;


### PR DESCRIPTION
These tests should return nonzero exit values when the verification checks fail.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>