### PR TITLE
Add deprecation warnings to 32/64-bit collectives

### DIFF
--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -438,36 +438,36 @@ SHMEM_BIND_C_COLL_CMPLX(`SHMEM_C_TO_ALL', `prod')
 
 /* COLL: Collect Routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_collect32(void *target, const void *source, size_t nlong,
-                     int PE_start, int logPE_stride, int PE_size, long *pSync);
+                     int PE_start, int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_collect64(void *target, const void *source, size_t nlong,
-                     int PE_start, int logPE_stride, int PE_size, long *pSync);
+                     int PE_start, int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_fcollect32(void *target, const void *source, size_t nlong,
                       int PE_start, int logPE_stride, int PE_size,
-                      long *pSync);
+                      long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_fcollect64(void *target, const void *source, size_t nlong,
                       int PE_start, int logPE_stride, int PE_size,
-                      long *pSync);
+                      long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 
 /* COLL: Broadcast Routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_broadcast32(void *target, const void *source, size_t nlong,
                        int PE_root, int PE_start, int logPE_stride,
-                       int PE_size, long *pSync);
+                       int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_broadcast64(void *target, const void *source, size_t nlong,
                        int PE_root, int PE_start, int logPE_stride,
-                       int PE_size, long *pSync);
+                       int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 
 /* COLL: All-to-All routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_alltoall32(void *dest, const void *source, size_t nelems, int PE_start,
-                      int logPE_stride, int PE_size, long *pSync);
+                      int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
-                      int logPE_stride, int PE_size, long *pSync);
+                      int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_alltoalls32(void *dest, const void *source, ptrdiff_t dst,
                        ptrdiff_t sst, size_t nelems, int PE_start,
-                       int logPE_stride, int PE_size, long *pSync);
+                       int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_alltoalls64(void *dest, const void *source, ptrdiff_t dst,
                        ptrdiff_t sst, size_t nelems, int PE_start,
-                       int logPE_stride, int PE_size, long *pSync);
+                       int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 
 /* Point-to-Point Synchronization Routines */
 define(`SHMEM_C_WAIT',

--- a/test/apps/gups.c
+++ b/test/apps/gups.c
@@ -322,7 +322,6 @@ SHMEMRandomAccess(void)
   uint64_t NumUpdates; /* total number of updates to table */
   uint64_t ProcNumUpdates; /* number of updates per processor */
 
-  static long pSync_bcast[SHMEM_BCAST_SYNC_SIZE];
   static long long int llpWrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
 
   static long pSync_reduce[SHMEM_REDUCE_SYNC_SIZE];
@@ -332,10 +331,6 @@ SHMEMRandomAccess(void)
   double *GUPs;
   double *temp_GUPs;
 
-
-  for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i += 1){
-        pSync_bcast[i] = SHMEM_SYNC_VALUE;
-  }
 
   for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i += 1){
         pSync_reduce[i] = SHMEM_SYNC_VALUE;
@@ -468,7 +463,7 @@ SHMEMRandomAccess(void)
   /* distribute result to all nodes */
   temp_GUPs = GUPs;
   shmem_barrier_all();
-  shmem_broadcast64(GUPs,temp_GUPs,1,0,0,0,NumProcs,pSync_bcast);
+  shmem_double_broadcast(SHMEM_TEAM_WORLD,GUPs,temp_GUPs,1,0);
   shmem_barrier_all();
 
   /* Verification phase */

--- a/test/performance/shmem_perf_suite/common.h
+++ b/test/performance/shmem_perf_suite/common.h
@@ -647,11 +647,6 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
                          MAX_HOSTNAME_LEN + (4 - MAX_HOSTNAME_LEN % 4);
     int i, errors = 0;
 
-    /* pSync for fcollect of hostnames */
-    static long pSync_collect[SHMEM_COLLECT_SYNC_SIZE];
-    for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
-        pSync_collect[i] = SHMEM_SYNC_VALUE;
-
     char *hostname = (char *) shmem_malloc (hostname_size * sizeof(char));
     char *dest = (char *) shmem_malloc (my_info->num_pes * hostname_size *
                                         sizeof(char));
@@ -669,8 +664,7 @@ int check_hostname_validation(const perf_metrics_t * const my_info) {
     shmem_barrier_all();
 
     /* nelems needs to be updated based on 32-bit API */
-    shmem_fcollect32(dest, hostname, hostname_size/4, 0, 0, my_info->num_pes,
-                     pSync_collect);
+    shmem_char_fcollect(SHMEM_TEAM_WORLD, dest, hostname, hostname_size/4);
 
     char *snode_name = NULL;
     char *tnode_name = NULL;

--- a/test/performance/tests/msgrate.c
+++ b/test/performance/tests/msgrate.c
@@ -299,23 +299,23 @@ main(int argc, char *argv[])
     shmem_barrier_all();
 
     /* broadcast results */
-    shmem_broadcast32(&start_err, &start_err, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &start_err, &start_err, 1, 0);
     if (0 != start_err) {
         shmem_finalize();
         exit(start_err);
     }
     shmem_barrier_all();
-    shmem_broadcast32(&npeers, &npeers, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &npeers, &npeers, 1, 0);
     shmem_barrier_all();
-    shmem_broadcast32(&niters, &niters, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &niters, &niters, 1, 0);
     shmem_barrier_all();
-    shmem_broadcast32(&nmsgs, &nmsgs, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &nmsgs, &nmsgs, 1, 0);
     shmem_barrier_all();
-    shmem_broadcast32(&nbytes, &nbytes, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &nbytes, &nbytes, 1, 0);
     shmem_barrier_all();
-    shmem_broadcast32(&cache_size, &cache_size, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &cache_size, &cache_size, 1, 0);
     shmem_barrier_all();
-    shmem_broadcast32(&ppn, &ppn, 1, 0, 0, 0, world_size, bcast_pSync);
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, &ppn, &ppn, 1, 0);
     shmem_barrier_all();
     if (0 == rank) {
         if (!machine_output) {

--- a/test/unit/alltoall.c
+++ b/test/unit/alltoall.c
@@ -29,14 +29,6 @@
 #include <stdint.h>
 #include <shmem.h>
 
-long pSync[SHMEM_ALLTOALL_SYNC_SIZE];
-
-static int is_active(int pe, int pe_start, int pe_stride, int pe_size) {
-    int stride = 1 << pe_stride;
-
-    return pe >= pe_start && pe < pe_start + pe_size * stride && (pe - pe_start) % stride == 0;
-}
-
 /* Tranlate a group PE index to a global PE rank. */
 static int pe_group_to_world(int group_pe, int pe_start, int pe_stride, int pe_size) {
     int stride = 1 << pe_stride;
@@ -64,13 +56,15 @@ static void alltoall_test(int32_t *out, int32_t *in, int pe_start, int pe_stride
 
     shmem_barrier_all();
 
-    if (is_active(me, pe_start, pe_stride, pe_size))
-        shmem_alltoall32(out, in, 1, pe_start, pe_stride, pe_size, pSync);
+    shmem_team_t new_team;
+    shmem_team_split_strided(SHMEM_TEAM_WORLD, pe_start, pe_stride, pe_size, NULL, 0, &new_team);
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_alltoall(new_team, out, in, 1);
 
     for (i = 0; i < npes; i++) {
         int expected;
 
-        if (is_active(me, pe_start, pe_stride, pe_size))
+        if (new_team != SHMEM_TEAM_INVALID)
             expected = pe_group_to_world(i, pe_start, pe_stride, pe_size);
         else
             expected = -1;
@@ -87,15 +81,12 @@ static void alltoall_test(int32_t *out, int32_t *in, int pe_start, int pe_stride
 
 
 int main(int argc, char **argv) {
-    int npes, i;
+    int npes;
     int32_t *in, *out;
 
     shmem_init();
 
     npes = shmem_n_pes();
-
-    for (i = 0; i < SHMEM_ALLTOALL_SYNC_SIZE; i++)
-        pSync[i] = SHMEM_SYNC_VALUE;
 
     in = shmem_malloc(4 * npes);
     out = shmem_malloc(4 * npes);

--- a/test/unit/bcast.c
+++ b/test/unit/bcast.c
@@ -43,8 +43,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-long pSync[SHMEM_BCAST_SYNC_SIZE];
-
 #define START_BCAST_SIZE 16
 #define BCAST_INCR 1024
 
@@ -90,10 +88,6 @@ main(int argc, char* argv[])
         }
     }
 
-    for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i += 1) {
-        pSync[i] = SHMEM_SYNC_VALUE;
-    }
-
     if ( mpe == 0 && Verbose ) {
         fprintf(stderr,"%d loops\n",loops);
     }
@@ -115,7 +109,7 @@ main(int argc, char* argv[])
 
         shmem_barrier_all();
 
-        shmem_broadcast64(dst, src, nLongs, 1, 0, 0, num_pes, pSync);
+        shmem_long_broadcast(SHMEM_TEAM_WORLD, dst, src, nLongs, 1);
 
         for(i=0; i < nLongs; i++) {
             /* the root node shouldn't have the result into dst (cf specification).*/

--- a/test/unit/collect.c
+++ b/test/unit/collect.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv) {
     /* TEST: All PEs contribute their PE id */
     src[0] = me;
 
-    shmem_collect32(dst, src, 1, 0, 0, npes, pSync);
+    shmem_int32_collect(SHMEM_TEAM_WORLD, dst, src, 1);
 
     for (i = 0; i < npes; i++) {
         if (dst[i] != i) {
@@ -87,8 +87,10 @@ int main(int argc, char **argv) {
     /* TEST: Even PEs contribute their PE id */
     src[0] = me;
 
-    if (me % 2 == 0) {
-        shmem_collect32(dst, src, 1, 0, 1, npes/2 + npes%2, pSync);
+    shmem_team_t new_team;
+    shmem_team_split_strided(SHMEM_TEAM_WORLD, 0, 2, npes/2 + npes%2, NULL, 0, &new_team);
+    if (new_team != SHMEM_TEAM_INVALID) {
+        shmem_int32_collect(new_team, dst, src, 1);
 
         for (i = 0; i < npes/2; i++) {
             if (dst[i] != i*2) {
@@ -105,7 +107,7 @@ int main(int argc, char **argv) {
     for (i = 0; i < me; i++)
         src[i] = me+1;
 
-    shmem_collect32(dst, src, me, 0, 0, npes, pSync);
+    shmem_int32_collect(SHMEM_TEAM_WORLD, dst, src, me);
 
     int idx = 0;
     for (i = 0; i < npes; i++) {

--- a/test/unit/collect_active_set.c
+++ b/test/unit/collect_active_set.c
@@ -32,14 +32,47 @@
 
 #define MAX_NPES 32
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long collect_psync[SHMEM_COLLECT_SYNC_SIZE];
 
 /* Note: Need to alternate psync arrays because the active set changes */
 long barrier_psync0[SHMEM_BARRIER_SYNC_SIZE];
 long barrier_psync1[SHMEM_BARRIER_SYNC_SIZE];
+#endif
 
 int64_t src[MAX_NPES];
 int64_t dst[MAX_NPES*MAX_NPES];
+
+/* Validate broadcasted data */
+static int validate_data(int i, int me, int npes) {
+    int idx = 0;
+    int errors = 0;
+    /* Validate destination buffer data */
+    for (int j = 0; j < npes - i; j++) {
+        for (int k = 0; k < i+j; k++, idx++) {
+            if (dst[idx] != i+j) {
+                printf("%d: Expected dst[%d] = %d, got dst[%d] = %"PRId64", iteration %d\n",
+                       me, idx, i+j, idx, dst[idx], i);
+                errors++;
+            }
+        }
+    }
+
+    /* Validate unused destination buffer */
+    for ( ; idx < MAX_NPES*MAX_NPES; idx++) {
+        if (dst[idx] != -1) {
+            printf("%d: Expected dst[%d] = %d, got dst[%d] = %"PRId64", iteration %d\n",
+                   me, idx, -1, idx, dst[idx], i);
+            errors++;
+        }
+    }
+
+    /* Reset for next iteration */
+    for (int j = 0; j < MAX_NPES*MAX_NPES; j++)
+        dst[j] = -1;
+
+    return errors;
+}
 
 int main(void)
 {
@@ -64,6 +97,7 @@ int main(void)
     for (i = 0; i < MAX_NPES*MAX_NPES; i++)
         dst[i] = -1;
 
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i < SHMEM_COLLECT_SYNC_SIZE; i++)
         collect_psync[i] = SHMEM_SYNC_VALUE;
 
@@ -71,6 +105,7 @@ int main(void)
         barrier_psync0[i] = SHMEM_SYNC_VALUE;
         barrier_psync1[i] = SHMEM_SYNC_VALUE;
     }
+#endif
 
     if (me == 0)
         printf("Shrinking active set test\n");
@@ -79,41 +114,30 @@ int main(void)
 
     /* A total of npes tests are performed, where the active set in each test
      * includes PEs i..npes-1 and each PE contributes PE ID elements */
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i <= me; i++) {
-        int j, k;
-        int idx = 0;
-
         if (me == i)
             printf(" + active set size %d\n", npes-i);
 
         shmem_collect64(dst, src, me, i, 0, npes-i, collect_psync);
-
-        /* Validate destination buffer data */
-        for (j = 0; j < npes - i; j++) {
-            for (k = 0; k < i+j; k++, idx++) {
-                if (dst[idx] != i+j) {
-                    printf("%d: Expected dst[%d] = %d, got dst[%d] = %"PRId64", iteration %d\n",
-                           me, idx, i+j, idx, dst[idx], i);
-                    errors++;
-                }
-            }
-        }
-
-        /* Validate unused destination buffer */
-        for ( ; idx < MAX_NPES*MAX_NPES; idx++) {
-            if (dst[idx] != -1) {
-                printf("%d: Expected dst[%d] = %d, got dst[%d] = %"PRId64", iteration %d\n",
-                       me, idx, -1, idx, dst[idx], i);
-                errors++;
-            }
-        }
-
-        /* Reset for next iteration */
-        for (j = 0; j < MAX_NPES*MAX_NPES; j++)
-            dst[j] = -1;
+        errors += validate_data(i, me, npes);
 
         shmem_barrier(i, 0, npes-i, (i % 2) ? barrier_psync0 : barrier_psync1);
     }
+#else
+    shmem_team_t new_team;
+    for (i = 0; i < npes; i++) {
+        if (me == i)
+            printf(" + active set size %d\n", npes-i);
+
+        shmem_team_split_strided(SHMEM_TEAM_WORLD, i, 1, npes-i, NULL, 0, &new_team);
+        if (new_team != SHMEM_TEAM_INVALID) {
+            shmem_int64_collect(new_team, dst, src, me);
+            errors += validate_data(i, me, npes);
+        }
+        shmem_barrier_all();
+    }
+#endif
 
     shmem_finalize();
 

--- a/test/unit/fcollect64.c
+++ b/test/unit/fcollect64.c
@@ -71,7 +71,6 @@ int Verbose;
 
 long *dst;
 long *src;
-long pSync[SHMEM_COLLECT_SYNC_SIZE];
 
 static int
 atoi_scaled(char *s)
@@ -169,9 +168,6 @@ main(int argc, char* argv[])
         return 1;
     }
 
-    for (c = 0; c < SHMEM_COLLECT_SYNC_SIZE;c++)
-        pSync[c] = SHMEM_SYNC_VALUE;
-
     if (Verbose && mpe == 0)
         fprintf(stderr,"loops(%d) nWords(%d) incr-per-loop(%d)\n",
                 loops,nWords,nIncr);
@@ -193,7 +189,7 @@ main(int argc, char* argv[])
 
         shmem_barrier_all();
 
-        shmem_fcollect64(dst,src,nWords,0,0,num_pes,pSync);
+        shmem_long_fcollect(SHMEM_TEAM_WORLD, dst,src,nWords);
 
         // Expect dst to be consecuative integers 0 ... (nLongs*num_pes)-1
         for(j=0; j < (nWords*num_pes); j++) {

--- a/test/unit/nop_collectives.c
+++ b/test/unit/nop_collectives.c
@@ -67,20 +67,44 @@ int main(void) {
     if (me == 0) printf("Testing zero length collectives\n");
 
     if (me == 0) printf(" + broadcast\n");
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_broadcast32(NULL, NULL, 0, 0, 0, 0, npes, bcast_psync);
+#else
+    shmem_int_broadcast(SHMEM_TEAM_WORLD, NULL, NULL, 0, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_broadcast64(NULL, NULL, 0, 0, 0, 0, npes, bcast_psync);
+#else
+    shmem_long_broadcast(SHMEM_TEAM_WORLD, NULL, NULL, 0, 0);
+#endif
     shmem_barrier_all();
 
     if (me == 0) printf(" + collect\n");
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_fcollect32(NULL, NULL, 0, 0, 0, npes, collect_psync);
+#else
+    shmem_int_fcollect(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_fcollect64(NULL, NULL, 0, 0, 0, npes, collect_psync);
+#else
+    shmem_long_fcollect(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
 
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_collect32(NULL, NULL, 0, 0, 0, npes, collect_psync);
+#else
+    shmem_int_collect(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_collect64(NULL, NULL, 0, 0, 0, npes, collect_psync);
+#else
+    shmem_long_collect(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
 
     if (me == 0) printf(" + reduction\n");
@@ -100,14 +124,30 @@ int main(void) {
     shmem_barrier_all();
 
     if (me == 0) printf(" + all-to-all\n");
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoall32(NULL, NULL, 0, 0, 0, npes, alltoall_psync);
+#else
+    shmem_int_alltoall(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoall64(NULL, NULL, 0, 0, 0, npes, alltoall_psync);
+#else
+    shmem_long_alltoall(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
 
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoalls32(NULL, NULL, 1, 1, 0, 0, 0, npes, alltoalls_psync);
+#else
+    shmem_int_alltoalls(SHMEM_TEAM_WORLD, NULL, NULL, 1, 1, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoalls64(NULL, NULL, 1, 1, 0, 0, 0, npes, alltoalls_psync);
+#else
+    shmem_long_alltoalls(SHMEM_TEAM_WORLD, NULL, NULL, 1, 1, 0);
+#endif
 
     if (me == 0) printf("Done\n");
 

--- a/test/unit/self_collectives.c
+++ b/test/unit/self_collectives.c
@@ -82,37 +82,79 @@ int main(void) {
     /* Note: Broadcast does not modify the output buffer at the root */
     if (me == 0) printf(" + broadcast\n");
 
+#ifndef ENABLE_DEPRECATED_TESTS
+    /* Set up active set team (start=me, stride=1, size=1) for all tests*/
+    shmem_team_t new_team;
+    shmem_team_split_strided(SHMEM_TEAM_WORLD, me, 1, 1, NULL, 0, &new_team);
+#endif
+
     in_32 = me; out_32 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_broadcast32(&in_32, &out_32, 1, 0, me, 0, 1, bcast_psync);
     CHECK("shmem_broadcast32", -1, out_32);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_broadcast(new_team, &in_32, &out_32, 1, 0);
+    CHECK("shmem_int32_broadcast", -1, out_32);
+#endif
     shmem_barrier_all();
 
     in_64 = me; out_64 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_broadcast64(&in_64, &out_64, 1, 0, me, 0, 1, bcast_psync);
     CHECK("shmem_broadcast64", -1, out_64);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int64_broadcast(new_team, &in_64, &out_64, 1, 0);
+    CHECK("shmem_int64_broadcast", -1, out_64);
+#endif
     shmem_barrier_all();
 
     /* Collect */
     if (me == 0) printf(" + collect\n");
 
     in_32 = me; out_32 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_fcollect32(&in_32, &out_32, 1, me, 0, 1, collect_psync);
     CHECK("shmem_fcollect32", in_32, out_32);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_fcollect(new_team, &in_32, &out_32, 1);
+    CHECK("shmem_int32_fcollect", in_32, out_32);
+#endif
     shmem_barrier_all();
 
     in_64 = me; out_64 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_fcollect64(&in_64, &out_64, 1, me, 0, 1, collect_psync);
     CHECK("shmem_fcollect64", in_64, out_64);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int64_fcollect(new_team, &in_64, &out_64, 1);
+    CHECK("shmem_int64_fcollect", in_64, out_64);
+#endif
     shmem_barrier_all();
 
     in_32 = me; out_32 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_collect32(&in_32, &out_32, 1, me, 0, 1, collect_psync);
     CHECK("shmem_collect32", in_32, out_32);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_collect(new_team, &in_32, &out_32, 1);
+    CHECK("shmem_int32_collect", in_32, out_32);
+#endif
     shmem_barrier_all();
 
     in_64 = me; out_64 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_collect64(&in_64, &out_64, 1, me, 0, 1, collect_psync);
     CHECK("shmem_collect64", in_64, out_64);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int64_collect(new_team, &in_64, &out_64, 1);
+    CHECK("shmem_int64_collect", in_64, out_64);
+#endif
     shmem_barrier_all();
 
     /* Reduction */
@@ -157,23 +199,47 @@ int main(void) {
     if (me == 0) printf(" + all-to-all\n");
 
     in_32 = me; out_32 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoall32(&in_32, &out_32, 1, me, 0, 1, alltoall_psync);
     CHECK("shmem_alltoall32", in_32, out_32);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_alltoall(new_team, &in_32, &out_32, 1);
+    CHECK("shmem_int32_alltoall", in_32, out_32);
+#endif
     shmem_barrier_all();
 
     in_64 = me; out_64 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoall64(&in_64, &out_64, 1, me, 0, 1, alltoall_psync);
     CHECK("shmem_alltoall64", in_64, out_64);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int64_alltoall(new_team, &in_64, &out_64, 1);
+    CHECK("shmem_int64_alltoall", in_64, out_64);
+#endif
     shmem_barrier_all();
 
     in_32 = me; out_32 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoalls32(&in_32, &out_32, 1, 1, 1, me, 0, 1, alltoalls_psync);
     CHECK("shmem_alltoalls32", in_32, out_32);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int32_alltoalls(new_team, &in_32, &out_32, 1, 1, 1);
+    CHECK("shmem_int32_alltoalls", in_32, out_32);
+#endif
     shmem_barrier_all();
 
     in_64 = me; out_64 = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_alltoalls64(&in_64, &out_64, 1, 1, 1, me, 0, 1, alltoalls_psync);
     CHECK("shmem_alltoalls64", in_64, out_64);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int64_alltoalls(new_team, &in_64, &out_64, 1, 1, 1);
+    CHECK("shmem_int64_alltoalls", in_64, out_64);
+#endif
     shmem_barrier_all();
 
     if (me == 0) printf("Done\n");

--- a/test/unit/sync-size.c
+++ b/test/unit/sync-size.c
@@ -42,7 +42,7 @@ long src[N];
 long dst[N];
 
 int main(int argc, char* argv[]) {
-    int i, j, me, npes, long_is_32;
+    int i, j, me, npes;
     int errors = 0;
 
     for (i = 0; i < SHMEM_SYNC_SIZE; i++) {
@@ -54,15 +54,6 @@ int main(int argc, char* argv[]) {
 
     me = shmem_my_pe();
     npes = shmem_n_pes();
-
-    if (sizeof(long) == 4) {
-        long_is_32 = 1;
-    } else if (sizeof(long) == 8) {
-        long_is_32 = 0;
-    } else {
-        printf("Error: sizeof(long) == %zu, must be either 4 or 8\n", sizeof(long));
-        shmem_global_exit(1);
-    }
 
     for (i = 0; i < N; i += 1) {
         src[i] = me;
@@ -76,10 +67,7 @@ int main(int argc, char* argv[]) {
 
     /* Broadcast */
 
-    if (long_is_32)
-        shmem_broadcast32(dst, src, N, 0, 0, 0, npes, pSync);
-    else
-        shmem_broadcast64(dst, src, N, 0, 0, 0, npes, pSync);
+    shmem_long_broadcast(SHMEM_TEAM_WORLD, dst, src, N, 0);
 
     for (i = 0; i < N && me > 0; i++) {
         if (dst[i] != 0) {
@@ -94,10 +82,7 @@ int main(int argc, char* argv[]) {
 
     long *dst_all = shmem_malloc(npes * N * sizeof(long));
 
-    if (long_is_32)
-        shmem_fcollect32(dst_all, src, N, 0, 0, npes, pSync);
-    else
-        shmem_fcollect64(dst_all, src, N, 0, 0, npes, pSync);
+    shmem_long_fcollect(SHMEM_TEAM_WORLD, dst_all, src, N);
 
     for (i = 0; i < npes; i++) {
         for (j = 0; j < N; j++) {


### PR DESCRIPTION
Includes deprecation attributes for these routines:
* shmem_collect32, shmem_collect64, shmem_fcollect32, shmem_fcollect64
* shmem_alltoall32, shmem_alltoall64, shmem_alltoalls32, shmem_alltoalls64
* shmem_broadcast32, shmem_broadcast64

Addresses issue #998 