### PR TITLE
Reduce return value across PEs during team creation

### DIFF
--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -163,6 +163,7 @@ int shmem_internal_team_init(void)
                                                          shmem_internal_params.TEAMS_MAX];
 
     psync_pool_avail = shmem_internal_shmalloc(2 * N_PSYNC_BYTES);
+    if (NULL == psync_pool_avail) return -1;
     psync_pool_avail_reduced = &psync_pool_avail[N_PSYNC_BYTES];
 
     /* Initialize the psync bits to 1, making all slots available: */
@@ -177,6 +178,7 @@ int shmem_internal_team_init(void)
 
     /* Initialize an integer used to agree on an equal return value across PEs in team creation: */
     team_ret_val = shmem_internal_shmalloc(sizeof(int) * 2);
+    if (NULL == team_ret_val) return -1;
     team_ret_val_reduced = &team_ret_val[1];
 
     return 0;
@@ -325,7 +327,7 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
 
     shmem_internal_op_to_all(team_ret_val_reduced, team_ret_val, 1, sizeof(int),
                              parent_team->start, parent_team->stride, parent_team->size, NULL,
-                             psync, SHM_INTERNAL_BOR, SHM_INTERNAL_INT);
+                             psync, SHM_INTERNAL_MAX, SHM_INTERNAL_INT);
 
     shmem_internal_team_release_psyncs(parent_team, REDUCE);
 

--- a/test/shmemx/shmemx_team_max.c
+++ b/test/shmemx/shmemx_team_max.c
@@ -57,9 +57,11 @@ int main(void)
         /* If success was not global, free a team and retry */
         if (dest_ret != 0) {
             /* FIXME: The team is currently leaked in the case below */
-            if (ret == 0)
+            if (ret == 0) {
                 printf("%d: Local success and global failure on iteration %d\n",
                        me, i);
+                shmem_global_exit(1);
+            }
 
             /* No more teams to free */
             if (i == j)

--- a/test/shmemx/shmemx_team_max.c
+++ b/test/shmemx/shmemx_team_max.c
@@ -56,7 +56,6 @@ int main(void)
 
         /* If success was not global, free a team and retry */
         if (dest_ret != 0) {
-            /* FIXME: The team is currently leaked in the case below */
             if (ret == 0) {
                 printf("%d: Local success and global failure on iteration %d\n",
                        me, i);


### PR DESCRIPTION
With upcoming changes to the teams proposal [(#305)](https://github.com/openshmem-org/specification/pull/305/), we need to guarantee that the return values are equal across PEs after team creation.  We can also check whether the reduction is successful in the `shmemx_team_max` unit test.

