### PR TITLE
UCX Transport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,26 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
 
+        ## UCX Builds
+        - >
+          SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
+          SOS_BUILD_OPTS="--enable-pmi-simple"
+        - >
+          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
+          SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
+        - >
+          SOS_DISABLE_FORTRAN=1
+          SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
+          SOS_BUILD_OPTS="--enable-pmi-mpi CC=mpicc"
+        - >
+          SOS_DISABLE_FORTRAN=1
+          SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
+          SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-pmi-simple"
+        - >
+          SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
+          SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-error-checking --enable-pmi-simple"
+
 os:
     - linux
 
@@ -219,6 +239,17 @@ before_install:
         cd libfabric
         ./autogen.sh
         ./configure --prefix=$TRAVIS_INSTALL/libfabric
+        make $TRAVIS_PAR_MAKE
+        make install
+      fi
+    ## Build UCX
+    - >
+      if [[ $SOS_TRANSPORT_OPTS = *"with-ucx"* ]]; then
+        cd $TRAVIS_SRC
+        git clone -b v1.7.0 --depth 10 https://github.com/openucx/ucx.git
+        cd ucx
+        ./autogen.sh
+        ./configure --prefix=$TRAVIS_INSTALL/ucx --enable-mt --disable-numa
         make $TRAVIS_PAR_MAKE
         make install
       fi

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -1,0 +1,146 @@
+# -*- shell-script -*-
+#
+# Copyright (C) 2015-2017 Mellanox Technologies, Inc.
+#                         All rights reserved.
+# Copyright (c) 2015      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+#                         reserved.
+# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# OMPI_CHECK_UCX(prefix, [action-if-found], [action-if-not-found])
+# --------------------------------------------------------
+# check if UCX support can be found.  sets prefix_{CPPFLAGS,
+# LDFLAGS, LIBS} as needed and runs action-if-found if there is
+# support, otherwise executes action-if-not-found
+AC_DEFUN([OMPI_CHECK_UCX],[
+    OPAL_VAR_SCOPE_PUSH([ompi_check_ucx_dir])
+
+    AS_IF([test -z "$ompi_check_ucx_happy"],
+          [AC_ARG_WITH([ucx],
+		       [AC_HELP_STRING([--with-ucx(=DIR)],
+				       [Build with Unified Communication X library support])])
+	   OPAL_CHECK_WITHDIR([ucx], [$with_ucx], [include/ucp/api/ucp.h])
+	   AC_ARG_WITH([ucx-libdir],
+		       [AC_HELP_STRING([--with-ucx-libdir=DIR],
+				       [Search for Unified Communication X libraries in DIR])])
+	   OPAL_CHECK_WITHDIR([ucx-libdir], [$with_ucx_libdir], [libucp.*])
+
+	   AS_IF([test "$with_ucx" != "no"],
+                 [AS_IF([test -n "$with_ucx" && test "$with_ucx" != "yes"],
+                        [ompi_check_ucx_dir="$with_ucx"],
+                        [PKG_CHECK_MODULES_STATIC([ucx],[ucx],
+                                             [ompi_check_ucx_dir=`$PKG_CONFIG --variable=prefix ucx`
+                                              AS_IF([test "$ompi_check_ucx_dir" = "/usr"],
+                                                    [ompi_check_ucx_dir=])],
+                                             [true])])
+                  ompi_check_ucx_happy="no"
+                  AS_IF([test -z "$ompi_check_ucx_dir"],
+                        [OPAL_CHECK_PACKAGE([ompi_check_ucx],
+                                   [ucp/api/ucp.h],
+                                   [ucp],
+                                   [ucp_cleanup],
+                                   [-luct -lucm -lucs],
+                                   [],
+                                   [],
+                                   [ompi_check_ucx_happy="yes"],
+                                   [ompi_check_ucx_happy="no"])
+                         AS_IF([test "$ompi_check_ucx_happy" = yes],
+                               [AC_MSG_CHECKING(for UCX version compatibility)
+                                AC_REQUIRE_CPP
+                                AC_COMPILE_IFELSE(
+                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                                    [ompi_check_ucx_happy="yes"],
+                                    [ompi_check_ucx_happy="no"])
+
+                                AC_MSG_RESULT([$ompi_check_ucx_happy])])
+                         AS_IF([test "$ompi_check_ucx_happy" = "no"],
+                               [ompi_check_ucx_dir=/opt/ucx])])
+                  AS_IF([test "$ompi_check_ucx_happy" != yes],
+                        [AS_IF([test -n "$with_ucx_libdir"],
+                               [ompi_check_ucx_libdir="$with_ucx_libdir"],
+                               [files=`ls $ompi_check_ucx_dir/lib64/libucp.* 2> /dev/null | wc -l`
+                                AS_IF([test "$files" -gt 0],
+                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib64],
+                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib])])
+
+                         ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
+                         ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
+                         ompi_check_ucx_$1_save_LIBS="$LIBS"
+
+                         OPAL_CHECK_PACKAGE([ompi_check_ucx],
+                                            [ucp/api/ucp.h],
+                                            [ucp],
+                                            [ucp_cleanup],
+                                            [-luct -lucm -lucs],
+                                            [$ompi_check_ucx_dir],
+                                            [$ompi_check_ucx_libdir],
+                                            [ompi_check_ucx_happy="yes"],
+                                            [ompi_check_ucx_happy="no"])
+
+                         CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
+                         LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
+                         LIBS="$ompi_check_ucx_$1_save_LIBS"
+
+                         AS_IF([test "$ompi_check_ucx_happy" = yes],
+                               [AC_MSG_CHECKING(for UCX version compatibility)
+                                AC_REQUIRE_CPP
+                                old_CPPFLAGS="$CPPFLAGS"
+                                CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
+                                AC_COMPILE_IFELSE(
+                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                                    [ompi_check_ucx_happy="yes"],
+                                    [ompi_check_ucx_happy="no"])
+
+                                AC_MSG_RESULT([$ompi_check_ucx_happy])
+                                CPPFLAGS=$old_CPPFLAGS])])
+
+                  old_CPPFLAGS="$CPPFLAGS"
+                  AS_IF([test -n "$ompi_check_ucx_dir"],
+                        [CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"])
+                  AC_CHECK_DECLS([ucp_tag_send_nbr],
+                                 [AC_DEFINE([HAVE_UCP_TAG_SEND_NBR],[1],
+                                            [have ucp_tag_send_nbr()])], [],
+                                 [#include <ucp/api/ucp.h>])
+                  AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb,
+                                  ucp_request_check_status, ucp_put_nb, ucp_get_nb],
+                                 [], [],
+                                 [#include <ucp/api/ucp.h>])
+                  AC_CHECK_DECLS([ucm_test_events],
+                                 [], [],
+                                 [#include <ucm/api/ucm.h>])
+                  AC_CHECK_DECLS([UCP_ATOMIC_POST_OP_AND,
+                                  UCP_ATOMIC_POST_OP_OR,
+                                  UCP_ATOMIC_POST_OP_XOR,
+                                  UCP_ATOMIC_FETCH_OP_FAND,
+                                  UCP_ATOMIC_FETCH_OP_FOR,
+                                  UCP_ATOMIC_FETCH_OP_FXOR,
+                                  UCP_PARAM_FIELD_ESTIMATED_NUM_PPN],
+                                 [], [],
+                                 [#include <ucp/api/ucp.h>])
+                  AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],
+                                 [AC_DEFINE([HAVE_UCP_WORKER_ADDRESS_FLAGS], [1],
+                                            [have worker address attribute])], [],
+                                 [#include <ucp/api/ucp.h>])
+                  CPPFLAGS=$old_CPPFLAGS
+
+                  OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])])])
+
+    AS_IF([test "$ompi_check_ucx_happy" = "yes"],
+          [$1_CPPFLAGS="[$]$1_CPPFLAGS $ompi_check_ucx_CPPFLAGS"
+           $1_LDFLAGS="[$]$1_LDFLAGS $ompi_check_ucx_LDFLAGS"
+           $1_LIBS="[$]$1_LIBS $ompi_check_ucx_LIBS"
+           $2],
+          [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "no"],
+                 [AC_MSG_ERROR([UCX support requested but not found.  Aborting])])
+           $3])
+
+    OPAL_VAR_SCOPE_POP
+])
+

--- a/configure.ac
+++ b/configure.ac
@@ -349,31 +349,55 @@ OPAL_CHECK_OFI([ofi],
     [transport_ofi="no"])
 
 # FIXME: Temporary hack
-AC_DEFINE([USE_UCX], [1], [Enable UCX transport])
-transport_ucx="yes"
+AC_ARG_WITH([ucx],
+    [AC_HELP_STRING([--with-ucx],
+                    [Enable the UCX transport. (default: disabled)])])
 
-# If both OFI and portals4 requested, user needs to choose one:
-if test -n "$with_ofi" -a "$with_ofi" != "no" -a -n "$with_portals4" -a "$with_portals4" != "no" ; then
-    AC_MSG_ERROR([Cannot choose both OFI and portals4 transports, see --help for details])
-# Check which was requested, OFI or portals4:
+num_transports=""
+if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
+    num_transports="x$num_transports"
+fi
+if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
+    num_transports="x$num_transports"
+fi
+if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
+    num_transports="x$num_transports"
+    transport_ucx="yes"
+fi
+
+if test -n "$num_transports" -a "$num_transports" != "x" ; then
+    AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
+fi
+
+if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
+    transport="portals4"
+    AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
 elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
     transport="ofi"
-    transport_portals4="no"
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
-elif test -n "$with_portals4" -a "$with_portals4" != "no" ; then
-    transport="portals4"
-    transport_ofi="no"
-    AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
-# If neither, set transport to "none" and print a warning:
+elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
+    transport="ucx"
+    transport_ucx="yes"
+    # FIXME: Temporary hack until UCX is wired into the build system properly
+    if test "$with_ucx" != "yes" ; then
+        CFLAGS="$CFLAGS -I$with_ucx/include"
+        LDFLAGS="$LDFLAGS -L$with_ucx/lib -lucs -lucp"
+    else
+        LDFLAGS="$LDFLAGS -lucs -lucp"
+    fi
+    AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
+    AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
 else
     transport="none"
-    transport_ofi="no"
     transport_portals4="no"
+    transport_ofi="no"
+    transport_ucx="no"
     AC_MSG_WARN([Neither OFI nor portals4 transport requested])
 fi
-AM_CONDITIONAL([USE_UCX], [test "$transport_ucx" = "yes"])
-AM_CONDITIONAL([USE_OFI], [test "$transport_ofi" = "yes"])
+
 AM_CONDITIONAL([USE_PORTALS4], [test "$transport_portals4" = "yes"])
+AM_CONDITIONAL([USE_OFI], [test "$transport_ofi" = "yes"])
+AM_CONDITIONAL([USE_UCX], [test "$transport_ucx" = "yes"])
 
 SANDIA_CHECK_XPMEM(
     [transport_xpmem="yes"],
@@ -844,7 +868,7 @@ AC_OUTPUT
 AS_IF([test "$enable_pmi_mpi" != "yes" -a "$enable_pmi_simple" != "yes" -a "$opal_external_pmix_version_found" != 1 -a "$ompi_check_pmi_happy" != "yes" -a -z "$pmi_type"],
          [AC_MSG_ERROR([No PMI client interface was configured, consider --enable-pmi-simple or --with-pmi])])
 
-AS_IF([test "$transport_portals4" != "yes" -a "$transport_ofi" != "yes"],
+AS_IF([test -z "$num_transports"],
       [AC_MSG_WARN([No transport found, resulting library will be unable to exchange messages])])
 
 AS_IF([test "$shmem_cv_c11_works" != "yes"],
@@ -880,6 +904,7 @@ echo ""
 echo "Transports:"
 echo "  Portals 4:      $transport_portals4"
 echo "  OFI:            $transport_ofi"
+echo "  UCX:            $transport_ucx"
 echo ""
 echo "On Node Communication:"
 echo "  XPMEM:          $transport_xpmem"

--- a/configure.ac
+++ b/configure.ac
@@ -348,10 +348,9 @@ OPAL_CHECK_OFI([ofi],
     [transport_ofi="yes"],
     [transport_ofi="no"])
 
-# FIXME: Temporary hack
-AC_ARG_WITH([ucx],
-    [AC_HELP_STRING([--with-ucx],
-                    [Enable the UCX transport. (default: disabled)])])
+OMPI_CHECK_UCX([ucx],
+    [transport_ucx="yes"],
+    [transport_ucx="no"])
 
 num_transports=""
 if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
@@ -362,7 +361,6 @@ if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
 fi
 if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
     num_transports="x$num_transports"
-    transport_ucx="yes"
 fi
 
 if test -n "$num_transports" -a "$num_transports" != "x" ; then
@@ -377,14 +375,6 @@ elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
 elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
     transport="ucx"
-    transport_ucx="yes"
-    # FIXME: Temporary hack until UCX is wired into the build system properly
-    if test "$with_ucx" != "yes" ; then
-        CFLAGS="$CFLAGS -I$with_ucx/include"
-        LDFLAGS="$LDFLAGS -L$with_ucx/lib -lucs -lucp"
-    else
-        LDFLAGS="$LDFLAGS -lucs -lucp"
-    fi
     AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
     AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
 else
@@ -392,7 +382,7 @@ else
     transport_portals4="no"
     transport_ofi="no"
     transport_ucx="no"
-    AC_MSG_WARN([Neither OFI nor portals4 transport requested])
+    AC_MSG_WARN([No transport requested])
 fi
 
 AM_CONDITIONAL([USE_PORTALS4], [test "$transport_portals4" = "yes"])
@@ -810,6 +800,14 @@ if test "$transport_ofi" = "yes" ; then
     LIBS="$LIBS $ofi_LIBS"
     WRAPPER_COMPILER_EXTRA_LDFLAGS="$ofi_LDFLAGS"
     WRAPPER_COMPILER_EXTRA_LIBS="$ofi_LIBS"
+fi
+
+if test "$transport_ucx" = "yes" ; then
+    CPPFLAGS="$CPPFLAGS $ucx_CPPFLAGS"
+    LDFLAGS="$LDFLAGS $ucx_LDFLAGS"
+    LIBS="$LIBS $ucx_LIBS"
+    WRAPPER_COMPILER_EXTRA_LDFLAGS="$ucx_LDFLAGS"
+    WRAPPER_COMPILER_EXTRA_LIBS="$ucx_LIBS"
 fi
 
 if test "$transport_xpmem" = "yes" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -439,7 +439,7 @@ else
     transport_shr_atomics="no"
 fi
 
-if test "$enable_shr_atomics" != "no" -a "$transport" = "none"; then
+if test "$enable_shr_atomics" != "no" -a "$transport_xpmem" = "yes" -a "$transport" = "none"; then
     transport_shr_atomics="yes"
     AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,10 @@ OPAL_CHECK_OFI([ofi],
     [transport_ofi="yes"],
     [transport_ofi="no"])
 
+# FIXME: Temporary hack
+AC_DEFINE([USE_UCX], [1], [Enable UCX transport])
+transport_ucx="yes"
+
 # If both OFI and portals4 requested, user needs to choose one:
 if test -n "$with_ofi" -a "$with_ofi" != "no" -a -n "$with_portals4" -a "$with_portals4" != "no" ; then
     AC_MSG_ERROR([Cannot choose both OFI and portals4 transports, see --help for details])
@@ -367,6 +371,7 @@ else
     transport_portals4="no"
     AC_MSG_WARN([Neither OFI nor portals4 transport requested])
 fi
+AM_CONDITIONAL([USE_UCX], [test "$transport_ucx" = "yes"])
 AM_CONDITIONAL([USE_OFI], [test "$transport_ofi" = "yes"])
 AM_CONDITIONAL([USE_PORTALS4], [test "$transport_portals4" = "yes"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -433,7 +433,14 @@ AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
        AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
-if test "$enable_shr_atomics" != "no" -a "$transport_xpmem" = "yes" -a "$transport_ofi" = "no" -a "$transport_portals4" = "no" ; then
+if test "$enable_shr_atomics" = "yes"; then
+    transport_shr_atomics="yes"
+else
+    transport_shr_atomics="no"
+fi
+
+if test "$enable_shr_atomics" != "no" -a "$transport" = "none"; then
+    transport_shr_atomics="yes"
     AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])
 fi
 
@@ -912,6 +919,7 @@ echo "On Node Communication:"
 echo "  XPMEM:          $transport_xpmem"
 echo "  CMA:            $transport_cma"
 echo "  memcpy (self):  $transport_memcpy"
+echo "  Shr. atomics:   $transport_shr_atomics"
 echo ""
 echo "Global Options:"
 if test "$enable_remote_virtual_addressing" = "yes"; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,11 +100,19 @@ libsma_la_SOURCES += \
 	transport_ofi.c
 endif
 
+if USE_UCX
+libsma_la_SOURCES += \
+	transport_ucx.h \
+	transport_ucx.c
+endif
+
 if !USE_PORTALS4
 if !USE_OFI
+if !USE_UCX
 libsma_la_SOURCES += \
 	transport_none.c \
 	transport_none.h
+endif
 endif
 endif
 

--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -29,7 +29,7 @@
 /* Note: Increase MAX_KV_COUNT if more key/values are needed.  MAX_KV_COUNT is
  * 2 * the number of key/value pairs. */
 #define MAX_KV_COUNT 20
-#define MAX_KV_LENGTH 64
+#define MAX_KV_LENGTH 512
 
 static int rank = -1;
 static int size = 0;

--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -250,7 +250,7 @@ shmem_runtime_exchange(void)
 int
 shmem_runtime_put(char *key, void *value, size_t valuelen)
 {
-    if (kv_length < MAX_KV_COUNT) {
+    if (kv_length < MAX_KV_COUNT && valuelen < MAX_KV_LENGTH) {
         memcpy(kv_index(kv_store_me, kv_length), key, MAX_KV_LENGTH);
         kv_length++;
         memcpy(kv_index(kv_store_me, kv_length), value, MAX_KV_LENGTH);

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -40,7 +40,7 @@ static int initialized_pmi = 0;
 static int *location_array = NULL;
 
 #define SINGLETON_KEY_LEN 128
-#define SINGLETON_VAL_LEN 256
+#define SINGLETON_VAL_LEN 1024
 
 typedef struct {
     char key[SINGLETON_KEY_LEN];

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -49,7 +49,10 @@ void
 shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
                       long *completion)
 {
-    if (len == 0) return;
+    if (len == 0) {
+        *completion = 1;
+        return;
+    }
 
     if (shmem_shr_transport_use_write(ctx, target, source, len, pe)) {
         shmem_shr_transport_put(ctx, target, source, len, pe);

--- a/src/shmem_env.c
+++ b/src/shmem_env.c
@@ -203,6 +203,8 @@ printf("\nNetwork transport: %s\n",
        "OFI"
 #elif defined(USE_PORTALS4)
        "Portals 4"
+#elif defined(USE_UCX)
+       "UCX"
 #else
        "none"
 #endif

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -109,6 +109,11 @@ SHMEM_INTERNAL_ENV_DEF(OFI_STX_DISABLE_PRIVATE, bool, false, SHMEM_INTERNAL_ENV_
                        "Disallow private contexts from having exclusive STX access")
 #endif
 
+#ifdef USE_UCX
+SHMEM_INTERNAL_ENV_DEF(PROGRESS_INTERVAL, long, 1000, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Polling interval for progress thread in microseconds (0 to disable)")
+#endif
+
 #ifdef ENABLE_PMI_MPI
 SHMEM_INTERNAL_ENV_DEF(MPI_THREAD_LEVEL, string, "MPI_THREAD_SINGLE", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Specify the MPI threading level when MPI is used as the process manager")

--- a/src/transport.h
+++ b/src/transport.h
@@ -54,6 +54,9 @@ typedef enum shm_internal_datatype_t shm_internal_datatype_t;
 #elif defined (USE_OFI)
 #include "transport_ofi.h"
 
+#elif defined (USE_UCX)
+#include "transport_ucx.h"
+
 #else /* No transport */
 #include "transport_none.h"
 

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -28,6 +28,21 @@ ucp_mem_h     shmem_transport_ucp_mem_heap;
 
 shmem_transport_peer_t *shmem_transport_peers;
 
+/* Tables to translate between SHM_INTERNAL and UCP ops */
+ucp_atomic_post_op_t shmem_transport_ucx_post_op[] = {
+    UCP_ATOMIC_POST_OP_AND,
+    UCP_ATOMIC_POST_OP_OR,
+    UCP_ATOMIC_POST_OP_XOR,
+    UCP_ATOMIC_POST_OP_ADD
+};
+
+ucp_atomic_fetch_op_t shmem_transport_ucx_fetch_op[] = {
+    UCP_ATOMIC_FETCH_OP_FAND,
+    UCP_ATOMIC_FETCH_OP_FOR,
+    UCP_ATOMIC_FETCH_OP_FXOR,
+    UCP_ATOMIC_FETCH_OP_FADD
+};
+
 void shmem_transport_recv_cb_nop(void *request, ucs_status_t status) {
     return;
 }
@@ -156,6 +171,9 @@ int shmem_transport_startup(void)
                                    sizeof(shmem_transport_peer_t));
 
     /* Build connection table to each peer */
+    /* FIXME: Currently, we create connections to each peer during startup.
+     * Would it be better to create endpoints on-demand? And is there a limit
+     * to how many we can have? */
     for (i = 0; i < shmem_internal_num_pes; i++) {
         ucs_status_t status;
         ucp_ep_params_t params;

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -54,7 +54,7 @@ static int shmem_transport_ucx_progress_thread_enabled = 1;
 
 static void * shmem_transport_ucx_progress_thread_func(void *arg)
 {
-    while (shmem_transport_ucx_progress_thread_enabled) {
+    while (__atomic_load_n(&shmem_transport_ucx_progress_thread_enabled, __ATOMIC_ACQUIRE)) {
         ucp_worker_progress(shmem_transport_ucp_worker);
         usleep(shmem_internal_params.PROGRESS_INTERVAL);
     }
@@ -259,7 +259,7 @@ int shmem_transport_fini(void)
     int i;
     void *progress_out;
 
-    shmem_transport_ucx_progress_thread_enabled = 0;
+    __atomic_store_n(&shmem_transport_ucx_progress_thread_enabled, 0, __ATOMIC_RELEASE);
     pthread_join(shmem_transport_ucx_progress_thread, &progress_out);
 
     /* Clean up contexts */

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -129,11 +129,13 @@ int shmem_transport_init(void)
         if (ret) RAISE_ERROR_STR("Runtime put of UCX data segment rkey");
         ucp_rkey_buffer_release(rkey);
 
+#ifndef ENABLE_REMOTE_VIRTUAL_ADDRESSING
         ret = shmem_runtime_put("data_base", &shmem_internal_data_base, sizeof(uint8_t*));
         if (ret) {
             RAISE_WARN_STR("Put of data segment address to runtime KVS failed");
             return 1;
         }
+#endif
 
         /* Heap segment */
         params.address = shmem_internal_heap_base;
@@ -149,11 +151,13 @@ int shmem_transport_init(void)
         if (ret) RAISE_ERROR_STR("Runtime put of UCX heap segment rkey");
         ucp_rkey_buffer_release(rkey);
 
+#ifndef ENABLE_REMOTE_VIRTUAL_ADDRESSING
         ret = shmem_runtime_put("heap_base", &shmem_internal_heap_base, sizeof(uint8_t*));
         if (ret) {
             RAISE_WARN_STR("Put of heap address to runtime KVS failed");
             return 1;
         }
+#endif
     }
 
     /* Configure the default context */
@@ -215,11 +219,13 @@ int shmem_transport_startup(void)
         UCX_CHECK_STATUS(status);
         free(rkey);
 
+#ifndef ENABLE_REMOTE_VIRTUAL_ADDRESSING
         ret = shmem_runtime_get(i, "data_base", &shmem_transport_peers[i].data_base, sizeof(void*));
         if (ret) RAISE_ERROR_MSG("Runtime get of UCX data base address failed (PE %d, ret %d)\n", i, ret);
 
         ret = shmem_runtime_get(i, "heap_base", &shmem_transport_peers[i].heap_base, sizeof(void*));
         if (ret) RAISE_ERROR_MSG("Runtime get of UCX heap base address failed (PE %d, ret %d)\n", i, ret);
+#endif
     }
 
     return 0;

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -1,0 +1,219 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2020 NVidia Corporation.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+#include <string.h>
+#include "transport_ucx.h"
+#include "shmem.h"
+#include "shmem_team.h"
+#include <ucs/type/status.h>
+#include <ucs/type/thread_mode.h>
+#include <ucp/api/ucp_def.h>
+#include <ucp/api/ucp.h>
+
+shmem_transport_ctx_t shmem_transport_ctx_default;
+shmem_ctx_t SHMEM_CTX_DEFAULT = (shmem_ctx_t) &shmem_transport_ctx_default;
+
+ucp_context_h shmem_transport_ucp_ctx;
+ucp_worker_h  shmem_transport_ucp_worker;
+ucp_config_t *shmem_transport_ucp_config;
+ucp_mem_h     shmem_transport_ucp_mem_data;
+ucp_mem_h     shmem_transport_ucp_mem_heap;
+
+shmem_transport_peer_t *shmem_transport_peers;
+
+int shmem_transport_init(void)
+{
+    ucs_status_t status;
+    ucp_params_t params;
+    ucp_worker_params_t worker_params;
+
+    params.field_mask = UCP_PARAM_FIELD_FEATURES;
+    params.features   = UCP_FEATURE_RMA | UCP_FEATURE_AMO32 | UCP_FEATURE_AMO64;
+
+    status = ucp_config_read(NULL, NULL, &shmem_transport_ucp_config);
+    UCX_CHECK_STATUS(status);
+    status = ucp_init(&params, shmem_transport_ucp_config, &shmem_transport_ucp_ctx);
+    UCX_CHECK_STATUS(status);
+
+    /* FIXME: Currently only supporting THREAD_SINGLE */
+    shmem_internal_assertp(shmem_internal_thread_level == SHMEM_THREAD_SINGLE);
+    worker_params.field_mask  = UCP_WORKER_PARAM_FIELD_THREAD_MODE;
+    worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
+
+    status = ucp_worker_create(shmem_transport_ucp_ctx, &worker_params,
+                               &shmem_transport_ucp_worker);
+    UCX_CHECK_STATUS(status);
+
+    /* Publish addressing info to be exchanged by runtime layer */
+    {
+        ucp_address_t *addr;
+        size_t len;
+        int ret;
+
+        status = ucp_worker_get_address(shmem_transport_ucp_worker, &addr, &len);
+        UCX_CHECK_STATUS(status);
+
+        ret = shmem_runtime_put("addr_len", &len, sizeof(size_t));
+        if (ret) RAISE_ERROR_MSG("Runtime put of UCX address length failed (length %zu)\n", len);
+
+        ret = shmem_runtime_put("addr", addr, len);
+        if (ret) RAISE_ERROR_MSG("Runtime put of UCX address failed (length %zu)\n", len);
+
+        ucp_worker_release_address(shmem_transport_ucp_worker, addr);
+    }
+
+    /* Register memory and publish rkeys */
+    {
+        void *rkey;
+        size_t len;
+        int ret;
+        ucp_mem_map_params_t params;
+
+        params.field_mask = UCP_MEM_MAP_PARAM_FIELD_ADDRESS |
+                            UCP_MEM_MAP_PARAM_FIELD_LENGTH  |
+                            UCP_MEM_MAP_PARAM_FIELD_FLAGS;
+        params.flags      = 0;
+
+        /* Data segment */
+        params.address = shmem_internal_data_base;
+        params.length  = shmem_internal_data_length;
+        status = ucp_mem_map(shmem_transport_ucp_ctx, &params, &shmem_transport_ucp_mem_data);
+        UCX_CHECK_STATUS(status);
+
+        status = ucp_rkey_pack(shmem_transport_ucp_ctx, shmem_transport_ucp_mem_data,
+                              &rkey, &len);
+        UCX_CHECK_STATUS(status);
+        ret = shmem_runtime_put("data_rkey_len", &len, sizeof(size_t));
+        if (ret) RAISE_ERROR_STR("Runtime put of UCX data segment rkey length");
+        ret = shmem_runtime_put("data_rkey", rkey, len);
+        if (ret) RAISE_ERROR_STR("Runtime put of UCX data segment rkey");
+        ucp_rkey_buffer_release(rkey);
+
+        ret = shmem_runtime_put("data_base", &shmem_internal_data_base, sizeof(uint8_t*));
+        if (ret) {
+            RAISE_WARN_STR("Put of data segment address to runtime KVS failed");
+            return 1;
+        }
+
+        /* Heap segment */
+        params.address = shmem_internal_heap_base;
+        params.length  = shmem_internal_heap_length;
+        status = ucp_mem_map(shmem_transport_ucp_ctx, &params, &shmem_transport_ucp_mem_heap);
+        UCX_CHECK_STATUS(status);
+
+        status = ucp_rkey_pack(shmem_transport_ucp_ctx, shmem_transport_ucp_mem_heap,
+                            &rkey, &len);
+        ret = shmem_runtime_put("heap_rkey_len", &len, sizeof(size_t));
+        if (ret) RAISE_ERROR_STR("Runtime put of UCX heap segment rkey length");
+        ret = shmem_runtime_put("heap_rkey", rkey, len);
+        if (ret) RAISE_ERROR_STR("Runtime put of UCX heap segment rkey");
+        ucp_rkey_buffer_release(rkey);
+
+        ret = shmem_runtime_put("heap_base", &shmem_internal_heap_base, sizeof(uint8_t*));
+        if (ret) {
+            RAISE_WARN_STR("Put of heap address to runtime KVS failed");
+            return 1;
+        }
+    }
+
+    /* Configure the default context */
+    shmem_transport_ctx_default.options = 0;
+    shmem_transport_ctx_default.team    = &shmem_internal_team_world;
+
+    return 0;
+}
+
+int shmem_transport_startup(void)
+{
+    int i, ret;
+
+    shmem_transport_peers = malloc(shmem_internal_num_pes *
+                                   sizeof(shmem_transport_peer_t));
+
+    /* Build connection table to each peer */
+    for (i = 0; i < shmem_internal_num_pes; i++) {
+        ucs_status_t status;
+        ucp_ep_params_t params;
+        size_t rkey_len;
+        void *rkey;
+
+        ret = shmem_runtime_get(i, "addr_len", &shmem_transport_peers[i].addr_len, sizeof(size_t));
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX address length failed (PE %d, ret %d)\n", i, ret);
+
+        shmem_transport_peers[i].addr = malloc(shmem_transport_peers[i].addr_len);
+        ret = shmem_runtime_get(i, "addr", shmem_transport_peers[i].addr,
+                                shmem_transport_peers[i].addr_len);
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX address failed (PE %d, ret %d)\n", i, ret);
+
+        params.field_mask = UCP_EP_PARAM_FIELD_REMOTE_ADDRESS;
+        params.address    = shmem_transport_peers[i].addr;
+
+        status = ucp_ep_create(shmem_transport_ucp_worker, &params, &shmem_transport_peers[i].ep);
+        UCX_CHECK_STATUS(status);
+
+        ret = shmem_runtime_get(i, "data_rkey_len", &rkey_len, sizeof(size_t));
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX data rkey length failed (PE %d, ret %d)\n", i, ret);
+        rkey = malloc(rkey_len);
+        if (rkey == NULL) RAISE_ERROR_MSG("Out of memory, allocating rkey buffer (len = %zu)\n", rkey_len);
+        ret = shmem_runtime_get(i, "data_rkey", rkey, rkey_len);
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX data rkey failed (PE %d, ret %d)\n", i, ret);
+        status = ucp_ep_rkey_unpack(shmem_transport_peers[i].ep, rkey, &shmem_transport_peers[i].data_rkey);
+        UCX_CHECK_STATUS(status);
+        free(rkey);
+
+        ret = shmem_runtime_get(i, "heap_rkey_len", &rkey_len, sizeof(size_t));
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX heap rkey length failed (PE %d, ret %d)\n", i, ret);
+        rkey = malloc(rkey_len);
+        if (rkey == NULL) RAISE_ERROR_MSG("Out of memory, allocating rkey buffer (len = %zu)\n", rkey_len);
+        ret = shmem_runtime_get(i, "heap_rkey", rkey, rkey_len);
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX heap rkey failed (PE %d, ret %d)\n", i, ret);
+        status = ucp_ep_rkey_unpack(shmem_transport_peers[i].ep, rkey, &shmem_transport_peers[i].heap_rkey);
+        UCX_CHECK_STATUS(status);
+        free(rkey);
+
+        ret = shmem_runtime_get(i, "data_base", &shmem_transport_peers[i].data_base, sizeof(void*));
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX data base address failed (PE %d, ret %d)\n", i, ret);
+
+        ret = shmem_runtime_get(i, "heap_base", &shmem_transport_peers[i].heap_base, sizeof(void*));
+        if (ret) RAISE_ERROR_MSG("Runtime get of UCX heap base address failed (PE %d, ret %d)\n", i, ret);
+    }
+
+    return 0;
+}
+
+int shmem_transport_fini(void)
+{
+    ucs_status_t status;
+    int i;
+
+    /* Clean up contexts */
+    shmem_transport_quiet(&shmem_transport_ctx_default);
+
+    /* Clean up peers table */
+    for (i = 0; i < shmem_internal_num_pes; i++) {
+        ucp_rkey_destroy(shmem_transport_peers[i].data_rkey);
+        ucp_rkey_destroy(shmem_transport_peers[i].heap_rkey);
+        ucs_status_ptr_t status = ucp_ep_close_nb(shmem_transport_peers[i].ep, UCP_EP_CLOSE_MODE_FLUSH);
+        /* FIXME: What to do with the status pointer? */
+        free(shmem_transport_peers[i].addr);
+    }
+
+    /* Unmap memory and shut down UCX */
+    status = ucp_mem_unmap(shmem_transport_ucp_ctx, shmem_transport_ucp_mem_data);
+    UCX_CHECK_STATUS(status);
+    status = ucp_mem_unmap(shmem_transport_ucp_ctx, shmem_transport_ucp_mem_heap);
+    UCX_CHECK_STATUS(status);
+
+    ucp_worker_destroy(shmem_transport_ucp_worker);
+    ucp_cleanup(shmem_transport_ucp_ctx);
+    ucp_config_release(shmem_transport_ucp_config);
+
+    return 0;
+}

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -178,6 +178,11 @@ static inline
 int
 shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx)
 {
+    /* FIXME: Contexts are not optimized yet. We could create a separate set of
+     * EPs for each context (or team), and/or we could use completion callbacks
+     * to implement completion counters at the SOS level to enable separate
+     * completion tracking per context. */
+
     if (team == SHMEMX_TEAM_INVALID)
         return 1;
 

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -250,8 +250,10 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
     status = ucp_put_nbi(shmem_transport_peers[pe].ep, source, len, (uint64_t) remote_addr, rkey);
     UCX_CHECK_STATUS_INPROGRESS(status);
     */
-    /* FIXME: Completing the put immediately works around a progress-related
-     * deadlock in the bigput test. Progress thread would be a better solution. */
+    /* FIXME: Completing the put immediately works around a deadlock in the
+     * bigput test. Unsure of the cause for deadlock; I had assumed it was
+     * progress-related. However, the progress thread seems to make it worse.
+     * */
     ucs_status_ptr_t pstatus = ucp_put_nb(shmem_transport_peers[pe].ep, source,
                                           len, (uint64_t) remote_addr, rkey,
                                           &shmem_transport_recv_cb_nop);

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -1,0 +1,471 @@
+
+/* -*- C -*-
+ *
+ * Copyright (c) 2020 NVidia Corporation.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+#ifndef TRANSPORT_UCX_H
+#define TRANSPORT_UCX_H
+
+#include "shmem_internal.h"
+#include "transport.h"
+#include <ucs/type/status.h>
+#include <ucp/api/ucp_def.h>
+#include <ucp/api/ucp.h>
+
+/* Operations */
+enum shm_internal_op_t {
+    SHM_INTERNAL_BAND,
+    SHM_INTERNAL_BOR,
+    SHM_INTERNAL_BXOR,
+    SHM_INTERNAL_MIN,
+    SHM_INTERNAL_MAX,
+    SHM_INTERNAL_SUM,
+    SHM_INTERNAL_PROD
+};
+
+typedef enum shm_internal_op_t shm_internal_op_t;
+typedef int shmem_transport_ct_t;
+
+struct shmem_transport_ctx_t {
+    long options;
+    struct shmem_internal_team_t *team;
+};
+typedef struct shmem_transport_ctx_t shmem_transport_ctx_t;
+
+typedef struct {
+    size_t         addr_len;
+    ucp_address_t *addr;
+    ucp_ep_h       ep;
+    /* FIXME: Add remote global addressing optimization */
+    uint8_t       *data_base, *heap_base;
+    ucp_rkey_h     data_rkey, heap_rkey;
+} shmem_transport_peer_t;
+
+extern shmem_transport_peer_t *shmem_transport_peers;
+extern ucp_worker_h shmem_transport_ucp_worker;
+
+#define UCX_CHECK_STATUS(status)                                                        \
+    do {                                                                                \
+        if (status != UCS_OK) {                                                         \
+            RAISE_ERROR_MSG("UCX error %d: %s\n", status, ucs_status_string(status));   \
+        }                                                                               \
+    } while (0)
+
+#define UCX_CHECK_STATUS_INPROGRESS(status)                                             \
+    do {                                                                                \
+        if (status != UCS_OK && status != UCS_INPROGRESS) {                             \
+            RAISE_ERROR_MSG("UCX error %d: %s\n", status, ucs_status_string(status));   \
+        }                                                                               \
+    } while (0)
+
+int shmem_transport_init(void);
+int shmem_transport_startup(void);
+int shmem_transport_fini(void);
+
+static inline
+void shmem_transport_ucx_get_mr(const void *addr, int dest_pe,
+                                uint8_t **remote_addr, ucp_rkey_h *rkey) {
+    if ((void*) addr >= shmem_internal_data_base &&
+        (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
+
+        *rkey = shmem_transport_peers[dest_pe].data_rkey;
+        *remote_addr = (uint8_t*) (((uint8_t *) addr - (uint8_t *) shmem_internal_data_base) +
+                       shmem_transport_peers[dest_pe].data_base);
+
+    } else if ((void*) addr >= shmem_internal_heap_base &&
+               (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
+
+        *rkey = shmem_transport_peers[dest_pe].heap_rkey;
+        *remote_addr = (uint8_t*) (((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base) +
+                       shmem_transport_peers[dest_pe].heap_base);
+    } else {
+        RAISE_ERROR_MSG("address (%p) outside of symmetric areas\n", addr);
+    }
+}
+
+static inline
+void
+shmem_transport_probe(void)
+{
+    /* FIXME: Requires hard polling, manual progress, and likely separate
+     * progress thread to meed progress requirements */
+    ucp_worker_progress(shmem_transport_ucp_worker);
+}
+
+static inline
+int
+shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx)
+{
+    if (team == SHMEMX_TEAM_INVALID)
+        return 1;
+
+    *ctx = malloc(sizeof(shmem_transport_ctx_t));
+
+    if (*ctx == NULL)
+        return 1;
+
+    (*ctx)->team = team;
+    (*ctx)->options = 0;
+
+    return 0;
+}
+
+static inline
+void
+shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
+{
+    if (ctx == SHMEMX_CTX_INVALID)
+        return;
+    else if (ctx == (shmem_transport_ctx_t *) SHMEM_CTX_DEFAULT)
+        RAISE_ERROR_STR("Cannot destroy SHMEM_CTX_DEFAULT");
+    else
+        free(ctx);
+
+    return;
+}
+
+static inline
+int
+shmem_transport_quiet(shmem_transport_ctx_t* ctx)
+{
+    ucs_status_t status;
+
+    status = ucp_worker_flush(shmem_transport_ucp_worker);
+    UCX_CHECK_STATUS(status);
+
+    return 0;
+}
+
+static inline
+int
+shmem_transport_fence(shmem_transport_ctx_t* ctx)
+{
+    ucs_status_t status;
+
+    status = ucp_worker_fence(shmem_transport_ucp_worker);
+    UCX_CHECK_STATUS(status);
+
+    return 0;
+}
+
+static inline
+void
+shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+{
+    ucs_status_t status;
+    ucp_rkey_h rkey;
+    uint8_t *remote_addr;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    /* FIXME: This needs to be a buffered put. Use bb here? */
+    status = ucp_put_nbi(shmem_transport_peers[pe].ep, source, len, (uint64_t) remote_addr, rkey);
+    UCX_CHECK_STATUS_INPROGRESS(status);
+
+    /* FIXME: Remove when buffered */
+    if (status != UCS_OK) {
+        shmem_internal_assert(status == UCS_INPROGRESS);
+        shmem_transport_quiet(ctx);
+    }
+}
+
+static inline
+void
+shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                       int pe, long *completion)
+{
+    ucs_status_t status;
+    ucp_rkey_h rkey;
+    uint8_t *remote_addr;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    /* FIXME: Could use ucp_put_nb here to take advantage of the completion flag */
+    status = ucp_put_nbi(shmem_transport_peers[pe].ep, source, len, (uint64_t) remote_addr, rkey);
+    UCX_CHECK_STATUS_INPROGRESS(status);
+}
+
+static inline
+void
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
+{
+    shmem_transport_quiet(ctx);
+}
+
+static inline
+void
+shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                       int pe)
+{
+    ucs_status_t status;
+    ucp_rkey_h rkey;
+    uint8_t *remote_addr;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    status = ucp_put_nbi(shmem_transport_peers[pe].ep, source, len, (uint64_t) remote_addr, rkey);
+    UCX_CHECK_STATUS_INPROGRESS(status);
+}
+
+static inline
+void
+shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                               uint64_t *sig_addr, uint64_t signal, int pe)
+{
+    shmem_transport_put_nbi(ctx, target, source, len, pe);
+    shmem_transport_fence(ctx);
+    shmem_transport_put_scalar(ctx, sig_addr, &signal, sizeof(uint64_t), pe);
+}
+
+static inline
+void
+shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+{
+    ucs_status_t status;
+    ucp_rkey_h rkey;
+    uint8_t *remote_addr;
+
+    shmem_transport_ucx_get_mr(source, pe, &remote_addr, &rkey);
+
+    status = ucp_get_nbi(shmem_transport_peers[pe].ep, target, len, (uint64_t) remote_addr, rkey);
+    UCX_CHECK_STATUS_INPROGRESS(status);
+}
+
+static inline
+void
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
+{
+    shmem_transport_quiet(ctx);
+}
+
+
+static inline
+void
+shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                     size_t len, int pe, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                         size_t len, int pe, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                      const void *operand, size_t len, int pe,
+                      shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                          const void *operand, size_t len, int pe,
+                          shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                      const void *mask, size_t len, int pe,
+                      shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                       int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+    if (datatype == SHM_INTERNAL_LONG && op == SHM_INTERNAL_SUM) {
+        uint8_t *remote_addr;
+        ucp_rkey_h rkey;
+        ucs_status_t status;
+
+        shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+        status = ucp_atomic_post(shmem_transport_peers[pe].ep, UCP_ATOMIC_POST_OP_ADD,
+                                 *(long*)source, sizeof(long), (uint64_t) remote_addr, rkey);
+        UCX_CHECK_STATUS_INPROGRESS(status);
+    }
+    else {
+        RAISE_ERROR_STR("No path to peer");
+    }
+}
+
+static inline
+void
+shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                        int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, long *completion)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
+                             int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
+                                 int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                             int pe, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
+                             int pe, shm_internal_datatype_t datatype)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+int shmem_transport_atomic_supported(shm_internal_op_t op, shm_internal_datatype_t datatype)
+{
+    /* Use software reductions, instead of atomic vector operation */
+    return 0;
+}
+
+static inline
+void shmem_transport_syncmem(void)
+{
+    return;
+}
+
+/*** Functions below are not supported ***/
+
+static inline
+void shmem_transport_ct_create(shmem_transport_ct_t **ct_ptr)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void shmem_transport_ct_free(shmem_transport_ct_t **ct_ptr)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+long shmem_transport_ct_get(shmem_transport_ct_t *ct)
+{
+    RAISE_ERROR_STR("No path to peer");
+    return 0;
+}
+
+static inline
+void shmem_transport_ct_set(shmem_transport_ct_t *ct, long value)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void
+shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void
+                          *source, size_t len, int pe, long *completion)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+static inline
+void shmem_transport_get_ct(shmem_transport_ct_t *ct, void
+                            *target, const void *source, size_t len, int pe)
+{
+    RAISE_ERROR_STR("No path to peer");
+}
+
+/**
+ * Query the value of the transport's received messages counter.
+ */
+static inline
+uint64_t shmem_transport_received_cntr_get(void)
+{
+    RAISE_ERROR_STR("Transport does not support received counter");
+    return 0;
+}
+
+/**
+ * Wait for the transport's received messages counter to be greater than or
+ * equal to the given value.
+ *
+ * @param ge_val Function returns when received messages >= ge_val
+ */
+static inline
+void shmem_transport_received_cntr_wait(uint64_t ge_val)
+{
+    RAISE_ERROR_STR("Transport does not support received counter");
+}
+
+static inline
+uint64_t shmem_transport_pcntr_get_issued_write(shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+static inline
+uint64_t shmem_transport_pcntr_get_issued_read(shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+static inline
+uint64_t shmem_transport_pcntr_get_completed_write(shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+static inline
+uint64_t shmem_transport_pcntr_get_completed_read(shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+static inline
+uint64_t shmem_transport_pcntr_get_completed_target(void)
+{
+    return 0;
+}
+
+static inline
+void shmem_transport_pcntr_get_all(shmem_transport_ctx_t *ctx, shmemx_pcntr_t *pcntr)
+{
+    return;
+}
+
+#endif /* TRANSPORT_UCX_H */

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -185,7 +185,7 @@ shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shm
      * completion tracking per context. */
 
     if (team == NULL)
-        return 1;
+        RAISE_ERROR_STR("Context creation occured on a NULL team");
 
     *ctx = malloc(sizeof(shmem_transport_ctx_t));
 
@@ -726,10 +726,12 @@ shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const v
     shmem_transport_fence(ctx);
     switch (sig_op) {
         case SHMEMX_SIGNAL_ADD:
-            shmem_transport_atomic(ctx, sig_addr, &signal, 8, pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+            shmem_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
             break;
         case SHMEMX_SIGNAL_SET:
-            shmem_transport_atomic_set(ctx, sig_addr, &signal, 8, pe, SHM_INTERNAL_UINT64);
+            shmem_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                       pe, SHM_INTERNAL_UINT64);
             break;
         default:
             RAISE_ERROR_MSG("Unsupported operation (%d)\n", sig_op);

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -11,6 +11,7 @@
 #ifndef TRANSPORT_UCX_H
 #define TRANSPORT_UCX_H
 
+#include <string.h>
 #include "shmem_internal.h"
 #include "transport.h"
 #include <ucs/type/status.h>
@@ -62,6 +63,40 @@ extern ucp_worker_h shmem_transport_ucp_worker;
             RAISE_ERROR_MSG("UCX error %d: %s\n", status, ucs_status_string(status));   \
         }                                                                               \
     } while (0)
+
+static inline
+ucs_status_t shmem_transport_ucx_complete_op(ucs_status_ptr_t req) {
+    ucp_worker_progress(shmem_transport_ucp_worker);
+
+    if (req == NULL)
+        return UCS_OK;
+    else if (UCS_PTR_IS_ERR(req))
+        return UCS_PTR_STATUS(req);
+    else {
+        ucs_status_t status = ucp_request_check_status(req);
+        while (status == UCS_INPROGRESS) {
+            ucp_worker_progress(shmem_transport_ucp_worker);
+            status = ucp_request_check_status(req);
+        }
+        ucp_request_release(req);
+        return status;
+    }
+}
+
+static inline
+ucs_status_t shmem_transport_ucx_release_op(ucs_status_ptr_t req) {
+    if (req == NULL)
+         return UCS_OK;
+    else if (UCS_PTR_IS_ERR(req))
+        return UCS_PTR_STATUS(req);
+    else {
+        ucp_request_release(req);
+        return UCS_INPROGRESS;
+    }
+}
+
+/* FIXME: Is this the right thing to do with callbacks? */
+void shmem_transport_recv_cb_nop(void *request, ucs_status_t status);
 
 int shmem_transport_init(void);
 int shmem_transport_startup(void);
@@ -186,6 +221,12 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
     shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
 
     /* FIXME: Could use ucp_put_nb here to take advantage of the completion flag */
+    /* The completion flag would need to either be (1) allocated by UCX as part
+     * of the request, or (2) a pointer in the request that is assigned the
+     * completion value here. Case (2) is also what we would need in order to
+     * reclaim bounce buffers. How would you set a field in a request like this
+     * in a way that is async safe (assuming other threads are also generating
+     * progress)? */
     status = ucp_put_nbi(shmem_transport_peers[pe].ep, source, len, (uint64_t) remote_addr, rkey);
     UCX_CHECK_STATUS_INPROGRESS(status);
 }
@@ -240,6 +281,7 @@ static inline
 void
 shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
 {
+    /* FIXME: If we complete ops in place, we might be able to make this a no-op */
     shmem_transport_quiet(ctx);
 }
 
@@ -249,7 +291,38 @@ void
 shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                      size_t len, int pe, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    uint64_t value;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)source;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)source;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)source;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)source;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_SWAP, value,
+                                  dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Result buffer is on the stack, needs to be completed immediately */
+    /* FIXME: Do we need to complete the op here, or will get_wait do the job? */
+    ucs_status_t status = shmem_transport_ucx_complete_op(pstatus);
+    UCX_CHECK_STATUS(status);
 }
 
 static inline
@@ -257,7 +330,39 @@ void
 shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                          size_t len, int pe, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    uint64_t value;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)source;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)source;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)source;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)source;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_SWAP, value,
+                                  dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Manual progress to avoid deadlock for application-level polling */
+    shmem_transport_probe();
+
+    ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
+    UCX_CHECK_STATUS_INPROGRESS(status);
 }
 
 static inline
