### PR TITLE
Slim down Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,14 +121,14 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
-          SOS_ENABLE_ERROR_TESTS=1
-          SHMEM_BARRIER_ALGORITHM=dissem SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
+          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
+          SHMEM_BARRIER_ALGORITHM=tree SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
           SHMEM_OFI_STX_MAX=0
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress"
         - >
           SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
-          SHMEM_BARRIER_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
+          SHMEM_BARRIER_ALGORITHM=dissem SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
           SHMEM_OFI_STX_AUTO=1
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress --enable-hard-polling"

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ env:
 
         ## UCX Builds
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
@@ -164,14 +165,17 @@ env:
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--enable-pmi-mpi CC=mpicc"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-pmi-simple"
         - >
+          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-error-checking --enable-pmi-simple"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -367,7 +367,7 @@ script:
     - make $TRAVIS_PAR_MAKE check TESTS=
     - $SOS_PM_PRE
     - >
-      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]]; then
+      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx" ]]; then
         make VERBOSE=1 TEST_RUNNER="$SOS_PM -np 2" check
       else
         $SOS_PM -np 1 test/unit/hello

--- a/.travis.yml
+++ b/.travis.yml
@@ -396,11 +396,6 @@ script:
     - export OSHRUN_LAUNCHER="$SOS_PM"
     - cd $TRAVIS_SRC/tests-uh
     - make $TRAVIS_PAR_MAKE C_feature_tests
-    - >
-      if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
-          sed -i '/RUN_CMD=\"oshrun\"/c\our $RUN_CMD=\"\";' common/testrunner.pl
-          export RUN_OPTIONS=$SOS_PM
-      fi
     - $SOS_PM_PRE
     - make C_feature_tests-run 2>&1 | tee uh-tests-c-feature-tests.log
     # Check for failures in the C tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -367,7 +367,7 @@ script:
     - make $TRAVIS_PAR_MAKE check TESTS=
     - $SOS_PM_PRE
     - >
-      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx"* ]]; then
+      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx" ]]; then
         make VERBOSE=1 TEST_RUNNER="$SOS_PM -np 2" check
       else
         $SOS_PM -np 1 test/unit/hello

--- a/.travis.yml
+++ b/.travis.yml
@@ -319,8 +319,6 @@ before_install:
         make install
         export PATH=$TRAVIS_INSTALL/prrte/bin:$PATH
       fi
-      ## Workaround for Travis CI stdout write error and resource temporarily unavailable issue:
-    - python2 -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -367,7 +367,7 @@ script:
     - make $TRAVIS_PAR_MAKE check TESTS=
     - $SOS_PM_PRE
     - >
-      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx" ]]; then
+      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx"* ]]; then
         make VERBOSE=1 TEST_RUNNER="$SOS_PM -np 2" check
       else
         $SOS_PM -np 1 test/unit/hello

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,6 @@ env:
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
           SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
-          SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
-          SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
-        - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-cxx --enable-memcpy --enable-pmi-simple"
         - >
@@ -127,13 +122,13 @@ env:
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
           SOS_ENABLE_ERROR_TESTS=1
-          SHMEM_BARRIER_ALGORITHM=tree SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
+          SHMEM_BARRIER_ALGORITHM=dissem SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
           SHMEM_OFI_STX_MAX=0
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress"
         - >
           SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
-          SHMEM_BARRIER_ALGORITHM=dissem SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
+          SHMEM_BARRIER_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
           SHMEM_OFI_STX_AUTO=1
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress --enable-hard-polling"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
           SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
@@ -81,7 +81,8 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_DISABLE_EXTERNAL_TESTS=1
+          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
@@ -163,7 +164,8 @@ env:
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_DISABLE_EXTERNAL_TESTS=1
+          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
@@ -287,27 +289,40 @@ before_install:
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
     - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
