### PR TITLE
Allocation routines return if any of the arguments are passed zero value

### DIFF
--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -332,7 +332,7 @@ shmem_realloc(void *ptr, size_t size)
 
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    if (size == 0) return ptr;
+    if (size == 0 && ptr == NULL) return ptr;
     if (ptr != NULL) {
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -278,9 +278,11 @@ shmem_internal_shmalloc(size_t size)
 void SHMEM_FUNCTION_ATTRIBUTES *
 shmem_malloc(size_t size)
 {
-    void *ret;
+    void *ret = NULL;
 
     SHMEM_ERR_CHECK_INITIALIZED();
+
+    if (size == 0) return ret;
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     ret = dlmalloc(size);
@@ -329,6 +331,8 @@ shmem_realloc(void *ptr, size_t size)
     void *ret;
 
     SHMEM_ERR_CHECK_INITIALIZED();
+
+    if (size == 0) return ptr;
     if (ptr != NULL) {
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
@@ -353,10 +357,11 @@ shmem_realloc(void *ptr, size_t size)
 void SHMEM_FUNCTION_ATTRIBUTES *
 shmem_align(size_t alignment, size_t size)
 {
-    void *ret;
+    void *ret = NULL;
 
     SHMEM_ERR_CHECK_INITIALIZED();
 
+    if (size == 0) return ret;
     if (alignment == 0)
         return NULL;
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -294,9 +294,11 @@ shmem_malloc(size_t size)
 void SHMEM_FUNCTION_ATTRIBUTES *
 shmem_calloc(size_t count, size_t size)
 {
-    void *ret;
+    void *ret = NULL;
 
     SHMEM_ERR_CHECK_INITIALIZED();
+
+    if (size == 0 || count == 0) return ret;
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     ret = dlcalloc(count, size);


### PR DESCRIPTION
To comply with the spec, if size or count is 0, then the `shmem_calloc` routine should not be semantically equivalent to `shmem_barrier_all` 

Signed-off-by: Md <md.rahman@intel.com>