### PR TITLE
Disable all external Travis CI tests for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
         - SOS_PM=mpiexec.hydra
         - SOS_PM_PRE=true
         - SOS_PM_POST=true
+        ## Disable all external tests until SOS has recurring Travis credits for OSS
+        - SOS_DISABLE_EXTERNAL_TESTS=1
         ## An encrypted value for INTEL_SERIAL_NUMBER:
         - secure: "luxfwDy26Pva+A58T/vPP7+Zek4rBEbpB2TpdXuLdIu/MJ2laoUkaZj/ouT6YgdSxUoiyLUlGIzLnByxnrVgWqYELsWHiV9hzsXZCNfgQDdUHV8UITCqSYVcd5WGNoVdC0QohKuIj47y6bP5ttcv1sIfpV74ztPJZE1dbb2QzgvWcIKWN8Abj55364ZnIidW7ErYLrAiKlBzSxZXCKiKD6qOUbpOBN8yuzaX9diXYJViest7iBC+BfwzXO8Shuouh6QrQhJ1T4oG6u6YJn17fnOwXKJCdkeQYr/E8ka4JRf8vZm7CNO1YdwNhtGtFNEzTJaP2XFLAQGCB9vffCxcqRbpWv+lpsFRsH+eiF/zp/xKGr5qzB9sPUxNANJyhphXK0VfIqDan7nz9di99NFBEF94Jl33E+KODTCAeHb6+a7yboR5B4BalM4jXKrcn/2A4pYrk45YF5IdLLOEvzTaOyVSgHoNIzXRZvHEL2AeYuvz5qLukzMB+QClbA1EeCBNyokuXK/TemeTvveXpQpCaVKNQ8zp/v30u8eiaV8R/dFa2evlJ6kwSaeXlXpXifeXd5Px0x6HF4FT9HLOtPVQ3rZXyfL2Eh92egu15GiTqMNkdVlVGUC20+iddLjtbPqRnVw0WnZkekh62A6rGuT4cTfAbZ2GVPD+IMqzokO1IGg="
     matrix:
@@ -28,50 +30,30 @@ env:
         - >
           SOS_TRANSPORT_OPTS=""
           SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple"
-        - >
-          SOS_TRANSPORT_OPTS=""
-          SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple --enable-profiling"
         ## Portals Builds
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
-          SOS_BUILD_OPTS="--disable-cxx --enable-memcpy --enable-pmi-simple"
-        - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
-          SOS_BUILD_OPTS="--enable-pmi-mpi CC=mpicc"
-        - >
-          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_DISABLE_FORTRAN=1
+          SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-fortran --enable-error-checking --enable-remote-virtual-addressing --disable-aslr-check --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_ENABLE_ERROR_TESTS=1 SHMEM_SYMMETRIC_HEAP_USE_MALLOC=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--disable-threads --enable-error-checking --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
-          SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
-          SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-error-checking --enable-pmi-simple"
-        - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
+          SOS_ENABLE_ERROR_TESTS=1
           SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1 SHMEM_BOUNCE_SIZE=0
           SOS_TRANSPORT_OPTS="--with-portals4=$TRAVIS_INSTALL/portals4/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-ofi-fence"
@@ -81,7 +63,9 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
+          SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
+          SOS_BUILD_OPTS="--enable-pmi-simple CFLAGS=-DENABLE_DEPRECATED_TESTS"
+        - >
           SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
@@ -126,13 +110,13 @@ env:
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
+          SOS_ENABLE_ERROR_TESTS=1
           SHMEM_BARRIER_ALGORITHM=tree SHMEM_BCAST_ALGORITHM=tree SHMEM_REDUCE_ALGORITHM=tree
           SHMEM_OFI_STX_MAX=0
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
           SOS_BUILD_OPTS="--enable-error-checking --enable-remote-virtual-addressing --enable-pmi-simple --enable-manual-progress"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1 SOS_ENABLE_ERROR_TESTS=1
+          SOS_ENABLE_ERROR_TESTS=1
           SHMEM_BARRIER_ALGORITHM=dissem SHMEM_REDUCE_ALGORITHM=recdbl SHMEM_FCOLLECT_ALGORITHM=recdbl
           SHMEM_OFI_STX_AUTO=1
           SOS_TRANSPORT_OPTS="--with-ofi=$TRAVIS_INSTALL/libfabric/"
@@ -161,26 +145,21 @@ env:
 
         ## UCX Builds
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_PM="prun" SOS_PM_PRE="prte --daemonize --host localhost:4" SOS_PM_POST="pterm"
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-pmix=$TRAVIS_INSTALL/pmix"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--enable-pmi-mpi CC=mpicc"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_DISABLE_FORTRAN=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-cma --enable-error-checking --enable-profiling --enable-pmi-simple"
         - >
-          SOS_DISABLE_EXTERNAL_TESTS=1
           SOS_TRANSPORT_OPTS="--with-ucx=$TRAVIS_INSTALL/ucx/"
           SOS_BUILD_OPTS="--with-xpmem=$TRAVIS_INSTALL/xpmem --enable-error-checking --enable-pmi-simple"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -259,22 +259,21 @@ before_install:
         sudo insmod $TRAVIS_INSTALL/xpmem/lib/modules/`uname -r`/kernel/xpmem/xpmem.ko
         sudo chown `whoami` /dev/xpmem
       fi
-    ## Fetch UH Tests
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/openshmem-org/tests-uh.git tests-uh
-    # Fetch Cray Tests
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/openshmem-org/tests-cray.git tests-cray
-    # Fetch Mellanox Tests
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/openshmem-org/tests-mellanox.git tests-mellanox
-    ## Fetch ISx
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/ParRes/ISx.git ISx
-    ## Fetch PRK
-    - cd $TRAVIS_SRC
-    - git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
-    - echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
+    - >
+      if [ -z "$SOS_DISABLE_EXTERNAL_TESTS" ]; then
+        cd $TRAVIS_SRC
+        ## Fetch UH Tests
+        git clone --depth 10 https://github.com/openshmem-org/tests-uh.git tests-uh
+        # Fetch Cray Tests
+        git clone --depth 10 https://github.com/openshmem-org/tests-cray.git tests-cray
+        # Fetch Mellanox Tests
+        git clone --depth 10 https://github.com/openshmem-org/tests-mellanox.git tests-mellanox
+        ## Fetch ISx
+        git clone --depth 10 https://github.com/ParRes/ISx.git ISx
+        ## Fetch PRK
+        git clone --depth 10 https://github.com/ParRes/Kernels.git PRK
+        echo -e "SHMEMCC=oshcc -std=c99\nSHMEMTOP=$$TRAVIS_INSTALL\n" > PRK/common/make.defs
+      fi
     ## Build Libevent
     - cd $TRAVIS_SRC
     - wget https://github.com/libevent/libevent/releases/download/release-2.1.10-stable/libevent-2.1.10-stable.tar.gz


### PR DESCRIPTION
* Remove some Portals4 testing rows
* Add a row to enable deprecated API tests

For those unaware, Travis CI has changed it's billing policies so we can no longer rely on it for a wide variety of long-running tests.  I applied for SOS to receive free Open-Source-Software (OSS) credits, but currently we only have ~25k credits (core-minutes).  That's _total_ credits... like forever.  That would give us only ~2 full SOS builds.  I asked if we can get recurring plan, but responses from Travis support are very slow.

For now I propose we slim down Travis as much as we can by disabling all external tests and removing some portals4 rows.  Hopefully this buys us a little time to figure out a more thorough CI strategy (likely using a Jenkins backend).