+    ## Build Libevent
+    - cd $TRAVIS_SRC
+    - wget https://github.com/libevent/libevent/releases/download/release-2.1.10-stable/libevent-2.1.10-stable.tar.gz
+    - tar -xzvf libevent-2.1.10-stable.tar.gz
+    - cd libevent-2.1.10-stable
+    - ./autogen.sh
+    - ./configure --prefix=$PWD/install
+    - make clean all install
     ## Build PMIx
     - >
       if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
         cd $TRAVIS_SRC
         git clone --depth 10 https://github.com/pmix/pmix pmix
+        git checkout e4a27268
         cd pmix
         ./autogen.pl
-        ./configure --prefix=$TRAVIS_INSTALL/pmix --disable-debug --with-libev CFLAGS=-O3
+        ./configure --prefix=$TRAVIS_INSTALL/pmix --with-libevent=$TRAVIS_SRC/libevent-2.1.10-stable/install --disable-debug CFLAGS=-O3
         make install
       fi
     ## Build PRRTE
     - >
       if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
         cd $TRAVIS_SRC
-        git clone -b v1.0.0 --depth 10 https://github.com/pmix/prrte prrte
+        git clone --depth 10 https://github.com/pmix/prrte prrte
+        git checkout 40ae55bc
         cd prrte
         ./autogen.pl
-        ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --without-slurm --with-libev
+        ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --without-slurm --with-libevent=$TRAVIS_SRC/libevent-2.1.10-stable/install
         make install
         export PATH=$TRAVIS_INSTALL/prrte/bin:$PATH
       fi
+      ## Workaround for Travis CI stdout write error and resource temporarily unavailable issue:
+    - python2 -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+
 
 install:
     - cd $TRAVIS_BUILD_DIR
@@ -367,6 +382,11 @@ script:
     - export OSHRUN_LAUNCHER="$SOS_PM"
     - cd $TRAVIS_SRC/tests-uh
     - make $TRAVIS_PAR_MAKE C_feature_tests
+    - >
+      if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
+          sed -i '/RUN_CMD=\"oshrun\"/c\our $RUN_CMD=\"\";' common/testrunner.pl
+          export RUN_OPTIONS=$SOS_PM
+      fi
     - $SOS_PM_PRE
     - make C_feature_tests-run 2>&1 | tee uh-tests-c-feature-tests.log
     # Check for failures in the C tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -367,7 +367,7 @@ script:
     - make $TRAVIS_PAR_MAKE check TESTS=
     - $SOS_PM_PRE
     - >
-      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]] || [[ $SOS_TRANSPORT_OPTS = *"with-ucx" ]]; then
+      if [[ $SOS_TRANSPORT_OPTS = *"with-ofi"* ]]; then
         make VERBOSE=1 TEST_RUNNER="$SOS_PM -np 2" check
       else
         $SOS_PM -np 1 test/unit/hello

--- a/configure.ac
+++ b/configure.ac
@@ -369,12 +369,18 @@ fi
 
 if test -n "$with_portals4" -a "$with_portals4" != "no" ; then
     transport="portals4"
+    transport_ofi="no"
+    transport_ucx="no"
     AC_DEFINE([USE_PORTALS4], [1], [Define if Portals 4 transport active])
 elif test -n "$with_ofi" -a "$with_ofi" != "no" ; then
     transport="ofi"
+    transport_portals="no"
+    transport_ucx="no"
     AC_DEFINE([USE_OFI], [1], [Define if OFI transport active])
 elif test -n "$with_ucx" -a "$with_ucx" != "no" ; then
     transport="ucx"
+    transport_ofi="no"
+    transport_portals="no"
     AC_DEFINE([USE_UCX], [1], [Define if UCX transport active])
     AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
 else


### PR DESCRIPTION
This includes various updates to make Travis go green again.

An alternative to the PRRTE/PMIx changes below is to disable it entirely temporarily, as in #964.

Here is a summary of the changes:
* Update PRRTE launch commands to latest version
* Checkout stable PRRTE/PMIx commits in Xenial Travis
* Remove Portals+PMIx Travis row (libev is required by Portals, but not working with latest PRRTE/PMIx)
* Switch to libevent 2.1.10-stable for PRRTE/PMIx
* ~~Force UH tests to use prun in PMIx rows~~
* Remove external tests from UCX rows in Travis
* Remove external test from manual-progress row in Travis

