### PR TITLE
Resolve configury issue with multiple transports detected

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -355,31 +355,39 @@ OMPI_CHECK_UCX([ucx],
 num_transports=""
 if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     num_transports="x$num_transports"
+fi
+if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
+    num_transports="x$num_transports"
+fi
+if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
+    num_transports="x$num_transports"
+fi
+
+if test -n "$num_transports" -a "$num_transports" != "x" ; then
+    AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
+fi
+
+if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     transport="portals4"
     transport_ofi="no"
     transport_ucx="no"
     AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
-fi
-if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
-    num_transports="x$num_transports"
+elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
     transport="ofi"
     transport_portals="no"
     transport_ucx="no"
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
-fi
-if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
-    num_transports="x$num_transports"
+elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
     transport="ucx"
     transport_ofi="no"
     transport_portals="no"
     AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
     AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
-fi
-
-if test -n "$num_transports" -a "$num_transports" != "x" ; then
-    AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
 else
     transport="none"
+    transport_portals4="no"
+    transport_ofi="no"
+    transport_ucx="no"
     AC_MSG_WARN([No transport requested])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -378,11 +378,8 @@ fi
 
 if test -n "$num_transports" -a "$num_transports" != "x" ; then
     AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
-elif test -z "$num_transports" ; then
+else
     transport="none"
-    transport_ofi="no"
-    transport_portals="no"
-    transport_ucx="no"
     AC_MSG_WARN([No transport requested])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -378,8 +378,11 @@ fi
 
 if test -n "$num_transports" -a "$num_transports" != "x" ; then
     AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
-else
+elif test -z "$num_transports" ; then
     transport="none"
+    transport_ofi="no"
+    transport_portals="no"
+    transport_ucx="no"
     AC_MSG_WARN([No transport requested])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -369,12 +369,18 @@ fi
 
 if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     transport="portals4"
+    transport_ofi="no"
+    transport_ucx="no"
     AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
 elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
     transport="ofi"
+    transport_portals="no"
+    transport_ucx="no"
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
 elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
     transport="ucx"
+    transport_ofi="no"
+    transport_portals="no"
     AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
     AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
 else

--- a/configure.ac
+++ b/configure.ac
@@ -355,39 +355,31 @@ OMPI_CHECK_UCX([ucx],
 num_transports=""
 if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     num_transports="x$num_transports"
-fi
-if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
-    num_transports="x$num_transports"
-fi
-if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
-    num_transports="x$num_transports"
-fi
-
-if test -n "$num_transports" -a "$num_transports" != "x" ; then
-    AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
-fi
-
-if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     transport="portals4"
     transport_ofi="no"
     transport_ucx="no"
     AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
-elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
+fi
+if test -n "$with_ofi" -a "$with_ofi" != "no" ; then
+    num_transports="x$num_transports"
     transport="ofi"
     transport_portals="no"
     transport_ucx="no"
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
-elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
+fi
+if test -n "$with_ucx" -a "$with_ucx" != "no" ; then
+    num_transports="x$num_transports"
     transport="ucx"
     transport_ofi="no"
     transport_portals="no"
     AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
     AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
+fi
+
+if test -n "$num_transports" -a "$num_transports" != "x" ; then
+    AC_MSG_ERROR([Cannot select more than one transport, see --help for details])
 else
     transport="none"
-    transport_portals4="no"
-    transport_ofi="no"
-    transport_ucx="no"
     AC_MSG_WARN([No transport requested])
 fi
 


### PR DESCRIPTION
I encountered this problem when testing Portals4 on a system with libfabric automatically detected.  It's the same issue as #954, which should be resolved by this PR.

Thanks for the patch @jdinan!