### PR TITLE
Use standard C interface in spec-tests (for now)

### DIFF
--- a/test/spec-example/shmemx_wait_until_any_vector.c
+++ b/test/spec-example/shmemx_wait_until_any_vector.c
@@ -49,8 +49,8 @@ int main(void)
 
     /* All odd PEs put 2 and all even PEs put 1 */
     for (int i = 0; i < npes; i++) {
-        shmem_atomic_set(&ivars[mype], mype % 2 + 1, i);
-        
+        shmem_int_atomic_set(&ivars[mype], mype % 2 + 1, i);
+
         /* Set cmp_values to the expected values coming from each PE */
         cmp_values[i] = i % 2 + 1;
     }


### PR DESCRIPTION
I caught a compilation error while testing an older compiler without C11 support  (gcc 4.8.5).

In `test/spec-examples`, it looks like we're using the C interfaces in many places where C11 is used... It seems like the path of least resistance for now, but I'll create a low-priority issue for this.