### PR TITLE
Fix several bugs in the team_split_2D operation

### DIFF
--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -373,10 +373,10 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
 
     int start = 0;
     int ret = 0;
-
-    shmem_internal_team_t *my_xteam, *my_yteam;
+    *xaxis_team = SHMEMX_TEAM_INVALID;
 
     for (int i = 0; i < num_xteams; i++) {
+        shmem_internal_team_t *my_xteam;
         int xsize = (i == num_xteams - 1 && parent_size % xrange) ? parent_size % xrange : xrange;
 
         ret = shmem_internal_team_split_strided(parent_team, start, parent_stride,
@@ -386,13 +386,17 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
         }
         start += xrange;
 
-        if (my_xteam != SHMEMX_TEAM_INVALID)
+        if (my_xteam != SHMEMX_TEAM_INVALID) {
+            shmem_internal_assert(*xaxis_team == SHMEMX_TEAM_INVALID);
             *xaxis_team = my_xteam;
+        }
     }
 
     start = 0;
+    *yaxis_team = SHMEMX_TEAM_INVALID;
 
     for (int i = 0; i < num_yteams; i++) {
+        shmem_internal_team_t *my_yteam;
         int remainder = parent_size % xrange;
         int yrange = parent_size / xrange;
         int ysize = (remainder && i < remainder) ? yrange + 1 : yrange;
@@ -404,8 +408,10 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
         }
         start += 1;
 
-        if (my_yteam != SHMEMX_TEAM_INVALID)
+        if (my_yteam != SHMEMX_TEAM_INVALID) {
+            shmem_internal_assert(*yaxis_team == SHMEMX_TEAM_INVALID);
             *yaxis_team = my_yteam;
+        }
     }
 
     long *psync = shmem_internal_team_choose_psync(parent_team, SYNC);

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -249,7 +249,7 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
     *new_team = SHMEMX_TEAM_INVALID;
 
     if (parent_team == SHMEMX_TEAM_INVALID) {
-        return 0;
+        return 1;
     }
 
     int global_PE_start = shmem_internal_team_pe(parent_team, PE_start);
@@ -365,6 +365,17 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
                                  shmem_internal_team_t **xaxis_team, const shmemx_team_config_t *yaxis_config,
                                  long yaxis_mask, shmem_internal_team_t **yaxis_team)
 {
+    *xaxis_team = SHMEMX_TEAM_INVALID;
+    *yaxis_team = SHMEMX_TEAM_INVALID;
+
+    if (parent_team == SHMEMX_TEAM_INVALID) {
+        return 1;
+    }
+
+    if (xrange > parent_team->size) {
+        xrange = parent_team->size;
+    }
+
     const int parent_start = parent_team->start;
     const int parent_stride = parent_team->stride;
     const int parent_size = parent_team->size;
@@ -373,7 +384,6 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
 
     int start = 0;
     int ret = 0;
-    *xaxis_team = SHMEMX_TEAM_INVALID;
 
     for (int i = 0; i < num_xteams; i++) {
         shmem_internal_team_t *my_xteam;
@@ -393,7 +403,6 @@ int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
     }
 
     start = 0;
-    *yaxis_team = SHMEMX_TEAM_INVALID;
 
     for (int i = 0; i < num_yteams; i++) {
         shmem_internal_team_t *my_yteam;

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -33,6 +33,7 @@ check_PROGRAMS += \
 	shmemx_test_all \
 	c11_test_shmemx_wait_until \
 	c11_test_shmemx_test \
+	shmemx_team_split_2d \
 	shmemx_team_translate_2 \
 	shmemx_team_reuse_teams \
 	shmemx_team_collect_active_set \

--- a/test/shmemx/shmemx_team_reuse_teams.c
+++ b/test/shmemx/shmemx_team_reuse_teams.c
@@ -57,7 +57,7 @@ int main(void)
         }
 
         ret = shmemx_team_split_strided(old_team, 1, 1, shmemx_team_n_pes(old_team)-1, NULL, 0, &new_team);
-        if (ret) ++errors;
+        if (old_team != SHMEMX_TEAM_INVALID && ret) ++errors;
 
         shmemx_team_destroy(old_team);
         old_team = new_team;

--- a/test/shmemx/shmemx_team_split_2d.c
+++ b/test/shmemx/shmemx_team_split_2d.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2019 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <shmem.h>
+#include <shmemx.h>
+
+static int check_2d(shmemx_team_t team, int xdim) {
+    int me = shmemx_team_my_pe(team);
+
+    shmemx_team_t xteam, yteam;
+
+    int ret = shmemx_team_split_2d(team, xdim, NULL, 0, &xteam, NULL, 0, &yteam);
+    int errors = 0;
+
+    if (ret == 0) {
+        int npes_x = shmemx_team_n_pes(xteam);
+        int npes_y = shmemx_team_n_pes(yteam);
+
+        if (xteam == SHMEMX_TEAM_INVALID || yteam == SHMEMX_TEAM_INVALID) {
+            printf("%d: Error, received an invalid team\n", shmem_my_pe());
+            ++errors;
+        }
+
+        /* Try converting the PE ids from xteam and yteam to global indices and
+         * compare with the expected indices */
+        for (int i = 0; i < npes_x; i++) {
+            int pe_g       = shmemx_team_translate_pe(xteam, i, SHMEMX_TEAM_WORLD);
+            int expected_g = shmemx_team_translate_pe(team, me/xdim * xdim + i, SHMEMX_TEAM_WORLD);
+
+            if (pe_g != expected_g) {
+                printf("%d: xteam pe %d expected %d, got %d\n", me, i, pe_g, expected_g);
+                errors++;
+            }
+        }
+
+        for (int i = 0; i < npes_y; i++) {
+            int pe_g = shmemx_team_translate_pe(yteam, i, SHMEMX_TEAM_WORLD);
+            int expected_g = shmemx_team_translate_pe(team, me % xdim + i * xdim, SHMEMX_TEAM_WORLD);
+
+            if (pe_g != expected_g) {
+                printf("%d: yteam pe %d expected %d, got %d\n", me, i, pe_g, expected_g);
+                errors++;
+            }
+        }
+
+        shmemx_team_destroy(xteam);
+        shmemx_team_destroy(yteam);
+    }
+
+    return errors != 0;
+}
+
+int main(void) {
+    int errors = 0, npes, ret;
+    shmemx_team_t even_team;
+
+    shmem_init();
+
+    npes = shmem_n_pes();
+
+    errors += check_2d(SHMEMX_TEAM_WORLD, 1);
+    errors += check_2d(SHMEMX_TEAM_WORLD, 2);
+    errors += check_2d(SHMEMX_TEAM_WORLD, 3);
+
+    ret = shmemx_team_split_strided(SHMEMX_TEAM_WORLD, 0, 2, npes/2 + 1, NULL, 0, &even_team);
+
+    if (ret == 0) {
+        errors += check_2d(even_team, 1);
+        errors += check_2d(even_team, 2);
+        errors += check_2d(even_team, 3);
+    }
+
+    shmem_finalize();
+    return errors != 0;
+}


### PR DESCRIPTION
The 2D team split operation was neglected a bit during the development of `shmem_team_split_strided`, so it's missing some important properties:

* PE numbers must be w.r.t. the team indexing
* updates to the PE strides must be w.r.t. the team's stride
* The returned team object(s) should be the one(s) containing my PE

I believe these changes more-or-less fix the issues we are seeing in the 2D example in #918.
