### PR TITLE
Set ctx to SHMEM_CTX_INVALID if team is invalid

### DIFF
--- a/src/teams_c.c4
+++ b/src/teams_c.c4
@@ -107,8 +107,10 @@ shmemx_team_create_ctx(shmemx_team_t team, long options, shmem_ctx_t *ctx)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    if (team == SHMEMX_TEAM_INVALID)
+    if (team == SHMEMX_TEAM_INVALID) {
+        *ctx = SHMEMX_CTX_INVALID;
         return -1;
+    }
 
     int ret = shmem_transport_ctx_create((shmem_internal_team_t *) team,
                                          options, (shmem_transport_ctx_t **) ctx);


### PR DESCRIPTION
I believe this is a bug.  The spec says,

> If team compares equal to SHMEM_TEAM_INVALID, then a nonzero value is returned and ctx is set to SHMEM_CTX_INVALID.

Signed-off-by: David M. Ozog <david.m.ozog@intel.com>