### PR TITLE
Update tests for shmalloc & shmem_calloc when size is zero

### DIFF
--- a/test/unit/shmalloc.c
+++ b/test/unit/shmalloc.c
@@ -193,14 +193,16 @@ main(int argc, char **argv)
 
         result_sz = (nProcs-1) * (nWords * sizeof(DataType));
         result = (DataType *)shmem_malloc(result_sz);
-        if (! result)
-        {
-            perror ("Failed result memory allocation");
-            shmem_finalize();
-            exit (1);
+        if (result_sz != 0) {
+            if (! result)
+            {
+                perror ("Failed result memory allocation");
+                shmem_finalize();
+                exit (1);
+            }
+            for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
+                *dp++ = 1;
         }
-        for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
-            *dp++ = 1;
 
 
         target_sz = nWords * sizeof(DataType);

--- a/test/unit/shmalloc.c
+++ b/test/unit/shmalloc.c
@@ -191,18 +191,23 @@ main(int argc, char **argv)
 
     for(l=0; l < loops; l++) {
 
-        result_sz = (nProcs-1) * (nWords * sizeof(DataType));
-        result = (DataType *)shmem_malloc(result_sz);
-        if (result_sz != 0) {
-            if (! result)
-            {
-                perror ("Failed result memory allocation");
-                shmem_finalize();
-                exit (1);
-            }
-            for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
-                *dp++ = 1;
+        result = (DataType *)shmem_malloc(0);
+        if (result != NULL) {
+            perror ("Zero-length memory allocation has non-null result");
+            shmem_finalize();
+            exit (1);
         }
+
+        result_sz = nProcs * (nWords * sizeof(DataType));
+        result = (DataType *)shmem_malloc(result_sz);
+        if (! result)
+        {
+            perror ("Failed result memory allocation");
+            shmem_finalize();
+            exit (1);
+        }
+        for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
+            *dp++ = 1;
 
 
         target_sz = nWords * sizeof(DataType);

--- a/test/unit/shmem_calloc.c
+++ b/test/unit/shmem_calloc.c
@@ -193,14 +193,16 @@ main(int argc, char **argv)
 
         result_sz = (nProcs-1) * (nWords * sizeof(DataType));
         result = (DataType *)shmem_calloc((nProcs-1)*nWords, sizeof(DataType));
-        if (! result)
-        {
-            perror ("Failed result memory allocation");
-            shmem_finalize();
-            exit (1);
+        if (result_sz != 0) {
+            if (! result)
+            {
+                perror ("Failed result memory allocation");
+                shmem_finalize();
+                exit (1);
+            }
+            for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
+                *dp++ += 1;
         }
-        for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
-            *dp++ += 1;
 
 
         target_sz = nWords * sizeof(DataType);

--- a/test/unit/shmem_calloc.c
+++ b/test/unit/shmem_calloc.c
@@ -191,18 +191,23 @@ main(int argc, char **argv)
 
     for(l=0; l < loops; l++) {
 
-        result_sz = (nProcs-1) * (nWords * sizeof(DataType));
-        result = (DataType *)shmem_calloc((nProcs-1)*nWords, sizeof(DataType));
-        if (result_sz != 0) {
-            if (! result)
-            {
-                perror ("Failed result memory allocation");
-                shmem_finalize();
-                exit (1);
-            }
-            for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
-                *dp++ += 1;
+        result = (DataType *)shmem_calloc(0);
+        if (result != NULL) {
+            perror ("Zero-length memory allocation has non-null result");
+            shmem_finalize();
+            exit (1);
         }
+
+        result_sz = nProcs * (nWords * sizeof(DataType));
+        result = (DataType *)shmem_calloc((nProcs-1)*nWords, sizeof(DataType));
+        if (! result)
+        {
+            perror ("Failed result memory allocation");
+            shmem_finalize();
+            exit (1);
+        }
+        for(dp=result; dp < &result[(result_sz/sizeof(DataType))];)
+            *dp++ += 1;
 
 
         target_sz = nWords * sizeof(DataType);

--- a/test/unit/shmem_calloc.c
+++ b/test/unit/shmem_calloc.c
@@ -191,7 +191,7 @@ main(int argc, char **argv)
 
     for(l=0; l < loops; l++) {
 
-        result = (DataType *)shmem_calloc(0);
+        result = (DataType *)shmem_calloc(0, sizeof(DataType));
         if (result != NULL) {
             perror ("Zero-length memory allocation has non-null result");
             shmem_finalize();
@@ -199,7 +199,7 @@ main(int argc, char **argv)
         }
 
         result_sz = nProcs * (nWords * sizeof(DataType));
-        result = (DataType *)shmem_calloc((nProcs-1)*nWords, sizeof(DataType));
+        result = (DataType *)shmem_calloc(nProcs * nWords, sizeof(DataType));
         if (! result)
         {
             perror ("Failed result memory allocation");


### PR DESCRIPTION
These tests fail when `nProcs` is 1 because they try to allocate a buffer with zero size while expecting a valid pointer.  Updating the tests so they don't fail in that case.