@@ -266,7 +371,40 @@ shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
                       const void *operand, size_t len, int pe,
                       shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    uint64_t value;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    memcpy(dest, source, len);
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)operand;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)operand;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)operand;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)operand;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_CSWAP,
+                                  value, dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Result buffer is on the stack, needs to be completed immediately */
+    /* FIXME: Do we need to complete the op here, or will get_wait do the job? */
+    ucs_status_t status = shmem_transport_ucx_complete_op(pstatus);
+    UCX_CHECK_STATUS(status);
 }
 
 static inline
@@ -275,16 +413,41 @@ shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *
                           const void *operand, size_t len, int pe,
                           shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
-}
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    uint64_t value;
 
-static inline
-void
-shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
-                      const void *mask, size_t len, int pe,
-                      shm_internal_datatype_t datatype)
-{
-    RAISE_ERROR_STR("No path to peer");
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    memcpy(dest, source, len);
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)operand;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)operand;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)operand;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)operand;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_CSWAP,
+                                  value, dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Manual progress to avoid deadlock for application-level polling */
+    shmem_transport_probe();
+
+    ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
+    UCX_CHECK_STATUS_INPROGRESS(status);
 }
 
 static inline
@@ -350,7 +513,7 @@ void
 shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                         int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, long *completion)
 {
-    RAISE_ERROR_STR("No path to peer");
+    RAISE_ERROR_STR("Unsupported operation");
 }
 
 static inline
