### PR TITLE
(v1.4.x) cherry-pick features/fixes ahead of v1.4.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -237,7 +237,7 @@ before_install:
         make $TRAVIS_PAR_MAKE
         make install
         ## Install the module and allow Travis to use it
-        sudo insmod $TRAVIS_INSTALL/xpmem/lib/modules/`uname -r`/xpmem.ko
+        sudo insmod $TRAVIS_INSTALL/xpmem/lib/modules/`uname -r`/kernel/xpmem/xpmem.ko
         sudo chown `whoami` /dev/xpmem
       fi
     ## Fetch UH Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ env:
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
           SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
@@ -81,7 +81,8 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_PM="prun -host localhost -oversubscribe" SOS_PM_PRE="prte --daemonize" SOS_PM_POST="prun -terminate"
+          SOS_DISABLE_EXTERNAL_TESTS=1
+          SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
@@ -125,7 +126,7 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
-          SOS_ENABLE_ERROR_TESTS=1
+          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
           SHMEM_BARRIER_ALGORITHM=tree SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
           SHMEM_OFI_STX_MAX=0
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
@@ -210,6 +211,9 @@ before_install:
         # JSD: --enable-transport-shmem removed; it was causing tests to hang
         make $TRAVIS_PAR_MAKE
         make install
+        if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
+          export SOS_BUILD_STATIC_OPTS="--disable-shared --enable-static"
+        fi
       fi
     ## Build libfabric
     - >
@@ -256,27 +260,47 @@ before_install:
     - cd $TRAVIS_SRC
     - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
     - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
+    ## Build Libevent
+    - cd $TRAVIS_SRC
+    - wget https://github.com/libevent/libevent/releases/download/release-2.1.10-stable/libevent-2.1.10-stable.tar.gz
+    - tar -xzvf libevent-2.1.10-stable.tar.gz
+    - cd libevent-2.1.10-stable
+    - ./autogen.sh
+    - ./configure --prefix=$PWD/install
+    - make clean all install
     ## Build PMIx
     - >
       if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
         cd $TRAVIS_SRC
         git clone --depth 10 https://github.com/pmix/pmix pmix
+        # Checkout a stable configuration for dist:xenial (FIXME: use a tag compatible with PRRTE when available)
+        git checkout e4a27268
         cd pmix
         ./autogen.pl
-        ./configure --prefix=$TRAVIS_INSTALL/pmix --disable-debug --with-libev CFLAGS=-O3
+        ./configure --prefix=$TRAVIS_INSTALL/pmix --with-libevent=$TRAVIS_SRC/libevent-2.1.10-stable/install --without-libev --disable-debug CFLAGS=-O3 $SOS_BUILD_STATIC_OPTS
         make install
       fi
     ## Build PRRTE
     - >
       if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]]; then
         cd $TRAVIS_SRC
-        git clone -b v1.0.0 --depth 10 https://github.com/pmix/prrte prrte
+        git clone --depth 10 https://github.com/pmix/prrte prrte
+        # Checkout a stable configuration for dist:xenial (FIXME: use a tag when available)
+        git checkout 40ae55bc
         cd prrte
         ./autogen.pl
-        ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --without-slurm --with-libev
+        ./configure --prefix=$TRAVIS_INSTALL/prrte --with-pmix=$TRAVIS_INSTALL/pmix --without-slurm --with-libevent=$TRAVIS_SRC/libevent-2.1.10-stable/install --without-libev $SOS_BUILD_STATIC_OPTS
         make install
         export PATH=$TRAVIS_INSTALL/prrte/bin:$PATH
       fi
+    ## If Portals+PRRTE, rebuild PMIx (FIXME after resolving PRRTE w/ libev issues)
+    - >
+      if [[ $SOS_BUILD_OPTS = *"with-pmix"* ]] && [[ $SOS_BUILD_OPTS = *"with-portals4"* ]]; then
+        cd $TRAVIS_SRC/pmix
+        ./configure --prefix=$TRAVIS_INSTALL/pmix --without-libevent --with-libev --disable-debug CFLAGS=-O3
+        make install
+      fi
+
 
 install:
     - cd $TRAVIS_BUILD_DIR
@@ -329,7 +353,7 @@ script:
     ###
     ### Portals builds stop here
     ###
-    - if [ -n "SOS_DISABLE_EXTERNAL_TESTS" ]; then travis_terminate $TRAVIS_TEST_RESULT; fi
+    - if [ -n "$SOS_DISABLE_EXTERNAL_TESTS" ]; then travis_terminate $TRAVIS_TEST_RESULT; fi
     ###
     ### Run the UH test suite
     ###

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,13 @@
 
 Sandia OpenSHMEM NEWS -- history of user-visible changes.
 
