### PR TITLE
Fix C99 header issue

### DIFF
--- a/mpp/shmem.h4
+++ b/mpp/shmem.h4
@@ -567,9 +567,6 @@ define(`SHMEM_CXX_TEST_SOME_VECTOR',
 }')dnl
 SHMEM_CXX_DEFINE_FOR_SYNC(`SHMEM_CXX_TEST_SOME_VECTOR')
 
-static inline int SHPRE()shmem_sync(shmem_team_t team) {
-    return shmem_team_sync(team);
-}
 
 /* C11 Generic Macros */
 #elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(SHMEM_INTERNAL_INCLUDE))
@@ -1214,7 +1211,6 @@ define(`SHMEM_C11_GEN_TEST_SOME_VECTOR', `        $2*: shmem_$1_test_some_vector
 SHMEM_BIND_C11_SYNC(`SHMEM_C11_GEN_TEST_SOME_VECTOR', `, \') \
     )(__VA_ARGS__)
 
-/* shmem_sync */
 #define shmem_sync(...) \
     _Generic(SHMEM_C11_TYPE_EVAL_PTR_OR_SCALAR(SHMEM_C11_ARG0(__VA_ARGS__)), \
         shmem_team_t: shmem_team_sync, \

--- a/test/unit/shmem_team_collect_active_set.c
+++ b/test/unit/shmem_team_collect_active_set.c
@@ -105,7 +105,11 @@ int main(void)
             for (j = 0; j < MAX_NPES*MAX_NPES; j++)
                 dst[j] = -1;
 
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
             shmem_sync(new_team);
+#else
+            shmem_team_sync(new_team);
+#endif
         }
 
         old_team = new_team;

--- a/test/unit/shmem_team_max.c
+++ b/test/unit/shmem_team_max.c
@@ -50,7 +50,11 @@ int main(void)
                                         NULL, 0, &new_team[i]);
 
         /* Wait for all PEs to fill in ret before starting the reduction */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
         shmem_sync(SHMEM_TEAM_WORLD);
+#else
+        shmem_team_sync(SHMEM_TEAM_WORLD);
+#endif
         shmem_int_and_reduce(SHMEM_TEAM_WORLD, &dest_ret, &ret, 1);
 
         /* If success was not global, free a team and retry */


### PR DESCRIPTION
Building with `-std=c99` fails on the tests with the following error:
```
../../../test/unit/shmem_team_collect_active_set.c:108:32: error: too few arguments to function call, expected 4, have 1
            shmem_sync(new_team);
            ~~~~~~~~~~         ^
../../mpp/shmem.h:1383:1: note: 'shmem_sync' declared here
SHMEM_FUNCTION_ATTRIBUTES void shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
^
../../mpp/shmem.h:36:40: note: expanded from macro 'SHMEM_FUNCTION_ATTRIBUTES'
#     define SHMEM_FUNCTION_ATTRIBUTES __attribute__((visibility("default")))
                                       ^
1 error generated.
```

There are also issues with the spec examples with `CFLAGS=-std=c99`. Not sure how to handle those.