### PR TITLE
Fix pSync size in shmem_malloc_with_hint unit test

### DIFF
--- a/test/unit/shmem_malloc_with_hints.c
+++ b/test/unit/shmem_malloc_with_hints.c
@@ -37,7 +37,7 @@
 
 #define SHMEM_MALLOC_INVALID_HINT ~(SHMEM_MALLOC_ATOMICS_REMOTE)
 
-long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
+long pSync[SHMEM_REDUCE_SYNC_SIZE];
 int pWrk[WRK_SIZE];
 
 
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
     npes = shmem_n_pes();
     mype = shmem_my_pe();
 
-    for (i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
+    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
         pSync[i] = SHMEM_SYNC_VALUE;
 
     passed = sumtoall_with_malloc_hint(0, mype, npes);


### PR DESCRIPTION
This test is calling a reduction on the pSync so the size should be `SHMEM_REDUCE_SYNC_SIZE`, not `SHMEM_ALLTOALL_SYNC_SIZE`.