+v1.4.x
+------
+- This branch is based on v1.4.5 with various cherry-picked commits useful for
+  testing the OpenSHMEM v1.4 APIs (cherry-picks include: teams bug fixes,
+  Travis testing updates, higher thread levels allowed in test, support for
+  shmem_perf_suite trial multipler, etc).
+
 v1.4.5
 ------
 - Added a complete OpenSHMEM teams API to the shmemx interfaces.

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.4.5], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.4.x], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])

--- a/sandia-openshmem.spec.in
+++ b/sandia-openshmem.spec.in
@@ -1,5 +1,6 @@
 %{!?configargs: %global configargs %{nil}}
 %{!?testdir: %global testdir %{buildroot}%{_datadir}/%{name}-%{version}/tests}
+%define debug_package %{nil}
 
 Name: sandia-openshmem
 Version: @VERSION@

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -537,7 +537,7 @@ void shmem_internal_bit_clear(unsigned char *ptr, size_t size, size_t index)
 static inline
 unsigned char shmem_internal_bit_fetch(unsigned char *ptr, size_t index)
 {
-    return (ptr[index / CHAR_BIT] >> index) & 1;
+    return (ptr[index / CHAR_BIT] >> (index % CHAR_BIT)) & 1;
 }
 
 static inline

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -517,7 +517,7 @@ void shmem_internal_bit_set(unsigned char *ptr, size_t size, size_t index)
 {
     shmem_internal_assert(size > 0 && (index < size * CHAR_BIT));
 
-    size_t which_byte = index / size;
+    size_t which_byte = index / CHAR_BIT;
     ptr[which_byte] |= (1 << (index % CHAR_BIT));
 
     return;
@@ -528,16 +528,19 @@ void shmem_internal_bit_clear(unsigned char *ptr, size_t size, size_t index)
 {
     shmem_internal_assert(size > 0 && (index < size * CHAR_BIT));
 
-    size_t which_byte = index / size;
+    size_t which_byte = index / CHAR_BIT;
     ptr[which_byte] &= ~(1 << (index % CHAR_BIT));
 
     return;
 }
 
 static inline
-unsigned char shmem_internal_bit_fetch(unsigned char *ptr, size_t index)
+unsigned char shmem_internal_bit_fetch(unsigned char *ptr, size_t size, size_t index)
 {
-    return (ptr[index / CHAR_BIT] >> (index % CHAR_BIT)) & 1;
+    shmem_internal_assert(size > 0 && (index < size * CHAR_BIT));
+
+    size_t which_byte = index / CHAR_BIT;
+    return (ptr[which_byte] >> (index % CHAR_BIT)) & 1;
 }
 
 static inline

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -481,6 +481,10 @@ long * shmem_internal_team_choose_psync(shmem_internal_team_t *team, shmem_inter
                 }
             }
 
+            /* No psync is available, so we must quiesce communication across all psyncs on this team. */
+            /* Currently, all collectives on all teams are done on the default context. */
+            shmem_internal_quiet(SHMEM_CTX_DEFAULT);
+
             size_t psync = team->psync_idx * SHMEM_SYNC_SIZE;
             shmem_internal_sync(team->start, team->stride, team->size,
                                 &shmem_internal_psync_barrier_pool[psync]);

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -439,7 +439,7 @@ int shmem_internal_team_destroy(shmem_internal_team_t *team)
 
     if (team == SHMEMX_TEAM_INVALID) {
         return -1;
-    } else if (shmem_internal_bit_fetch(psync_pool_avail, team->psync_idx)) {
+    } else if (shmem_internal_bit_fetch(psync_pool_avail, N_PSYNC_BYTES, team->psync_idx)) {
         RAISE_ERROR_STR("Destroying a team without an active pSync");
     } else {
         shmem_internal_bit_set(psync_pool_avail, N_PSYNC_BYTES, team->psync_idx);

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -190,15 +190,15 @@ cleanup:
     }
     if (shmem_internal_psync_pool) {
         shmem_internal_free(shmem_internal_psync_pool);
-        shmem_internal_team_pool = NULL;
+        shmem_internal_psync_pool = NULL;
     }
     if (psync_pool_avail) {
         shmem_internal_free(psync_pool_avail);
-        shmem_internal_team_pool = NULL;
+        psync_pool_avail = NULL;
     }
     if (team_ret_val) {
         shmem_internal_free(team_ret_val);
-        shmem_internal_team_pool = NULL;
+        team_ret_val = NULL;
     }
 
     return -1;
@@ -333,6 +333,8 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
             shmem_internal_team_pool[myteam->psync_idx] = *new_team;
         }
     }
