### PR TITLE
Zero the STX KVS struct before adding to uthash table

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -495,7 +495,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
 
             if (is_unused) {
                 stx->is_private = 1;
-                shmem_transport_ofi_stx_kvs_t *e = malloc(sizeof(shmem_transport_ofi_stx_kvs_t));
+                shmem_transport_ofi_stx_kvs_t *e = calloc(1, sizeof(shmem_transport_ofi_stx_kvs_t));
                 if (e == NULL) {
                     RAISE_ERROR_STR("out of memory when allocating STX KVS entry");
                 }


### PR DESCRIPTION
We need to zero out a structure before adding to the uthash table to avoid hashing the "padding" bits ([see note here](https://troydhanson.github.io/uthash/userguide.html#_structure_keys)).

I don't remember exactly when/how this came up during teams development, but it definitely causes hard-to-detect errors in the STX management...

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>