### PR TITLE
Fix small leak on kvs_value in runtime-pmi.c

### DIFF
--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -123,6 +123,14 @@ shmem_runtime_fini(void)
         free(location_array);
     }
 
+    if (kvs_key) {
+        free(kvs_key);
+    }
+
+    if (kvs_value) {
+        free(kvs_value);
+    }
+
     if (initialized_pmi) {
         PMI_Finalize();
         initialized_pmi = 0;
@@ -266,7 +274,7 @@ shmem_runtime_get(int pe, char *key, void *value, size_t valuelen)
         HASH_FIND_STR(singleton_kvs, kvs_key, e);
         if (e == NULL)
             return 3;
-        kvs_value = e->val;
+        *kvs_value = *(e->val);
     }
     else {
         if (PMI_SUCCESS != PMI_KVS_Get(kvs_name, kvs_key, kvs_value, max_val_len)) {

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -119,17 +119,10 @@ shmem_runtime_init(int enable_node_ranks)
 int
 shmem_runtime_fini(void)
 {
-    if (location_array) {
-        free(location_array);
-    }
-
-    if (kvs_key) {
-        free(kvs_key);
-    }
-
-    if (kvs_value) {
-        free(kvs_value);
-    }
+    free(location_array);
+    free(kvs_name);
+    free(kvs_key);
+    free(kvs_value);
 
     if (initialized_pmi) {
         PMI_Finalize();

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -274,7 +274,7 @@ shmem_runtime_get(int pe, char *key, void *value, size_t valuelen)
         HASH_FIND_STR(singleton_kvs, kvs_key, e);
         if (e == NULL)
             return 3;
-        *kvs_value = *(e->val);
+        strncpy(kvs_value, e->val, max_val_len);
     }
     else {
         if (PMI_SUCCESS != PMI_KVS_Get(kvs_name, kvs_key, kvs_value, max_val_len)) {


### PR DESCRIPTION
Valgrind says there's a consistent 1KB leak here, but only when NPES == 1.

The problem appears to be that the address of `kvs_value` was being set, so it becomes an invalid free during finalization.  Setting the value instead seems to be the original intent.