### PR TITLE
Update NEWS and MAJOR/MINOR_VERSION for v1.4.5

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,8 @@ v1.4.5
 - Added support for shared memory atomic operations with the appropriate
   acquire/release memory ordering where required.  This feature requires
   the --enable-shr-transport build flag.
+- Improved experimental support for the RXM/Verbs provider stack with
+  libfabric 1.8 and newer.
 - Updated SOS to use the new OFI memory registration mode flags instead of
   the deprecated FI_MR_SCALABLE/FI_MR_BASIC modes.
 - Updated the wait/test any/all/some "status" array semantics to reflect

--- a/NEWS
+++ b/NEWS
@@ -18,7 +18,7 @@ v1.4.5
 - Updated the utility atomics (spinlocks and counters) to use __atomic built-in
   functions rather than the deprecated __sync builtins.
 - Removed redundant shmem_barrier_all from the GUPS example application.
-- Moved examples taken from the OpenSHMEM specification to the
+- Moved unit tests derived from OpenSHMEM specification examples to the
   test/spec-example directory.
 
 v1.4.4

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,25 @@
 
 Sandia OpenSHMEM NEWS -- history of user-visible changes.
 
+v1.4.5
+------
+- Added a complete OpenSHMEM teams API to the shmemx interfaces.
+- Added the OpenSHMEM wait/test vector API to the shmemx interfaces.
+- Added support for shared memory atomic operations with the appropriate
+  acquire/release memory ordering where required.  This feature requires
+  the --enable-shr-transport build flag.
+- Updated SOS to use the new OFI memory registration mode flags instead of
+  the deprecated FI_MR_SCALABLE/FI_MR_BASIC modes.
+- Updated the wait/test any/all/some "status" array semantics to reflect
+  recent changes to the OpenSHMEM specification.
+- Added a memory sync before returning from barriers to ensure shared memory
+  updates and remote updates cached in the NIC are visible in memory.
+- Updated the utility atomics (spinlocks and counters) to use __atomic built-in
+  functions rather than the deprecated __sync builtins.
+- Removed redundant shmem_barrier_all from the GUPS example application.
+- Moved examples taken from the OpenSHMEM specification to the
+  test/spec-example directory.
+
 v1.4.4
 ------
 - Experimental support for RXM/Verbs provider stack with libfabric 1.8.

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.4.4], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.4.5], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])


### PR DESCRIPTION
Here is a draft of the `NEWS` file for a v1.4.5 release.  Am I missing anything?

With regard to the open PRs, I think #929 might be ok to include in v1.4.5, but everything is tested except for that change... (except Portals, still need to check that).  #918 may change as v1.5 of the OpenSHMEM specification is released, so I tend to think we should defer that one.  Thoughts @jdinan and @wrrobin?