### PR TITLE
Update to new OFI MR modes

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -74,7 +74,9 @@ struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
 uint64_t*                       shmem_transport_ofi_target_heap_keys;
 uint64_t*                       shmem_transport_ofi_target_data_keys;
-#ifndef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+int                             shmem_transport_ofi_use_absolute_address;
+#else
 uint8_t**                       shmem_transport_ofi_target_heap_addrs;
 uint8_t**                       shmem_transport_ofi_target_data_addrs;
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
@@ -708,7 +710,12 @@ int publish_mr_info(void)
         }
     }
 
-#ifndef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+    if (shmem_transport_ofi_info.p_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
+        shmem_transport_ofi_use_absolute_address = 1;
+    else
+        shmem_transport_ofi_use_absolute_address = 0;
+#else /* !ENABLE_REMOTE_VIRTUAL_ADDRESSING */
     {
         int err;
         void *heap_base, *data_base;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1178,6 +1178,12 @@ int query_for_fabric(struct fabric_info *info)
         return 1;
     }
 
+    if (info->p_info->domain_attr->mr_mode != domain_attr.mr_mode) {
+        RAISE_WARN_MSG("MR mode mismatch (requested 0x%x, received 0x%x)\n",
+                       domain_attr.mr_mode, info->p_info->domain_attr->mr_mode);
+        return 1;
+    }
+
     /* Check if the domain supports STXs */
     if (info->p_info->domain_attr->max_ep_stx_ctx == 0) {
         shmem_transport_ofi_stx_max = 0;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -741,7 +741,7 @@ int publish_mr_info(void)
         }
     }
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
-#endif /* ENABLE_MR_SCALABLE */
+#endif /* !ENABLE_MR_SCALABLE */
 
     return 0;
 }
@@ -819,7 +819,7 @@ int populate_mr_tables(void)
         }
     }
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
-#endif /* ENABLE_MR_SCALABLE */
+#endif /* !ENABLE_MR_SCALABLE */
 
     return 0;
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -526,11 +526,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
 }
 
 #define OFI_MAJOR_VERSION 1
-#ifdef ENABLE_MR_RMA_EVENT
 #define OFI_MINOR_VERSION 5
-#else
-#define OFI_MINOR_VERSION 0
-#endif
 
 static
 void init_bounce_buffer(shmem_free_list_item_t *item)
@@ -1101,12 +1097,14 @@ int query_for_fabric(struct fabric_info *info)
     domain_attr.data_progress = FI_PROGRESS_AUTO;
     domain_attr.resource_mgmt = FI_RM_ENABLED;
 #ifdef ENABLE_MR_SCALABLE
-    domain_attr.mr_mode       = FI_MR_SCALABLE; /* VA space-doesn't have to be pre-allocated */
+                                /* Scalable, offset-based addressing, formerly FI_MR_SCALABLE */
+    domain_attr.mr_mode       = 0;
 #  if !defined(ENABLE_HARD_POLLING) && defined(ENABLE_MR_RMA_EVENT)
     domain_attr.mr_mode       = FI_MR_RMA_EVENT; /* can support RMA_EVENT on MR */
 #  endif
 #else
-    domain_attr.mr_mode       = FI_MR_BASIC; /* VA space is pre-allocated */
+                                /* Portable, absolute addressing, formerly FI_MR_BASIC */
+    domain_attr.mr_mode       = FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
 #endif
 #if !defined(ENABLE_MR_SCALABLE) || !defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
     domain_attr.mr_key_size   = 1; /* Heap and data use different MR keys, need


### PR DESCRIPTION
Update SOS to use MR mode flags instead of deprecated `FI_MR_SCALABLE` and `FI_MR_BASIC` modes. This update requires SOS to be able to deal with the individual modes in basic support being selectively enabled by the provider. In cases where SOS is compiled with basic support, but some of the MR mode flags are cleared by the provider, SOS still builds and populates translation tables even though all entries have the same value (room for future optimization).

Note, this PR does not add support for `FI_MR_LOCAL` SOS level registration of local communication buffers. We don't have a provider that requires this yet and it will be a fairly significant chunk of work to add.

Closes #900 