### PR TITLE
Wait/test: update "status" semantics to match spec

### DIFF
--- a/mpp/shmemx.h4
+++ b/mpp/shmemx.h4
@@ -44,37 +44,37 @@ include(shmemx_c_func.h4)dnl
 } /* extern "C" */
 
 define(`SHMEM_CXX_WAIT_UNTIL_ALL',
-`static inline void shmemx_wait_until_all($2 *ivars, size_t nelems, int *status, int cmp, $2 cmp_value) {
+`static inline void shmemx_wait_until_all($2 *ivars, size_t nelems, const int *status, int cmp, $2 cmp_value) {
     shmemx_$1_wait_until_all(ivars, nelems, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_WAIT_UNTIL_ALL')
 
 define(`SHMEM_CXX_WAIT_UNTIL_ANY',
-`static inline size_t shmemx_wait_until_any($2 *ivars, size_t nelems, int *status, int cmp, $2 cmp_value) {
+`static inline size_t shmemx_wait_until_any($2 *ivars, size_t nelems, const int *status, int cmp, $2 cmp_value) {
     return shmemx_$1_wait_until_any(ivars, nelems, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_WAIT_UNTIL_ANY')
 
 define(`SHMEM_CXX_WAIT_UNTIL_SOME',
-`static inline size_t shmemx_wait_until_some($2 *ivars, size_t nelems, size_t *indices, int *status, int cmp, $2 cmp_value) {
+`static inline size_t shmemx_wait_until_some($2 *ivars, size_t nelems, size_t *indices, const int *status, int cmp, $2 cmp_value) {
     return shmemx_$1_wait_until_some(ivars, nelems, indices, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_WAIT_UNTIL_SOME')
 
 define(`SHMEM_CXX_TEST_ALL',
-`static inline int shmemx_test_all($2 *ivars, size_t nelems, int cmp, $2 cmp_value) {
-    return shmemx_$1_test_all(ivars, nelems, cmp, cmp_value);
+`static inline int shmemx_test_all($2 *ivars, size_t nelems, const int *status, int cmp, $2 cmp_value) {
+    return shmemx_$1_test_all(ivars, nelems, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_TEST_ALL')
 
 define(`SHMEM_CXX_TEST_ANY',
-`static inline size_t shmemx_test_any($2 *ivars, size_t nelems, int *status, int cmp, $2 cmp_value) {
+`static inline size_t shmemx_test_any($2 *ivars, size_t nelems, const int *status, int cmp, $2 cmp_value) {
     return shmemx_$1_test_any(ivars, nelems, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_TEST_ANY')
 
 define(`SHMEM_CXX_TEST_SOME',
-`static inline size_t shmemx_test_some($2 *ivars, size_t nelems, size_t *indices, int *status, int cmp, $2 cmp_value) {
+`static inline size_t shmemx_test_some($2 *ivars, size_t nelems, size_t *indices, const int *status, int cmp, $2 cmp_value) {
     return shmemx_$1_test_some(ivars, nelems, indices, status, cmp, cmp_value);
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_TEST_SOME')

--- a/mpp/shmemx_c_func.h4
+++ b/mpp/shmemx_c_func.h4
@@ -39,27 +39,27 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_all(shmem_ctx_t ctx, shme
 
 /* Wait_until and test any/all/some point-to-point API, proposed for OpenSHMEM 1.5 */
 define(`SHMEM_C_WAIT_UNTIL_ALL',
-`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_$1_wait_until_all($2 *vars, size_t nelems, int *status, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_$1_wait_until_all($2 *vars, size_t nelems, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_WAIT_UNTIL_ALL')
 
 define(`SHMEM_C_WAIT_UNTIL_ANY',
-`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_wait_until_any($2 *vars, size_t nelems, int *status, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_wait_until_any($2 *vars, size_t nelems, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_WAIT_UNTIL_ANY')
 
 define(`SHMEM_C_WAIT_UNTIL_SOME',
-`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_wait_until_some($2 *vars, size_t nelems, size_t *indices, int *status, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_wait_until_some($2 *vars, size_t nelems, size_t *indices, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_WAIT_UNTIL_SOME')
 
 define(`SHMEM_C_TEST_ALL',
-`SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmemx_$1_test_all($2 *vars, size_t nelems, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmemx_$1_test_all($2 *vars, size_t nelems, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_TEST_ALL')
 
 define(`SHMEM_C_TEST_ANY',
-`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_test_any($2 *vars, size_t nelems, int *status, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_test_any($2 *vars, size_t nelems, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_TEST_ANY')
 
 define(`SHMEM_C_TEST_SOME',
-`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_test_some($2 *vars, size_t nelems, size_t *indices, int *status, int cmp, $2 value);')dnl
+`SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmemx_$1_test_some($2 *vars, size_t nelems, size_t *indices, const int *status, int cmp, $2 value);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_TEST_SOME')
 
 /* Nonblocking swap operations, proposed for OpenSHMEM 1.5 */

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -184,7 +184,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
 #define SHMEM_DEF_WAIT_UNTIL_ALL(STYPE,TYPE)                                                   \
     void SHMEM_FUNCTION_ATTRIBUTES                                                             \
     shmemx_##STYPE##_wait_until_all(TYPE *vars, size_t nelems,                                 \
-                                    int *status, int cond, TYPE value)                         \
+                                    const int *status, int cond, TYPE value)                   \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
@@ -218,7 +218,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
 #define SHMEM_DEF_WAIT_UNTIL_ANY(STYPE,TYPE)                                                   \
     size_t SHMEM_FUNCTION_ATTRIBUTES                                                           \
     shmemx_##STYPE##_wait_until_any(TYPE *vars, size_t nelems,                                 \
-                                    int *status, int cond, TYPE value)                         \
+                                    const int *status, int cond, TYPE value)                   \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
@@ -248,7 +248,6 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
                 if (status == NULL || !status[idx]) {                                          \
                     COMP(cond, vars[idx], value, cmpret);                                      \
                     if (cmpret) {                                                              \
-                        if (status) status[idx] = 1;                                           \
                         found_idx = idx;                                                       \
                         break;                                                                 \
                     }                                                                          \
@@ -268,7 +267,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
 #define SHMEM_DEF_WAIT_UNTIL_SOME(STYPE,TYPE)                                                  \
     size_t SHMEM_FUNCTION_ATTRIBUTES                                                           \
     shmemx_##STYPE##_wait_until_some(TYPE *vars, size_t nelems, size_t *indices,               \
-                                     int *status, int cond, TYPE value)                        \
+                                     const int *status, int cond, TYPE value)                  \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
@@ -292,7 +291,6 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
                 if (status == NULL || !status[i]) {                                            \
                     COMP(cond, vars[i], value, cmpret);                                        \
                     if (cmpret) {                                                              \
-                        if (status) status[i] = 1;                                             \
                         indices[ncompleted++] = i;                                             \
                         cmpret = 0;                                                            \
                     }                                                                          \
@@ -332,22 +330,32 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
 
 #define SHMEM_DEF_TEST_ALL(STYPE,TYPE)                                                         \
     int SHMEM_FUNCTION_ATTRIBUTES                                                              \
-    shmemx_##STYPE##_test_all(TYPE *vars, size_t nelems, int cond, TYPE value)                 \
+    shmemx_##STYPE##_test_all(TYPE *vars, size_t nelems, const int *status, int cond,          \
+                              TYPE value)                                                      \
     {                                                                                          \
         size_t ncompleted = 0;                                                                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
-        if (nelems == 0) {                                                                     \
+        size_t i = 0, num_ignored = 0;                                                         \
+                                                                                               \
+        if (status) {                                                                          \
+            for (i = 0; i < nelems; i++) {                                                     \
+                if (status[i]) num_ignored++;                                                  \
+            }                                                                                  \
+        }                                                                                      \
+        if (nelems == 0 || num_ignored == nelems) {                                            \
             shmem_transport_probe();                                                           \
-            return 1;                                                                          \
+            return 0;                                                                          \
         }                                                                                      \
                                                                                                \
-        for (size_t i = 0; i < nelems; i++) {                                                  \
-            int cmpret;                                                                        \
-            COMP(cond, vars[i], value, cmpret);                                                \
-            if (cmpret) ncompleted++;                                                          \
+        for (i = 0; i < nelems; i++) {                                                         \
+            if (status == NULL || !status[i]) {                                                \
+                int cmpret;                                                                    \
+                COMP(cond, vars[i], value, cmpret);                                            \
+                if (cmpret) ncompleted++;                                                      \
+            }                                                                                  \
         }                                                                                      \
         if (ncompleted == nelems) {                                                            \
             shmem_internal_membar_acq_rel();                                                   \
@@ -364,7 +372,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
 
 #define SHMEM_DEF_TEST_ANY(STYPE,TYPE)                                                         \
     size_t SHMEM_FUNCTION_ATTRIBUTES                                                           \
-    shmemx_##STYPE##_test_any(TYPE *vars, size_t nelems, int *status,                          \
+    shmemx_##STYPE##_test_any(TYPE *vars, size_t nelems, const int *status,                    \
                               int cond, TYPE value)                                            \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
@@ -383,7 +391,6 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
             if (status == NULL || !status[idx]) {                                              \
                 COMP(cond, vars[idx], value, cmpret);                                          \
                 if (cmpret) {                                                                  \
-                    if (status) status[idx] = 1;                                               \
                     found_idx = idx;                                                           \
                     break;                                                                     \
                 }                                                                              \
@@ -404,7 +411,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
 #define SHMEM_DEF_TEST_SOME(STYPE,TYPE)                                                        \
     size_t SHMEM_FUNCTION_ATTRIBUTES                                                           \
     shmemx_##STYPE##_test_some(TYPE *vars, size_t nelems, size_t *indices,                     \
-                               int *status, int cond, TYPE value)                              \
+                               const int *status, int cond, TYPE value)                        \
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
@@ -427,7 +434,6 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
             if (status == NULL || !status[i]) {                                                \
                 COMP(cond, vars[i], value, cmpret);                                            \
                 if (cmpret) {                                                                  \
-                    if (status) status[i] = 1;                                                 \
                     indices[ncompleted++] = i;                                                 \
                     cmpret = 0;                                                                \
                 }                                                                              \

--- a/test/shmemx/c11_test_shmemx_test.c
+++ b/test/shmemx/c11_test_shmemx_test.c
@@ -43,8 +43,9 @@
     static TYPE remote = 0;                                                    \
     const int mype = shmem_my_pe();                                            \
     const int npes = shmem_n_pes();                                            \
+    int status = 0;                                                            \
     shmem_p(&remote, (TYPE)mype+1, (mype + 1) % npes);                         \
-    while (!shmemx_test_all(&remote, 1, SHMEM_CMP_NE, 0)) ;                    \
+    while (!shmemx_test_all(&remote, 1, &status, SHMEM_CMP_NE, 0)) ;           \
     if (remote != (TYPE)((mype + npes - 1) % npes)+1) {                        \
       printf("PE %i received incorrect value with "                            \
              "TEST_SHMEM_TEST_ALL(%s)\n", mype, #TYPE);                        \

--- a/test/shmemx/shmemx_test_all.c
+++ b/test/shmemx/shmemx_test_all.c
@@ -39,11 +39,12 @@ int main(void)
     int npes = shmem_n_pes();
 
     int *flags = shmem_calloc(npes, sizeof(int));
+    int *status = NULL;
 
     for (int i = 0; i < npes; i++)
         shmem_int_p(&flags[mype], 1, i);
 
-    while (!shmemx_int_test_all(flags, npes, SHMEM_CMP_EQ, 1));
+    while (!shmemx_int_test_all(flags, npes, status, SHMEM_CMP_EQ, 1));
 
     /* Check the flags array */
     for (int i = 0; i < npes; i++) {

--- a/test/spec-example/shmemx_test_any.c
+++ b/test/spec-example/shmemx_test_any.c
@@ -85,7 +85,7 @@ int main(void)
     /* Sanity check case with NULL status array */
     completed_idx = shmemx_int_test_any(flags, npes, NULL, SHMEM_CMP_EQ, 1);
 
-    if (completed_idx >= npes)
+    if (completed_idx >= (size_t)npes)
         shmem_global_exit(3);
 
 

--- a/test/spec-example/shmemx_wait_until_any.c
+++ b/test/spec-example/shmemx_wait_until_any.c
@@ -84,7 +84,7 @@ int main(void)
     /* Sanity check the case with NULL status array */
     completed_idx = shmemx_int_wait_until_any(flags, npes, NULL, SHMEM_CMP_EQ, 1);
 
-    if (completed_idx >= npes)
+    if (completed_idx >= (size_t)npes)
         shmem_global_exit(3);
 
     shmem_finalize();

--- a/test/spec-example/shmemx_wait_until_some.c
+++ b/test/spec-example/shmemx_wait_until_some.c
@@ -56,7 +56,7 @@ int main(void)
     /* Sanity check the case with NULL status array */
     ncompleted = shmemx_int_wait_until_some(flags, npes, indices, NULL, SHMEM_CMP_EQ, 1);
 
-    if (ncompleted != npes)
+    if (ncompleted != (size_t)npes)
         shmem_global_exit(3);
 
     shmem_finalize();


### PR DESCRIPTION
* add `status` array to `shmem_test_all`
* make `status` a const
* remove updates to `status` when conditions are satisfied
* update corresponding unit tests
* fix compiler comparison warnings with a cast