@@ -358,7 +521,57 @@ void
 shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
                              int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    ucp_atomic_post_op_t ucx_op;
+    uint64_t value;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    /* XXX: This could be a lookup table instead of a switch statement */
+    switch (op) {
+        case SHM_INTERNAL_BAND:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FAND;
+            break;
+        case SHM_INTERNAL_BOR:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FOR;
+            break;
+        case SHM_INTERNAL_BXOR:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FXOR;
+            break;
+        case SHM_INTERNAL_SUM:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FADD;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported op op=%d\n", op);
+    }
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)source;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)source;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)source;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)source;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, ucx_op, value,
+                                  dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Result buffer is on the stack, needs to be completed immediately */
+    /* FIXME: Do we need to complete the op here, or will get_wait do the job? */
+    ucs_status_t status = shmem_transport_ucx_complete_op(pstatus);
+    UCX_CHECK_STATUS(status);
 }
 
 static inline
@@ -366,7 +579,58 @@ void
 shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
                                  int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    ucp_atomic_post_op_t ucx_op;
+    uint64_t value;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    /* XXX: This could be a lookup table instead of a switch statement */
+    switch (op) {
+        case SHM_INTERNAL_BAND:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FAND;
+            break;
+        case SHM_INTERNAL_BOR:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FOR;
+            break;
+        case SHM_INTERNAL_BXOR:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FXOR;
+            break;
+        case SHM_INTERNAL_SUM:
+            ucx_op = UCP_ATOMIC_FETCH_OP_FADD;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported op op=%d\n", op);
+    }
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)source;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)source;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)source;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)source;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, ucx_op, value,
+                                  dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Manual progress to avoid deadlock for application-level polling */
+    shmem_transport_probe();
+
+    ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
+    UCX_CHECK_STATUS_INPROGRESS(status);
 }
 
 static inline
