### PR TITLE
SOS v1.4.4 updates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,9 +6,13 @@ v1.4.4
 ------
 - Experimental support for RXM/Verbs provider stack with libfabric 1.8.
   Requires --enable-hard-polling and --enable-ofi-mr=basic build flags.  The
-  FI_MR_CACHE_MAX_COUNT=0 environment variable should be set when threading is
-  used.  Depending on the libfabric build, SHMEM_OFI_PROVIDER="verbs;ofi_rxm"
-  may also need to be set to select the provider.
+  FI_MR_CACHE_MAX_COUNT environment variable should be set to 0 when threading
+  is used.  Depending on the libfabric build, setting
+  SHMEM_OFI_PROVIDER="verbs;ofi_rxm" may be necessary to select the provider.
+- Rewrite of node-level detection/management to enable improvements in on-node
+  communication and resource management.
+- Added SHMEM_OFI_STX_AUTO environment variable to enable automatic
+  partitioning of STX resources on node.  See README for details.
 - Updated unit tests and performance test suite to properly handle failed
   context creation.
 - Updated OFI transport to support providers that do not support the

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,34 @@
 
 Sandia OpenSHMEM NEWS -- history of user-visible changes.
 
+v1.4.4
+------
+- Experimental support for RXM/Verbs provider stack with libfabric 1.8.
+  Requires --enable-hard-polling and --enable-ofi-mr=basic build flags.  The
+  FI_MR_CACHE_MAX_COUNT=0 environment variable should be set when threading is
+  used.  Depending on the libfabric build, SHMEM_OFI_PROVIDER="verbs;ofi_rxm"
+  may also need to be set to select the provider.
+- Updated unit tests and performance test suite to properly handle failed
+  context creation.
+- Updated OFI transport to support providers that do not support the
+  FI_SHARED_CONTEXT TX attribute (STX) on endpoints.
+- Updated OFI transport to bind a CQ to the target EP (required by some
+  providers) and poll the target CQ when driving manual progress.  As a result,
+  manual progress no longer requries a target-side counter and can be used in
+  conjunction with hard polling.
+- Added support for decimal values in the SHMEM_SYMMETRIC_SIZE environment
+  variable (e.g., 1.5G).
+- Updated shmem_init_thread routine to return an error when library
+  initialization fails (e.g., due to invalid SHMEM_SYMMETRIC_SIZE value).
+- Fixed argument/context handling in Mandelbrot example program.
+- Improved handling of context creation failure.
+- Added missing pshmem_global_exit symbol to profiling interfaces.
+- Updated shmem_ptr to return a pointer for the local process, even when
+  inter-PE shared memory is not enabled.
+- Updated fence, quiet, and context destroy to perform no operation for
+  SHMEMX_CTX_INVALID.
+- Additional bugfixes and improvement (see git log for details).
+
 v1.4.3
 ------
 - Added NBI atomics support to performance suite benchmarks.

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.4.3], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.4.4], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])

--- a/scripts/simple-build-ofi.sh
+++ b/scripts/simple-build-ofi.sh
@@ -13,7 +13,7 @@
 set -e
 
 if [ -z "$SOS_VERSION" ] ; then
-    SOS_VERSION="v1.4.3"
+    SOS_VERSION="v1.4.4"
 fi
 if [ -z "$OFI_VERSION" ] ; then
     OFI_VERSION="v1.7.0"


### PR DESCRIPTION
- [x] Coverity Scan (0 new defects, 1 eliminated)
- [x] Test with PSM2
- [x] Test with RXM/Verbs
- [x] Test with Portals 4
- [x] Post-release: Update sos-tests (https://github.com/openshmem-org/tests-sos/pull/13/)