### PR TITLE
Updates to utility atomics

### DIFF
--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -158,31 +158,31 @@ shmem_internal_membar_store(void) {
 
 #include <stdint.h>
 
-typedef uint64_t shmem_internal_atomic_uint64_t;
+typedef uint64_t shmem_internal_cntr_t;
 
 static inline
 void
-shmem_internal_atomic_write(shmem_internal_atomic_uint64_t *ptr, uint64_t value) {
+shmem_internal_cntr_write(shmem_internal_cntr_t *ptr, uint64_t value) {
     __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
     return;
 }
 
 static inline
 uint64_t
-shmem_internal_atomic_read(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_read(shmem_internal_cntr_t *val) {
     return __atomic_load_n(val, __ATOMIC_ACQUIRE);
 }
 
 static inline
 void
-shmem_internal_atomic_inc(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_inc(shmem_internal_cntr_t *val) {
     __atomic_fetch_add(val, 1, __ATOMIC_RELEASE);
     return;
 }
 
 static inline
 void
-shmem_internal_atomic_dec(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_dec(shmem_internal_cntr_t *val) {
     __atomic_fetch_sub(val, 1, __ATOMIC_RELEASE);
     return;
 }
@@ -191,31 +191,31 @@ shmem_internal_atomic_dec(shmem_internal_atomic_uint64_t *val) {
 
 #include <stdatomic.h>
 
-typedef atomic_uint_fast64_t shmem_internal_atomic_uint64_t;
+typedef atomic_uint_fast64_t shmem_internal_cntr_t;
 
 static inline
 void
-shmem_internal_atomic_write(shmem_internal_atomic_uint64_t *ptr, uint64_t value) {
+shmem_internal_cntr_write(shmem_internal_cntr_t *ptr, uint64_t value) {
     atomic_store(ptr, value);
     return;
 }
 
 static inline
 uint64_t
-shmem_internal_atomic_read(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_read(shmem_internal_cntr_t *val) {
     return (uint64_t)atomic_load(val);
 }
 
 static inline
 void
-shmem_internal_atomic_inc(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_inc(shmem_internal_cntr_t *val) {
     atomic_fetch_add(val, 1);
     return;
 }
 
 static inline
 void
-shmem_internal_atomic_dec(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_dec(shmem_internal_cntr_t *val) {
     atomic_fetch_sub(val, 1);
     return;
 }
@@ -223,31 +223,31 @@ shmem_internal_atomic_dec(shmem_internal_atomic_uint64_t *val) {
 
 #  else /* !define( ENABLE_THREADS ) */
 
-typedef uint64_t shmem_internal_atomic_uint64_t;
+typedef uint64_t shmem_internal_cntr_t;
 
 static inline
 void
-shmem_internal_atomic_write(shmem_internal_atomic_uint64_t *ptr, uint64_t value) {
+shmem_internal_cntr_write(shmem_internal_cntr_t *ptr, uint64_t value) {
     *ptr = value;
     return;
 }
 
 static inline
 uint64_t
-shmem_internal_atomic_read(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_read(shmem_internal_cntr_t *val) {
     return *val;
 }
 
 static inline
 void
-shmem_internal_atomic_inc(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_inc(shmem_internal_cntr_t *val) {
     *val = *val+1;
     return;
 }
 
 static inline
 void
-shmem_internal_atomic_dec(shmem_internal_atomic_uint64_t *val) {
+shmem_internal_cntr_dec(shmem_internal_cntr_t *val) {
     *val = *val-1;
     return;
 }

--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -92,7 +92,7 @@ shmem_spinlock_fini(shmem_spinlock_t *lock)
 
 #if (defined(__STDC_NO_ATOMICS__) || !defined(HAVE_STDATOMIC_H))
 
-/* The full memory barrier is used in cases where global ordering is requred,
+/* The full memory barrier is used in cases where global ordering is required,
  * and thus requires sequential consistency.  For example, PE 0 performs
  * updates followed by a quiet.  PE 1 observes PE 0's updates and informs PE 2
  * that PE 0's updates are available.  PE 2 must also see PE 0's updates.

--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -47,8 +47,8 @@
 /* Spinlocks */
 
 struct shmem_spinlock_t {
-    long enter;
-    long exit;
+    unsigned long enter;
+    unsigned long exit;
 };
 typedef struct shmem_spinlock_t shmem_spinlock_t;
 

--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -66,11 +66,10 @@ static inline
 void
 shmem_spinlock_lock(shmem_spinlock_t *lock)
 {
-    long val = __atomic_fetch_add(&lock->enter, 1, __ATOMIC_ACQUIRE);
-    while (val != __atomic_load_n(&lock->exit, __ATOMIC_RELAXED)) {
+    long val = __atomic_fetch_add(&lock->enter, 1, __ATOMIC_ACQ_REL);
+    while (val != __atomic_load_n(&lock->exit, __ATOMIC_ACQUIRE)) {
         SPINLOCK_BODY();
     }
-    __atomic_thread_fence(__ATOMIC_ACQUIRE);
 }
 
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -115,6 +115,8 @@ shmem_internal_put_signal_nbi(shmem_ctx_t ctx, void *target, const void *source,
             shmem_transport_put_signal_nbi((shmem_transport_ctx_t *)ctx, target, source, len, sig_addr, signal, pe);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
+            /* Memory fence to ensure target PE observes stores in the correct order */
+            shmem_internal_membar_release();
             shmem_transport_cma_put(sig_addr, &signal, sizeof(uint64_t), pe, node_rank);
         }
 #else

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -107,14 +107,14 @@ shmem_internal_put_signal_nbi(shmem_ctx_t ctx, void *target, const void *source,
         *sig_addr = signal;
 #elif USE_XPMEM
         shmem_transport_xpmem_put(target, source, len, pe, node_rank);
-        shmem_internal_membar_store(); /* Memory fence to ensure target PE observes stores in the correct order */
+        /* Memory fence to ensure target PE observes stores in the correct order */
+        shmem_internal_membar_release();
         shmem_transport_xpmem_put(sig_addr, &signal, sizeof(uint64_t), pe, node_rank);
 #elif USE_CMA
         if (len > shmem_internal_params.CMA_PUT_MAX) {
             shmem_transport_put_signal_nbi((shmem_transport_ctx_t *)ctx, target, source, len, sig_addr, signal, pe);
         } else {
             shmem_transport_cma_put(target, source, len, pe, node_rank);
-            shmem_internal_membar_store(); /* Memory fence to ensure target PE observes stores in the correct order */
             shmem_transport_cma_put(sig_addr, &signal, sizeof(uint64_t), pe, node_rank);
         }
 #else

--- a/src/shmem_lock.h
+++ b/src/shmem_lock.h
@@ -95,14 +95,14 @@ shmem_internal_set_lock(long *lockp)
             SHMEM_WAIT(&(lock->data), lock_cur.data);
         }
     } else {
-        /* Lock was acquired immediately without calling SHMEM_WAIT, 
-         * which provides memory ordering. Therefore, issuing a load 
+        /* Lock was acquired immediately without calling SHMEM_WAIT,
+         * which provides memory ordering. Therefore, issuing an acquire
          * fence to ensure memory ordering. */
-        shmem_internal_membar_load();
+        shmem_internal_membar_acquire();
         /* Transport level memory flush is required to make memory
-         * changes (i.e. operations performed within a previous 
+         * changes (i.e. operations performed within a previous
          * critical section) visible */
-        shmem_transport_syncmem();                                                         \
+        shmem_transport_syncmem();
     }
 }
 
@@ -121,11 +121,14 @@ shmem_internal_test_lock(long *lockp)
     shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, &zero, sizeof(int), 0, SHM_INTERNAL_INT);
     shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
     if (0 == curr) {
-        shmem_internal_membar_load();
+        /* Lock was acquired immediately without calling SHMEM_WAIT,
+         * which provides memory ordering. Therefore, issuing an acquire
+         * fence to ensure memory ordering. */
+        shmem_internal_membar_acquire();
         /* Transport level memory flush is required to make memory
          * changes (i.e. operations performed within a previous
          * critical section) visible */
-        shmem_transport_syncmem();                                                         \
+        shmem_transport_syncmem();
         return 0;
     }
     return 1;

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -52,7 +52,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
     ret = shmem_transport_fence((shmem_transport_ctx_t *)ctx);
     if (0 != ret) { RAISE_ERROR(ret); }
 
-    shmem_internal_membar_store();
+    shmem_internal_membar_release();
 
     /* Since fence does not guarantee any memory visibility, 
      * transport level memory flush is not required here. */
@@ -147,13 +147,13 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_WAIT(var, value) do {                                     \
         SHMEM_INTERNAL_WAIT_UNTIL(var, SHMEM_CMP_NE, value);            \
-        shmem_internal_membar_load();                                   \
+        shmem_internal_membar_acquire();                                \
         shmem_transport_syncmem();                                      \
     } while (0)
 
 #define SHMEM_WAIT_UNTIL(var, cond, value) do {                         \
         SHMEM_INTERNAL_WAIT_UNTIL(var, cond, value);                    \
-        shmem_internal_membar_load();                                   \
+        shmem_internal_membar_acquire();                                \
         shmem_transport_syncmem();                                      \
     } while (0)
 

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -198,7 +198,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
                                                                                                \
         for (i = 0; i < nelems; i++) SHMEM_INTERNAL_WAIT_UNTIL(&vars[i], cond, value);         \
                                                                                                \
-        shmem_internal_membar_load();                                                          \
+        shmem_internal_membar_acquire();                                                       \
         shmem_transport_syncmem();                                                             \
     }
 
@@ -247,7 +247,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
             if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
                                                                                                \
-        shmem_internal_membar_load();                                                          \
+        shmem_internal_membar_acquire();                                                       \
         shmem_transport_syncmem();                                                             \
         return found_idx;                                                                      \
     }
@@ -290,7 +290,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
             }                                                                                  \
             if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
-        shmem_internal_membar_load();                                                          \
+        shmem_internal_membar_acquire();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
     }
@@ -309,7 +309,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
                                                                                                \
         COMP(cond, *(var), value, cmpret);                                                     \
         if (cmpret) {                                                                          \
-            shmem_internal_membar_load();                                                      \
+            shmem_internal_membar_acquire();                                                   \
         } else {                                                                               \
             shmem_transport_probe();                                                           \
         }                                                                                      \
@@ -339,7 +339,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
             if (cmpret) ncompleted++;                                                          \
         }                                                                                      \
         if (ncompleted == nelems) {                                                            \
-            shmem_internal_membar_load();                                                      \
+            shmem_internal_membar_acquire();                                                   \
             return 1;                                                                          \
         } else {                                                                               \
             shmem_transport_probe();                                                           \
@@ -378,7 +378,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
              }                                                                                 \
         }                                                                                      \
         if (found_idx != SIZE_MAX)                                                             \
-            shmem_internal_membar_load();                                                      \
+            shmem_internal_membar_acquire();                                                   \
         else                                                                                   \
             shmem_transport_probe();                                                           \
                                                                                                \
@@ -421,7 +421,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
             }                                                                                  \
         }                                                                                      \
         if (!cmpret) shmem_transport_probe();                                                  \
-        shmem_internal_membar_load();                                                          \
+        shmem_internal_membar_acquire();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
     }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1566,8 +1566,8 @@ int shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
     memset(ctxp, 0, sizeof(shmem_transport_ctx_t));
 
 #ifndef USE_CTX_LOCK
-    shmem_internal_atomic_write(&ctxp->pending_put_cntr, 0);
-    shmem_internal_atomic_write(&ctxp->pending_get_cntr, 0);
+    shmem_internal_cntr_write(&ctxp->pending_put_cntr, 0);
+    shmem_internal_cntr_write(&ctxp->pending_get_cntr, 0);
 #endif
 
     ctxp->stx_idx = -1;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -268,8 +268,8 @@ struct shmem_transport_ctx_t {
     uint64_t                        pending_put_cntr;
     uint64_t                        pending_get_cntr;
 #else
-    shmem_internal_atomic_uint64_t  pending_put_cntr;
-    shmem_internal_atomic_uint64_t  pending_get_cntr;
+    shmem_internal_cntr_t           pending_put_cntr;
+    shmem_internal_cntr_t           pending_get_cntr;
 #endif
     /* These counters are protected by the BB lock */
     uint64_t                        pending_bb_cntr;
@@ -303,8 +303,8 @@ extern struct fid_ep* shmem_transport_ofi_target_ep;
 #else
 #define SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx)
 #define SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx)
-#define SHMEM_TRANSPORT_OFI_CNTR_READ(cntr) shmem_internal_atomic_read(cntr)
-#define SHMEM_TRANSPORT_OFI_CNTR_INC(cntr) shmem_internal_atomic_inc(cntr)
+#define SHMEM_TRANSPORT_OFI_CNTR_READ(cntr) shmem_internal_cntr_read(cntr)
+#define SHMEM_TRANSPORT_OFI_CNTR_INC(cntr) shmem_internal_cntr_inc(cntr)
 #endif /* USE_CTX_LOCK */
 
 #define SHMEM_TRANSPORT_OFI_CTX_BB_LOCK(ctx)                                    \

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -1427,8 +1427,10 @@ void shmem_transport_received_cntr_wait(uint64_t ge_val)
 static inline
 void shmem_transport_syncmem(void)
 {
-    // TODO: libfabric does not yet have an analog to PtlAtomicSync() in Portals4, so the OFI 
-    // transport routine will be a nop until an API is provided.
+    /* TODO: libfabric does not yet have an analog to PtlAtomicSync() in
+     * Portals4, so the OFI transport routine will be a nop until an API is
+     * provided.
+     */
 }
 
 static inline

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -74,7 +74,7 @@ int8_t shmem_transport_portals4_pt_state[SHMEM_TRANSPORT_PORTALS4_NUM_PTS] = {
 ptl_handle_ni_t shmem_transport_portals4_ni_h = PTL_INVALID_HANDLE;
 ptl_handle_md_t shmem_transport_portals4_put_event_md_h = PTL_INVALID_HANDLE;
 ptl_handle_ct_t shmem_transport_portals4_put_event_ct_h = PTL_INVALID_HANDLE;
-shmem_internal_atomic_uint64_t shmem_transport_portals4_pending_put_event_cntr;
+shmem_internal_cntr_t shmem_transport_portals4_pending_put_event_cntr;
 #if ENABLE_REMOTE_VIRTUAL_ADDRESSING
 ptl_handle_le_t shmem_transport_portals4_le_h = PTL_INVALID_HANDLE;
 #else
@@ -140,8 +140,8 @@ shmem_transport_ctx_init(shmem_transport_ctx_t *ctx, long options, int id)
     ctx->get_md = PTL_INVALID_HANDLE;
     ctx->put_ct = PTL_INVALID_HANDLE;
     ctx->get_ct = PTL_INVALID_HANDLE;
-    shmem_internal_atomic_write(&ctx->pending_put_cntr, 0);
-    shmem_internal_atomic_write(&ctx->pending_get_cntr, 0);
+    shmem_internal_cntr_write(&ctx->pending_put_cntr, 0);
+    shmem_internal_cntr_write(&ctx->pending_get_cntr, 0);
 
     /* Allocate put completion tracking resources */
     ret = PtlCTAlloc(shmem_transport_portals4_ni_h, &ctx->put_ct);
@@ -256,7 +256,7 @@ shmem_transport_ctx_create(long options, shmem_transport_ctx_t **ctx)
 
     memset(*ctx, 0, sizeof(shmem_transport_ctx_t));
 
-    shmem_internal_atomic_write(&shmem_transport_portals4_pending_put_event_cntr, 0);
+    shmem_internal_cntr_write(&shmem_transport_portals4_pending_put_event_cntr, 0);
     ret = shmem_transport_ctx_init(*ctx, options, id);
 
     if (ret) {


### PR DESCRIPTION
Updates to the utility atomics (spinlocks and counters) to use `__atomic` rather than deprecated `__sync`, inline assembly, and compiler fences.  Rename the thread-safe counter routines to avoid name confusion with `shmem_internal_atomic_*` API used to implement the AMOs.