+
+    shmem_internal_team_release_psyncs(parent_team, REDUCE);
 
     /* This barrier on the parent team eliminates problematic race conditions
      * during psync allocation between back-to-back team creations. */

--- a/test/performance/shmem_perf_suite/README
+++ b/test/performance/shmem_perf_suite/README
@@ -41,12 +41,17 @@ Notes for Users:
         -e : end length (power of two) DEFAULT: 8MB
         -s : start length (power of two) DEFAULT: 1B
         -n : number of trials (must be greater than 20 (warmup size)) DEFAULT: 100
+        -m : scale the number of trials by a floating point multiplier DEFAULT: 1.0
         -v : validate input stream used for performance data (off by default)
         BW only:
             -k : output in KB
             -b : output in B
             -T : number of threads, DEFAULT: 1
             -C : thread level (SINGLE, FUNNELED, SERIALIZED, MULTIPLE), DEFAULT: SINGLE
+
+    Environment Variables:
+        SHMEM_PERF_SUITE_TRIALS_MULTIPLIER : Scale the number of trials by a floating
+                                             point multiplier.
 
 Notes for performance tests developers:
     overall model:

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -390,7 +390,7 @@ int bw_init_data_stream(perf_metrics_t * const metric_info,
 #if defined(ENABLE_THREADS)
     int tl;
     shmem_init_thread(metric_info->thread_safety, &tl);
-    if(tl != metric_info->thread_safety) {
+    if(tl < metric_info->thread_safety) {
         fprintf(stderr,"Could not initialize with requested thread "
                 "level %d: got %d\n", metric_info->thread_safety, tl);
         return -1;

--- a/test/performance/shmem_perf_suite/bw_common.h
+++ b/test/performance/shmem_perf_suite/bw_common.h
@@ -34,7 +34,7 @@
 static const char * dt_names [] = { "uint", "ulong", "ulonglong" };
 
 /*default settings if no input is provided */
-static 
+static
 void init_metrics(perf_metrics_t *metric_info) {
     metric_info->t_type = BW;
     set_metric_defaults(metric_info);
@@ -45,7 +45,7 @@ void init_metrics(perf_metrics_t *metric_info) {
     metric_info->opstyle = STYLE_RMA;
 }
 
-static 
+static
 void update_bw_type(perf_metrics_t *data, int b_type) {
     if (b_type == BI_DIR) {
         data->bw_type_str = "Bi-dir";
@@ -60,7 +60,7 @@ void update_bw_type(perf_metrics_t *data, int b_type) {
 /*                   Result Printing and Calc                 */
 /**************************************************************/
 
-static 
+static
 void print_atomic_header(perf_metrics_t * const metric_info) {
     print_header(metric_info);
     printf("\n\nBandwidth test type:    %10s\n", metric_info->bw_type_str);
@@ -72,7 +72,7 @@ void print_atomic_header(perf_metrics_t * const metric_info) {
         printf("Communication style:      PAIRWISE\n");
     }
 
-    printf("\nOperation%15sBandwidth%15sMessage Rate%15sLatency\n", 
+    printf("\nOperation%15sBandwidth%15sMessage Rate%15sLatency\n",
             " ", " ", " ");
 
     if (metric_info->unit == MB) {
@@ -86,7 +86,7 @@ void print_atomic_header(perf_metrics_t * const metric_info) {
     printf("%15s in Mops/sec%15s  in us\n", " ", " ");
 }
 
-static 
+static
 void print_bw_header(perf_metrics_t * const metric_info) {
     print_header(metric_info);
     printf("\n\nBandwidth test type:    %10s\n", metric_info->bw_type_str);
@@ -105,7 +105,7 @@ void print_bw_header(perf_metrics_t * const metric_info) {
     printf("%16sin msgs/sec\n", " ");
 }
 
-static 
+static
 void print_data_results(double bw, double mr, const perf_metrics_t * const data,
                             int len, double total_t) {
     static int atomic_type_index = 0;
@@ -123,7 +123,7 @@ void print_data_results(double bw, double mr, const perf_metrics_t * const data,
     }
 
     if (data->opstyle == STYLE_ATOMIC) {
-        printf("%13s%10.2f%15s%12.2f%12s%10.2f", " ", bw, " ", 
+        printf("%13s%10.2f%15s%12.2f%12s%10.2f", " ", bw, " ",
                 mr/1.0e6, " ", total_t/(data->trials * data->window_size));
     } else
         printf("%14s%10.2f%15s%12.2f", " ", bw, " ", mr);
@@ -139,15 +139,15 @@ void print_data_results(double bw, double mr, const perf_metrics_t * const data,
     printf("\n");
 }
 
-static inline 
-void calc_and_print_results(double end_t, double start_t, int len, 
+static inline
+void calc_and_print_results(double end_t, double start_t, int len,
                             perf_metrics_t * const metric_info) {
     int stride = 0, start_pe = 0, nPEs = 0;
     static double pe_bw_sum, bw = 0.0; /*must be symmetric for reduction*/
     double pe_bw_avg = 0.0, pe_mr_avg = 0.0;
     int nred_elements = 1;
     static double pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
-    static double pe_time_start, pe_time_end, 
+    static double pe_time_start, pe_time_end,
                   end_time_max = 0.0, start_time_min = 0.0;
     double total_t = 0.0, total_t_max = 0.0;
     int multiplier = 1;
@@ -161,11 +161,11 @@ void calc_and_print_results(double end_t, double start_t, int len,
     if (end_t > 0 && start_t > 0 && (end_t - start_t) > 0) {
         total_t = end_t - start_t;
 #ifdef ENABLE_OPENMP
-        bw = ((double) len * (double) metric_info->num_partners * (double) multiplier / 1.0e6 * 
+        bw = ((double) len * (double) metric_info->num_partners * (double) multiplier / 1.0e6 *
              metric_info->window_size * metric_info->trials *
              (double) metric_info->nthreads) / (total_t / 1.0e6);
 #else
-        bw = ((double) len * (double) metric_info->num_partners * (double) multiplier / 1.0e6 * 
+        bw = ((double) len * (double) metric_info->num_partners * (double) multiplier / 1.0e6 *
              metric_info->window_size * metric_info->trials) /
              (total_t / 1.0e6);
 #endif
@@ -179,24 +179,24 @@ void calc_and_print_results(double end_t, double start_t, int len,
 
     if (metric_info->individual_report == 1) {
         if (metric_info->my_node < metric_info->midpt) {
-            printf("Individual bandwith for PE %6d (initer) is %10.2f\n", 
+            printf("Individual bandwith for PE %6d (initer) is %10.2f\n",
                 metric_info->my_node, pe_bw_sum);
         } else {
-            printf("Individual bandwith for PE %6d (target) is %10.2f\n", 
+            printf("Individual bandwith for PE %6d (target) is %10.2f\n",
                 metric_info->my_node, pe_bw_sum);
         }
     }
-    
+
     pe_time_start = start_t;
     pe_time_end = end_t;
     shmem_barrier(start_pe, stride, nPEs, bar_psync);
-    if (metric_info->cstyle != COMM_INCAST) {  
+    if (metric_info->cstyle != COMM_INCAST) {
         if (nPEs >= 2) {
             shmem_double_min_to_all(&start_time_min, &pe_time_start, nred_elements,
                                 start_pe, stride, nPEs, pwrk,
                                 red_psync);
             shmem_barrier(start_pe, stride, nPEs, bar_psync);
-            shmem_double_max_to_all(&end_time_max, &pe_time_end, nred_elements, 
+            shmem_double_max_to_all(&end_time_max, &pe_time_end, nred_elements,
                                 start_pe, stride, nPEs, pwrk,
                                 red_psync);
         } else if (nPEs == 1) {
@@ -205,25 +205,25 @@ void calc_and_print_results(double end_t, double start_t, int len,
         }
 
         /* calculating bandwidth based on the highest time duration across all PEs */
-        if (end_time_max > 0 && start_time_min > 0 && 
+        if (end_time_max > 0 && start_time_min > 0 &&
            (end_time_max - start_time_min) > 0) {
 
             total_t_max = (end_time_max - start_time_min);
             int total_transfers = MAX(metric_info->szinitiator, metric_info->sztarget);
 #ifdef ENABLE_OPENMP
-            bw = ((double) len * (double) multiplier * (double) total_transfers / 
-                 1.0e6 * metric_info->window_size * metric_info->trials * 
+            bw = ((double) len * (double) multiplier * (double) total_transfers /
+                 1.0e6 * metric_info->window_size * metric_info->trials *
                  (double) metric_info->nthreads) / (total_t_max / 1.0e6);
 #else
-            bw = ((double) len * (double) multiplier * (double) total_transfers / 
-                 1.0e6 * metric_info->window_size * metric_info->trials) / 
+            bw = ((double) len * (double) multiplier * (double) total_transfers /
+                 1.0e6 * metric_info->window_size * metric_info->trials) /
                  (total_t_max / 1.0e6);
 #endif
         } else {
             fprintf(stderr, "Incorrect time measured from bandwidth test: "
-                        "start_min = %lf, end_max = %lf\n", 
+                        "start_min = %lf, end_max = %lf\n",
                          start_time_min, end_time_max);
-        } 
+        }
         pe_bw_sum = bw;
     } else {
         if (nPEs >= 2) {
@@ -252,7 +252,7 @@ static int validate_atomics(perf_metrics_t * const m_info) {
                                 * ATOMICS_N_DTs * ATOMICS_N_OPs) + m_info->my_node;
 
     if (m_info->cstyle == COMM_INCAST) {
-        if (tbw == BI_DIR) 
+        if (tbw == BI_DIR)
             printf("WARNING: This use-case is not currently well defined\n");
 
         if (m_info->my_node == 0) {
@@ -284,7 +284,7 @@ static int validate_atomics(perf_metrics_t * const m_info) {
  * NOTE: post function validation assumptions, data isn't flushed pre/post */
 extern void bi_dir_bw(int len, perf_metrics_t *metric_info);
 
-static inline 
+static inline
 void bi_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
     int partner_pe = partner_node(metric_info);
 
@@ -319,7 +319,7 @@ void bi_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
         } else {
             errors = validate_atomics(metric_info);
         }
-        if (errors >= 0) 
+        if (errors >= 0)
             printf("Validation complete (%d errors)\n", errors);
     }
 }
@@ -333,7 +333,7 @@ void bi_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
  * NOTE: post function validation assumptions, data isn't flushed pre/post */
 extern void uni_dir_bw(int len, perf_metrics_t *metric_info);
 
-static inline 
+static inline
 void uni_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
     int partner_pe = partner_node(metric_info);
 
@@ -369,7 +369,7 @@ void uni_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
         } else if (metric_info->opstyle == STYLE_ATOMIC) {
             errors = validate_atomics(metric_info);
         }
-        if (errors >= 0) 
+        if (errors >= 0)
             printf("Validation complete (%d errors)\n", errors);
     }
 }
@@ -379,7 +379,7 @@ void uni_dir_bw_test_and_output(perf_metrics_t * const metric_info) {
 /**************************************************************/
 
 /* create and init (with my_PE_num) two symmetric arrays on the heap */
-static inline 
+static inline
 int bw_init_data_stream(perf_metrics_t * const metric_info,
                         int argc, char *argv[]) {
 
@@ -438,7 +438,7 @@ int bw_init_data_stream(perf_metrics_t * const metric_info,
 }
 
 
-static inline 
+static inline
 int bi_dir_init(perf_metrics_t * const metric_info, int argc,
                 char *argv[], op_style opstyle) {
     int ret = bw_init_data_stream(metric_info, argc, argv);
@@ -446,11 +446,11 @@ int bi_dir_init(perf_metrics_t * const metric_info, int argc,
         metric_info->opstyle = opstyle;
         update_bw_type(metric_info, BI_DIR);
         return 0;
-    } else 
+    } else
         return ret;
 }
 
-static inline 
+static inline
 int uni_dir_init(perf_metrics_t * const metric_info, int argc,
                  char *argv[], op_style opstyle) {
     int ret = bw_init_data_stream(metric_info, argc, argv);
@@ -459,11 +459,11 @@ int uni_dir_init(perf_metrics_t * const metric_info, int argc,
         metric_info->opstyle = opstyle;
         update_bw_type(metric_info, UNI_DIR);
         return 0;
-    } else 
+    } else
         return ret;
 }
 
-static inline 
+static inline
 void bw_data_free(const perf_metrics_t * const metric_info) {
     shmem_barrier_all();
 
@@ -471,14 +471,14 @@ void bw_data_free(const perf_metrics_t * const metric_info) {
     aligned_buffer_free(metric_info->dest);
 }
 
-static inline 
+static inline
 void bw_finalize(void) {
 #ifndef VERSION_1_0
     shmem_finalize();
 #endif
 }
 
-static inline 
+static inline
 void bi_dir_bw_main(int argc, char *argv[], op_style opstyle) {
 
     perf_metrics_t metric_info;
@@ -490,10 +490,10 @@ void bi_dir_bw_main(int argc, char *argv[], op_style opstyle) {
         bw_data_free(&metric_info);
     }
 
-    bw_finalize(); 
-} 
+    bw_finalize();
+}
 
-static inline 
+static inline
 void uni_dir_bw_main(int argc, char *argv[], op_style opstyle) {
 
     perf_metrics_t metric_info;
@@ -506,4 +506,4 @@ void uni_dir_bw_main(int argc, char *argv[], op_style opstyle) {
     }
 
     bw_finalize();
-} 
+}

--- a/test/performance/shmem_perf_suite/common.h
+++ b/test/performance/shmem_perf_suite/common.h
@@ -131,7 +131,7 @@ typedef enum {
 #define FIRST_FETCH_OP OP_FETCH
 
 const char *atomic_op_name[] = { "set", "inc", "add", "and",
-                                 "or", "xor", 
+                                 "or", "xor",
                                  "fetch", "cswap", "swap", "finc",
                                  "fadd", "fand", "for", "fxor" };
 
@@ -146,8 +146,7 @@ typedef struct perf_metrics {
     op_style opstyle;
 
     float trials_multiplier; /* adjust trials value through env var
-                              * SOS_TRIALS_MULTIPLIER. Invalid for
-                              * user inputs*/
+                              * SHMEM_PERF_SUITE_TRIALS_MULTIPLIER. */
 
     /* parameters for threaded tests */
     int nthreads;
@@ -174,11 +173,11 @@ long red_psync[SHMEM_REDUCE_SYNC_SIZE];
 long bar_psync[SHMEM_BARRIER_SYNC_SIZE];
 
 /* default settings with no input provided */
-static inline 
+static inline
 void set_metric_defaults(perf_metrics_t *metric_info) {
     char *val = NULL;
     metric_info->trials_multiplier = 1.0; /* Default 1 */
-    val = getenv("SOS_TRIALS_MULTIPLIER");
+    val = getenv("SHMEM_PERF_SUITE_TRIALS_MULTIPLIER");
     if (val && strlen(val))
         metric_info->trials_multiplier = atof(val);
 
@@ -212,7 +211,7 @@ void set_metric_defaults(perf_metrics_t *metric_info) {
 }
 
 /* update metrics after shmem init */
-static inline 
+static inline
 void update_metrics(perf_metrics_t *metric_info) {
     metric_info->my_node = shmem_my_pe();
     metric_info->num_pes = shmem_n_pes();
@@ -306,7 +305,7 @@ static void aligned_buffer_free(char * ptr_aligned)
 #endif
 }
 
-static inline 
+static inline
 int is_divisible_by_4(int num) {
     if (num < 0)
         shmem_global_exit(1);
@@ -314,7 +313,7 @@ int is_divisible_by_4(int num) {
 }
 
 /*to be a power of 2 must only have 1 set bit*/
-static inline 
+static inline
 int is_pow_of_2(unsigned int num) {
     /*move first set bit all the way to right*/
     while(num && !((num >>=1 ) & 1));
@@ -323,7 +322,7 @@ int is_pow_of_2(unsigned int num) {
     return ((num == 1 || num == 0) ? true : false);
 }
 
-static 
+static
 void init_array(const char *buf, int len, int my_pe_num) {
     int i = 0;
     int array_size = len / sizeof(int);
@@ -335,7 +334,7 @@ void init_array(const char *buf, int len, int my_pe_num) {
         ibuf[i] = my_pe_num;
 }
 
-static inline 
+static inline
 int validate_recv(char *buf, int len, int partner_pe) {
     int i = 0;
     int array_size = len / sizeof(int);
@@ -350,7 +349,7 @@ int validate_recv(char *buf, int len, int partner_pe) {
         }
     }
     if (errors > 0) {
-        printf("Validation error: stored_value = %d, expected value = %d\n", 
+        printf("Validation error: stored_value = %d, expected value = %d\n",
                                   ibuf[0], partner_pe);
     }
     return errors;
@@ -366,7 +365,7 @@ int command_line_arg_check(int argc, char *argv[], perf_metrics_t * const metric
     extern char *optarg;
 
     /* check command line args */
-    while ((ch = getopt(argc, argv, "e:s:n:w:p:r:l:kbivtC:T:")) != EOF) {
+    while ((ch = getopt(argc, argv, "e:s:n:m:w:p:r:l:kbivtC:T:")) != EOF) {
         switch (ch) {
         case 's':
             metric_info->start_len = strtoul(optarg, (char **)NULL, 0);
@@ -405,6 +404,17 @@ int command_line_arg_check(int argc, char *argv[], perf_metrics_t * const metric
                 errors++;
             }
             break;
+        case 'm':
+            metric_info->trials_multiplier = strtod(optarg, (char **)NULL);
+            if(metric_info->trials * metric_info->trials_multiplier <
+                (metric_info->warmup * 2)) {
+                fprintf(stderr, "Error: trials * trials_multiplier (%ld) must be >= 2*warmup (%ld)\n",
+                        (unsigned long int)(metric_info->trials * metric_info->trials_multiplier),
+                        metric_info->warmup * 2);
+                errors++;
+            }
+            metric_info->trials *= metric_info->trials_multiplier;
+            break;
         case 'p':
             metric_info->warmup = strtoul(optarg, (char **)NULL, 0);
             if(metric_info->warmup > (metric_info->trials/2)) {
@@ -425,7 +435,7 @@ int command_line_arg_check(int argc, char *argv[], perf_metrics_t * const metric
             break;
         case 'v':
             metric_info->validate = true;
-            if(metric_info->t_type == BW && metric_info->target_data) 
+            if(metric_info->t_type == BW && metric_info->target_data)
                 errors++;
             break;
         case 'w':
@@ -492,12 +502,14 @@ int command_line_arg_check(int argc, char *argv[], perf_metrics_t * const metric
 static inline
 void print_usage(int errors) {
     fprintf(stderr, "\nNumber of errors in the command line: %d\n", errors);
-    fprintf(stderr, "\nUsage: <benchmark executable> [OPTION]\n" 
+    fprintf(stderr, "\nUsage: <benchmark executable> [OPTION]\n"
            " -s START_MSG_SIZE           Smallest message size. Must be power of 2\n"
            " -e END_MSG_SIZE             Largest message size. Must be power of 2\n"
            " -p WARMUP                   Number of warmup iterations\n"
            " -n TRIALS                   Number of trial iterations. Must be at\n"
            "                             least twice of WARMUP\n"
+           " -m TRIALS_MULTIPLIER        Scale the TRIALS value by a floating\n"
+           "                             point multiplier.  Must be greater than 0.\n"
            " -w WINDOW_SIZE              Window size for streaming. Cannot be used\n"
            "                             in conjunction with -t. Specific to band-\n"
            "                             -width experiments\n"
@@ -521,7 +533,7 @@ void print_usage(int errors) {
 
 
 #if defined(ENABLE_THREADS)
-static 
+static
 const char *thread_safety_str(perf_metrics_t * const metric_info) {
     if (metric_info->thread_safety == SHMEM_THREAD_SINGLE) {
         return "SINGLE";
@@ -532,14 +544,14 @@ const char *thread_safety_str(perf_metrics_t * const metric_info) {
     } else if (metric_info->thread_safety == SHMEM_THREAD_MULTIPLE) {
         return "MULTIPLE";
     } else {
-        fprintf(stderr, "Unexpected thread safety value: %d. " 
+        fprintf(stderr, "Unexpected thread safety value: %d. "
                         "Setting it to SINGLE\n", metric_info->thread_safety);
         metric_info->thread_safety = SHMEM_THREAD_SINGLE;
         return "SINGLE";
     }
 }
 
-static inline 
+static inline
 void thread_safety_validation_check(perf_metrics_t * const metric_info) {
     if (metric_info->nthreads == 1)
         return;
@@ -548,7 +560,7 @@ void thread_safety_validation_check(perf_metrics_t * const metric_info) {
             if(metric_info->my_node == 0) {
                 fprintf(stderr, "Warning: argument \"-T %d\" is ignored"
                                 " because of the thread level specified."
-                                " Switching to single thread with thread" 
+                                " Switching to single thread with thread"
                                 " safety %s\n", metric_info->nthreads,
                                   thread_safety_str(metric_info));
             }
@@ -559,7 +571,7 @@ void thread_safety_validation_check(perf_metrics_t * const metric_info) {
 }
 #endif
 
-static inline 
+static inline
 int only_even_PEs_check(int my_node, int num_pes) {
     if (num_pes % 2 != 0) {
         if (my_node == 0) {
@@ -572,7 +584,7 @@ int only_even_PEs_check(int my_node, int num_pes) {
 
 
 /* Returns partner node; Assumes only one partner */
-static inline 
+static inline
 int partner_node(const perf_metrics_t * const my_info)
 {
     if (my_info->num_pes == 1)
@@ -614,7 +626,7 @@ int target_node(const perf_metrics_t * const my_info)
         (my_info->my_node < (my_info->midpt + my_info->sztarget)));
 }
 
-static inline 
+static inline
 int is_streaming_node(const perf_metrics_t * const my_info, int node)
 {
     if (my_info->cstyle == COMM_PAIRWISE) {
@@ -641,7 +653,7 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
         pSync_collect[i] = SHMEM_SYNC_VALUE;
 
     char *hostname = (char *) shmem_malloc (hostname_size * sizeof(char));
-    char *dest = (char *) shmem_malloc (my_info->num_pes * hostname_size * 
+    char *dest = (char *) shmem_malloc (my_info->num_pes * hostname_size *
                                         sizeof(char));
 
     if (hostname == NULL || dest == NULL) {
@@ -657,7 +669,7 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
     shmem_barrier_all();
 
     /* nelems needs to be updated based on 32-bit API */
-    shmem_fcollect32(dest, hostname, hostname_size/4, 0, 0, my_info->num_pes, 
+    shmem_fcollect32(dest, hostname, hostname_size/4, 0, 0, my_info->num_pes,
                      pSync_collect);
 
     char *snode_name = NULL;
@@ -672,7 +684,7 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
 
             if (strncmp(snode_name, curr_name, hostname_size) != 0) {
                 fprintf(stderr, "PE %d on %s is a streaming node "
-                                "but not placed on %s\n", i, curr_name, 
+                                "but not placed on %s\n", i, curr_name,
                                  snode_name);
                 errors++;
             }
@@ -683,7 +695,7 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
 
             if (strncmp(tnode_name, curr_name, hostname_size) != 0) {
                 fprintf(stderr, "PE %d on %s is a target node "
-                                "but not placed on %s\n", i, curr_name, 
+                                "but not placed on %s\n", i, curr_name,
                                  tnode_name);
                 errors++;
             }
@@ -797,11 +809,11 @@ static
 void print_header(perf_metrics_t * const metric_info) {
     printf("\n%20sSandia OpenSHMEM Performance Suite%20s\n", " ", " ");
     printf("%20s==================================%20s\n", " ", " ");
-    printf("Total Number of PEs:    %10d%6sWindow size:            %10lu\n", 
+    printf("Total Number of PEs:    %10d%6sWindow size:            %10lu\n",
             metric_info->num_pes, " ", metric_info->window_size);
-    printf("Number of source PEs:   %10d%6sMaximum message size:   %10lu\n", 
+    printf("Number of source PEs:   %10d%6sMaximum message size:   %10lu\n",
             metric_info->szinitiator, " ", metric_info->max_len);
-    printf("Number of target PEs:   %10d%6sNumber of threads:      %10d\n", 
+    printf("Number of target PEs:   %10d%6sNumber of threads:      %10d\n",
             metric_info->sztarget, " ", metric_info->nthreads);
     printf("Iteration count:        %10lu%6s", metric_info->trials, " ");
 #if defined(ENABLE_THREADS)

--- a/test/performance/shmem_perf_suite/latency_common.h
+++ b/test/performance/shmem_perf_suite/latency_common.h
@@ -143,7 +143,7 @@ int latency_init_resources(int argc, char *argv[],
 #if defined(ENABLE_THREADS)
     int tl;
     shmem_init_thread(metric_info->thread_safety, &tl);
-    if(tl != metric_info->thread_safety) {
+    if(tl < metric_info->thread_safety) {
         fprintf(stderr,"Could not initialize with requested thread "
                 "level %d: got %d\n", metric_info->thread_safety, tl);
         return -1;

--- a/test/unit/query_thread.c
+++ b/test/unit/query_thread.c
@@ -37,7 +37,7 @@ main(int argc, char* argv[])
     int tl, ret;
     ret = shmem_init_thread(SHMEM_THREAD_FUNNELED, &tl);
 
-    if (tl != SHMEM_THREAD_FUNNELED || ret != 0) {
+    if (tl < SHMEM_THREAD_FUNNELED || ret != 0) {
         printf("Init failed (requested thread level %d, got %d, ret %d)\n",
                SHMEM_THREAD_FUNNELED, tl, ret);
         if (ret == 0) {
@@ -54,7 +54,7 @@ main(int argc, char* argv[])
     printf("%d: Query result for thread level %d\n", shmem_my_pe(), provided);
 
 #if defined(ENABLE_THREADS)
-    if (provided != SHMEM_THREAD_FUNNELED) 
+    if (provided < SHMEM_THREAD_FUNNELED)
         shmem_global_exit(1);
 #else
     if (provided != SHMEM_THREAD_SINGLE && provided != SHMEM_THREAD_FUNNELED && 


### PR DESCRIPTION
I went ahead and created a `v1.4.x` branch on SOS that is synced with the `v1.4.5` tag.

This PR cherry-picks several commits from the master branch to include in `v1.4.x` to fix some bugs and have a useful Travis script.  Here's a short list of what's included:

* 8de8a785075b3cf5498c8753d98814506ce5e396 to allow higher thread levels in the tests and adds to `v1.4.x`. 
* All commits from PR #968 (teams bug fixes)
* ea3ea06749af57fb12fb48ddac23eaf6ca01244f to fix XPMEM testing in Travis
* A manual merge of the updates from PR #966  (primarily to update PMIx support in Travis)

I'll also add the shmem_perf_suite trial multiplier in PR #988 (and sync with https://github.com/openshmem-org/tests-sos) to `v1.4.x` after it's approved/merged into master.

All should feel free to request other features/bug fixes for `v1.4.x`.