@@ -374,7 +638,19 @@ void
 shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+
+    shmem_transport_ucx_get_mr(source, pe, &remote_addr, &rkey);
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_FADD, 0,
+                                  target, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* FIXME: Need to block here? */
+    ucs_status_t status = shmem_transport_ucx_complete_op(pstatus);
+    UCX_CHECK_STATUS(status);
 }
 
 static inline
@@ -382,7 +658,69 @@ void
 shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, shm_internal_datatype_t datatype)
 {
-    RAISE_ERROR_STR("No path to peer");
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    ucs_status_ptr_t pstatus;
+    uint64_t value;
+    uint64_t dest;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    switch (len) {
+        case 1:
+            value = (uint64_t)*(uint8_t*)source;
+            break;
+        case 2:
+            value = (uint64_t)*(uint16_t*)source;
+            break;
+        case 4:
+            value = (uint64_t)*(uint32_t*)source;
+            break;
+        case 8:
+            value = (uint64_t)*(uint64_t*)source;
+            break;
+        default:
+            RAISE_ERROR_MSG("Unsupported datatype len=%zu\n", len);
+    }
+
+    pstatus = ucp_atomic_fetch_nb(shmem_transport_peers[pe].ep, UCP_ATOMIC_FETCH_OP_SWAP, value,
+                                  &dest, len, (uint64_t) remote_addr, rkey,
+                                  &shmem_transport_recv_cb_nop);
+
+    /* Result buffer is on the stack, needs to be completed immediately */
+    /* FIXME: Do we need to complete the op here, or will get_wait do the job? */
+    ucs_status_t status = shmem_transport_ucx_complete_op(pstatus);
+    UCX_CHECK_STATUS(status);
+}
+
+static inline
+void
+shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
+                      const void *mask, size_t len, int pe,
+                      shm_internal_datatype_t datatype)
+{
+    uint8_t *remote_addr;
+    ucp_rkey_h rkey;
+    int done = 0;
+
+    shmem_transport_ucx_get_mr(target, pe, &remote_addr, &rkey);
+
+    if (len != 4)
+        RAISE_ERROR_STR("Unsupported datatype");
+
+    while (!done) {
+        uint32_t v;
+
+        shmem_transport_atomic_fetch(ctx, &v, target, len, pe, datatype);
+
+        uint32_t new = (v & ~*(uint32_t *)mask) | (*(uint32_t *)source & *(uint32_t *)mask);
+
+        shmem_transport_cswap(ctx, target, &new, dest, &v, len, pe, datatype);
+        if (*(uint32_t *)dest == v) done = 1;
+
+        /* Manual progress to avoid deadlock for application-level polling */
+        shmem_transport_probe();
+    }
 }
 
 static inline


### PR DESCRIPTION
This PR adds an SOS transport that uses the UCX/UCP interfaces. It fully supports all of the OpenSHMEM interfaces, but has not been tested/optimized for performance. A known limitation is that there are currently no context-related optimizations.