### PR TITLE
Resolving comparison warnings in p2p vector tests

### DIFF
--- a/test/shmemx/c11_test_shmemx_test_vector.c
+++ b/test/shmemx/c11_test_shmemx_test_vector.c
@@ -14,7 +14,7 @@
         int *status = calloc(npes, sizeof(int));                                                                     \
         TYPE *cmp_values = malloc(npes * sizeof(TYPE));                                                              \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -46,7 +46,7 @@
         int *status = calloc(npes, sizeof(int));                                                                     \
         TYPE *cmp_values = malloc(npes * sizeof(TYPE));                                                              \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -57,9 +57,9 @@
                                                                                                                      \
         expected_sum = (npes-1) * npes / 2;                                                                          \
                                                                                                                      \
-        size_t ncompleted = 0;                                                                                       \
+        int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
-            int ndone = shmemx_test_any_vector(ivars, npes, status, SHMEM_CMP_EQ, cmp_values);                       \
+            size_t ndone = shmemx_test_any_vector(ivars, npes, status, SHMEM_CMP_EQ, cmp_values);                    \
             if (ndone != SIZE_MAX){                                                                                  \
                 status[ndone] = 1;                                                                                   \
                 total_sum += ivars[ndone];                                                                           \
@@ -83,7 +83,7 @@
                                                                                                                      \
         size_t *indices  = malloc(npes * sizeof(size_t));                                                            \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -94,13 +94,13 @@
                                                                                                                      \
         expected_sum = (npes-1) * npes / 2;                                                                          \
                                                                                                                      \
-        size_t ncompleted = 0;                                                                                       \
+        int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
-            int ndone = shmemx_test_some_vector(ivars, npes, indices, status, SHMEM_CMP_EQ, cmp_values);             \
+            size_t ndone = shmemx_test_some_vector(ivars, npes, indices, status, SHMEM_CMP_EQ, cmp_values);          \
             if(ndone != 0){                                                                                          \
-                for(i = 0; i < ndone; i++){                                                                          \
-                    total_sum += ivars[indices[i]];                                                                  \
-                    status[indices[i]] = 1;                                                                          \
+                for(size_t j = 0; j < ndone; j++){                                                                   \
+                    total_sum += ivars[indices[j]];                                                                  \
+                    status[indices[j]] = 1;                                                                          \
                 }                                                                                                    \
                 ncompleted += ndone;                                                                                 \
             }                                                                                                        \

--- a/test/shmemx/c11_test_shmemx_test_vector.c
+++ b/test/shmemx/c11_test_shmemx_test_vector.c
@@ -71,7 +71,7 @@
             rc = EXIT_FAILURE;                                                                                       \
         }                                                                                                            \
                                                                                                                      \
-    } while(0)                                                                                                       
+    } while(0)
 
 #define TEST_SHMEM_TEST_SOME(TYPE)                                                                                   \
     do{                                                                                                              \
@@ -110,7 +110,7 @@
             rc = EXIT_FAILURE;                                                                                       \
         }                                                                                                            \
                                                                                                                      \
-    } while(0)                                                                                                       
+    } while(0)
 
 
 #else
@@ -123,7 +123,7 @@
 
 int main(void)
 {
-   
+
     shmem_init();
 
     int rc = EXIT_SUCCESS;
@@ -168,7 +168,6 @@ int main(void)
 
 
     shmem_finalize();
-    return rc;    
-
+    return rc;
 
 }

--- a/test/shmemx/c11_test_shmemx_wait_until_vector.c
+++ b/test/shmemx/c11_test_shmemx_wait_until_vector.c
@@ -14,7 +14,7 @@
         int *status = calloc(npes, sizeof(int));                                                                     \
         TYPE *cmp_values = malloc(npes * sizeof(TYPE));                                                              \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -43,7 +43,7 @@
         int *status = calloc(npes, sizeof(int));                                                                     \
         TYPE *cmp_values = malloc(npes * sizeof(TYPE));                                                              \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -54,7 +54,7 @@
                                                                                                                      \
         expected_sum = (npes-1) * npes / 2;                                                                          \
                                                                                                                      \
-        size_t ncompleted = 0;                                                                                       \
+        int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
             int ndone = shmemx_wait_until_any_vector(ivars, npes, status, SHMEM_CMP_EQ, cmp_values);                 \
             status[ndone] = 1;                                                                                       \
@@ -78,7 +78,7 @@
                                                                                                                      \
         size_t *indices  = malloc(npes * sizeof(size_t));                                                            \
                                                                                                                      \
-        size_t i = 0;                                                                                                \
+        int i = 0;                                                                                                   \
         int expected_sum = 0;                                                                                        \
         int total_sum = 0;                                                                                           \
                                                                                                                      \
@@ -89,7 +89,7 @@
                                                                                                                      \
         expected_sum = (npes-1) * npes / 2;                                                                          \
                                                                                                                      \
-        size_t ncompleted = 0;                                                                                       \
+        int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
             int ndone = shmemx_wait_until_some_vector(ivars, npes, indices, status, SHMEM_CMP_EQ, cmp_values);       \
             for(i = 0; i < ndone; i++){                                                                              \

--- a/test/shmemx/c11_test_shmemx_wait_until_vector.c
+++ b/test/shmemx/c11_test_shmemx_wait_until_vector.c
@@ -56,7 +56,7 @@
                                                                                                                      \
         int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
-            int ndone = shmemx_wait_until_any_vector(ivars, npes, status, SHMEM_CMP_EQ, cmp_values);                 \
+            size_t ndone = shmemx_wait_until_any_vector(ivars, npes, status, SHMEM_CMP_EQ, cmp_values);              \
             status[ndone] = 1;                                                                                       \
             total_sum += ivars[ndone];                                                                               \
             ncompleted++;                                                                                            \
@@ -66,7 +66,7 @@
             rc = EXIT_FAILURE;                                                                                       \
         }                                                                                                            \
                                                                                                                      \
-    } while(0)                                                                                                       
+    } while(0)
 
 #define TEST_SHMEM_WAIT_UNTIL_SOME(TYPE)                                                                             \
     do{                                                                                                              \
@@ -91,10 +91,10 @@
                                                                                                                      \
         int ncompleted = 0;                                                                                          \
         while(ncompleted < npes){                                                                                    \
-            int ndone = shmemx_wait_until_some_vector(ivars, npes, indices, status, SHMEM_CMP_EQ, cmp_values);       \
-            for(i = 0; i < ndone; i++){                                                                              \
-                total_sum += ivars[indices[i]];                                                                      \
-                status[indices[i]] = 1;                                                                              \
+            size_t ndone = shmemx_wait_until_some_vector(ivars, npes, indices, status, SHMEM_CMP_EQ, cmp_values);    \
+            for(size_t j = 0; j < ndone; j++){                                                                       \
+                total_sum += ivars[indices[j]];                                                                      \
+                status[indices[j]] = 1;                                                                              \
             }                                                                                                        \
             ncompleted += ndone;                                                                                     \
         }                                                                                                            \
@@ -103,7 +103,7 @@
             rc = EXIT_FAILURE;                                                                                       \
         }                                                                                                            \
                                                                                                                      \
-    } while(0)                                                                                                       
+    } while(0)
 
 
 #else
@@ -116,7 +116,7 @@
 
 int main(void)
 {
-   
+
     shmem_init();
 
     int rc = EXIT_SUCCESS;
@@ -161,7 +161,6 @@ int main(void)
 
 
     shmem_finalize();
-    return rc;    
-
+    return rc;
 
 }


### PR DESCRIPTION
The compiler warns about these comparisons when using `-Wall -Wextra` flags.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>