### PR TITLE
Add memory sync before returning from barriers

### DIFF
--- a/src/shmem_atomic.h
+++ b/src/shmem_atomic.h
@@ -120,6 +120,15 @@ shmem_internal_membar_acquire(void) {
 }
 
 
+static inline
+void
+shmem_internal_membar_acq_rel(void) {
+    if (SHMEM_INTERNAL_NEED_MEMBAR)
+        __atomic_thread_fence(__ATOMIC_ACQ_REL);
+    return;
+}
+
+
 /* Atomics */
 #  ifdef ENABLE_THREADS
 #    if (defined(__STDC_NO_ATOMICS__) || !defined(HAVE_STDATOMIC_H))

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -76,6 +76,10 @@ shmem_internal_sync(int PE_start, int logPE_stride, int PE_size, long *pSync)
         RAISE_ERROR_MSG("Illegal barrier/sync type (%d)\n",
                         shmem_internal_barrier_type);
     }
+
+    /* Ensure remote updates are visible in memory */
+    shmem_internal_membar_acquire();
+    shmem_transport_syncmem();
 }
 
 

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -78,7 +78,7 @@ shmem_internal_sync(int PE_start, int logPE_stride, int PE_size, long *pSync)
     }
 
     /* Ensure remote updates are visible in memory */
-    shmem_internal_membar_acquire();
+    shmem_internal_membar_acq_rel();
     shmem_transport_syncmem();
 }
 

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -147,13 +147,13 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_WAIT(var, value) do {                                     \
         SHMEM_INTERNAL_WAIT_UNTIL(var, SHMEM_CMP_NE, value);            \
-        shmem_internal_membar_acquire();                                \
+        shmem_internal_membar_acq_rel();                                \
         shmem_transport_syncmem();                                      \
     } while (0)
 
 #define SHMEM_WAIT_UNTIL(var, cond, value) do {                         \
         SHMEM_INTERNAL_WAIT_UNTIL(var, cond, value);                    \
-        shmem_internal_membar_acquire();                                \
+        shmem_internal_membar_acq_rel();                                \
         shmem_transport_syncmem();                                      \
     } while (0)
 

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -198,7 +198,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
                                                                                                \
         for (i = 0; i < nelems; i++) SHMEM_INTERNAL_WAIT_UNTIL(&vars[i], cond, value);         \
                                                                                                \
-        shmem_internal_membar_acquire();                                                       \
+        shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
     }
 
@@ -247,7 +247,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
             if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
                                                                                                \
-        shmem_internal_membar_acquire();                                                       \
+        shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return found_idx;                                                                      \
     }
@@ -290,7 +290,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
             }                                                                                  \
             if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
-        shmem_internal_membar_acquire();                                                       \
+        shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
     }
@@ -309,7 +309,8 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
                                                                                                \
         COMP(cond, *(var), value, cmpret);                                                     \
         if (cmpret) {                                                                          \
-            shmem_internal_membar_acquire();                                                   \
+            shmem_internal_membar_acq_rel();                                                   \
+            shmem_transport_syncmem();                                                         \
         } else {                                                                               \
             shmem_transport_probe();                                                           \
         }                                                                                      \
@@ -339,7 +340,8 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
             if (cmpret) ncompleted++;                                                          \
         }                                                                                      \
         if (ncompleted == nelems) {                                                            \
-            shmem_internal_membar_acquire();                                                   \
+            shmem_internal_membar_acq_rel();                                                   \
+            shmem_transport_syncmem();                                                         \
             return 1;                                                                          \
         } else {                                                                               \
             shmem_transport_probe();                                                           \
@@ -377,9 +379,10 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
                 }                                                                              \
              }                                                                                 \
         }                                                                                      \
-        if (found_idx != SIZE_MAX)                                                             \
-            shmem_internal_membar_acquire();                                                   \
-        else                                                                                   \
+        if (found_idx != SIZE_MAX) {                                                           \
+            shmem_internal_membar_acq_rel();                                                   \
+            shmem_transport_syncmem();                                                         \
+        } else                                                                                 \
             shmem_transport_probe();                                                           \
                                                                                                \
         return found_idx;                                                                      \
@@ -421,7 +424,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
             }                                                                                  \
         }                                                                                      \
         if (!cmpret) shmem_transport_probe();                                                  \
-        shmem_internal_membar_acquire();                                                       \
+        shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
     }


### PR DESCRIPTION
These are the same memory syncs we do before returning from wait/test
operations to ensure shared memory updates and remote updates cached in
the NIC are visible in memory.

Signed-off-by: James Dinan <james.dinan@intel.com>