### PR TITLE
Added "Deprecated" Attribute to Necessary Reduction and Barrier Routines 

### DIFF
--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -403,7 +403,7 @@ define(`SHMEM_C_CTX_FETCH_OR',
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_OR')
 
 /* COLL: Barrier Synchronization Routines */
-SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_barrier_all(void);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_sync_all(void);
@@ -414,7 +414,7 @@ define(`SHMEM_C_TO_ALL',
 SH_PAD(`$1',`$4')                    const $2 *source, int nreduce,
 SH_PAD(`$1',`$4')                    int PE_start, int logPE_stride,
 SH_PAD(`$1',`$4')                    int PE_size, $2 *pWrk,
-SH_PAD(`$1',`$4')                    long *pSync);')dnl
+SH_PAD(`$1',`$4')                    long *pSync) SHMEM_ATTRIBUTE_DEPRECATED;')dnl
 dnl
 SHMEM_BIND_C_COLL_INTS(`SHMEM_C_TO_ALL', `and')
 

--- a/test/unit/big_reduction.c
+++ b/test/unit/big_reduction.c
@@ -40,8 +40,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-long pSync[SHMEM_REDUCE_SYNC_SIZE];
-
 #define N 128
 
 long src[N];
@@ -49,8 +47,6 @@ long dst[N];
 
 #define MAX(a, b) ((a) > (b)) ? (a) : (b)
 #define WRK_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
-
-long pWrk[WRK_SIZE];
 
 int
 main(int argc, char* argv[])
@@ -74,10 +70,6 @@ main(int argc, char* argv[])
         }
     }
 
-    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i += 1) {
-        pSync[i] = SHMEM_SYNC_VALUE;
-    }
-
     shmem_init();
 
     for (i = 0; i < N; i += 1) {
@@ -85,7 +77,7 @@ main(int argc, char* argv[])
     }
     shmem_barrier_all();
 
-    shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
+    shmem_long_max_reduce(SHMEM_TEAM_WORLD, dst, src, N);
 
     if (Verbose) {
         printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );

--- a/test/unit/cxx_test_shmem_complex.cpp
+++ b/test/unit/cxx_test_shmem_complex.cpp
@@ -59,8 +59,8 @@ long syncArr[SHMEM_REDUCE_SYNC_SIZE];
                                                                      \
     memset(TYPE##_src,0,sizeof(TYPE##_src));                         \
                                                                      \
-    shmem_complex##LETTER##_##OP##_to_all(TYPE##_dest,TYPE##_src,10, \
-      0,0, shmem_n_pes(), TYPE##_workData, syncArr);                 \
+    shmem_complex##LETTER##_##OP##_reduce(SHMEM_TEAM_WORLD,          \
+		    TYPE##_dest,TYPE##_src,10);                      \
                                                                      \
     shmem_barrier_all();                                             \
                                                                      \

--- a/test/unit/max_reduction.c
+++ b/test/unit/max_reduction.c
@@ -38,8 +38,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-long pSync[SHMEM_REDUCE_SYNC_SIZE];
-
 #define N 3
 
 long src[N];
@@ -47,8 +45,6 @@ long dst[N];
 
 #define MAX(a, b) ((a) > (b)) ? (a) : (b)
 #define WRK_SIZE MAX(N/2+1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)
-
-long pWrk[WRK_SIZE];
 
 int
 main(int argc, char* argv[])
@@ -72,10 +68,6 @@ main(int argc, char* argv[])
         }
     }
 
-    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i += 1) {
-        pSync[i] = SHMEM_SYNC_VALUE;
-    }
-
     shmem_init();
 
     for (i = 0; i < N; i += 1) {
@@ -83,7 +75,7 @@ main(int argc, char* argv[])
     }
     shmem_barrier_all();
 
-    shmem_long_max_to_all(dst, src, N, 0, 0, shmem_n_pes(), pWrk, pSync);
+    shmem_long_max_reduce(SHMEM_TEAM_WORLD, dst, src, N);
 
     if (Verbose) {
         printf("%d/%d\tdst =", shmem_my_pe(), shmem_n_pes() );

--- a/test/unit/mt_membar.c
+++ b/test/unit/mt_membar.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv) {
     pthread_barrier_destroy(&fencebar);    
 
     shmem_barrier_all(); 
-    shmem_int_sum_to_all(&sum_error, &errors, 1, 0, 0, npes, pWrk, pSync);
+    shmem_int_sum_reduce(SHMEM_TEAM_WORLD, &sum_error, &errors, 1);
 
     shmem_finalize();
     return (sum_error == 0) ? 0 : 1;

--- a/test/unit/nop_collectives.c
+++ b/test/unit/nop_collectives.c
@@ -108,19 +108,47 @@ int main(void) {
     shmem_barrier_all();
 
     if (me == 0) printf(" + reduction\n");
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_and_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_and_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_or_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_or_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_xor_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_xor_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_min_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_min_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_max_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_max_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_sum_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_sum_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_prod_to_all(NULL, NULL, 0, 0, 0, npes, pwrk, reduce_psync);
+#else
+    shmem_int_prod_reduce(SHMEM_TEAM_WORLD, NULL, NULL, 0);
+#endif
     shmem_barrier_all();
 
     if (me == 0) printf(" + all-to-all\n");

--- a/test/unit/nop_collectives.c
+++ b/test/unit/nop_collectives.c
@@ -38,8 +38,10 @@ long alltoalls_psync[SHMEM_ALLTOALLS_SYNC_SIZE];
 int pwrk[SHMEM_REDUCE_MIN_WRKDATA_SIZE];
 
 int main(void) {
-    int i;
-    int me, npes;
+    int me;
+
+#ifdef ENABLE_DEPRECATED_TESTS
+    int i, npes;
 
     for (i = 0; i < SHMEM_BCAST_SYNC_SIZE; i++)
         bcast_psync[i] = SHMEM_SYNC_VALUE;
@@ -58,11 +60,15 @@ int main(void) {
 
     for (i = 0; i < SHMEM_REDUCE_MIN_WRKDATA_SIZE; i++)
         pwrk[i] = 0;
+#endif
 
     shmem_init();
 
     me = shmem_my_pe();
+
+#ifdef ENABLE_DEPRECATED_TESTS
     npes = shmem_n_pes();
+#endif
 
     if (me == 0) printf("Testing zero length collectives\n");
 

--- a/test/unit/pingpong-short.c
+++ b/test/unit/pingpong-short.c
@@ -61,11 +61,6 @@ static int atoi_scaled(char *s);
 int output_mod = OUTPUT_MOD;
 int Verbose;
 int Slow;
-long pSync0[SHMEM_BARRIER_SYNC_SIZE],
-    pSync1[SHMEM_BARRIER_SYNC_SIZE],
-    pSync2[SHMEM_BARRIER_SYNC_SIZE],
-    pSync3[SHMEM_BARRIER_SYNC_SIZE],
-    pSync4[SHMEM_BARRIER_SYNC_SIZE];
 
 #define DFLT_NWORDS 128
 #define DFLT_LOOPS 100
@@ -88,11 +83,6 @@ main(int argc, char* argv[])
     char *prog_name;
     DataType *wp;
     long work_sz;
-
-    for(j=0; j < SHMEM_BARRIER_SYNC_SIZE; j++) {
-        pSync0[j] = pSync1[j] = pSync2[j] = pSync3[j] =
-            pSync4[j] = SHMEM_SYNC_VALUE;
-    }
 
     shmem_init();
     my_pe = shmem_my_pe();
@@ -200,7 +190,7 @@ main(int argc, char* argv[])
         if ( Verbose && (j==0 || (j % output_mod) == 0) )
             fprintf(stderr,"[%d] +(%d)\n", shmem_my_pe(),j);
 #endif
-        shmem_barrier(0, 0, nProcs, pSync0);
+        shmem_barrier_all();
         if ( my_pe == 0 ) {
             int p;
             for(p=1; p < nProcs; p++)
@@ -220,7 +210,7 @@ main(int argc, char* argv[])
         if ( Verbose && (j==0 || (j % output_mod) == 0) )
             fprintf(stderr,"[%d] -(%d)\n", my_pe,j);
 #endif
-        shmem_barrier(0, 0, nProcs, pSync1);
+        shmem_barrier_all();
 
         RDprintf("Workers[1 ... %d] verify Target data put by my_pe 0\n",
                  nWorkers);
@@ -241,7 +231,7 @@ main(int argc, char* argv[])
         else /* clear results buffer, workers will put here */
             memset(work, 0, work_sz);
 
-        shmem_barrier(0, 0, nProcs, pSync2);
+        shmem_barrier_all();
 
         RDprintf("Workers[1 ... %d] put Target data to PE0 work "
                  "vector\n",nWorkers);
@@ -264,7 +254,7 @@ main(int argc, char* argv[])
             }
         }
 
-        shmem_barrier(0, 0, nProcs, pSync3);
+        shmem_barrier_all();
 
         if ( my_pe == 0 ) {
             RDprintf("Loop(%d) PE0 verifing work data.\n",j);
@@ -283,7 +273,7 @@ main(int argc, char* argv[])
                     break;
             }
         }
-        shmem_barrier(0, 0, nProcs, pSync4);
+        shmem_barrier_all();
 
         if (loops > 1) {
             RDfprintf(stderr,".");

--- a/test/unit/pingpong.c
+++ b/test/unit/pingpong.c
@@ -61,12 +61,6 @@ int output_mod = OUTPUT_MOD;
 int Verbose;
 int Slow;
 
-long pSync0[SHMEM_BARRIER_SYNC_SIZE],
-    pSync1[SHMEM_BARRIER_SYNC_SIZE],
-    pSync2[SHMEM_BARRIER_SYNC_SIZE],
-    pSync3[SHMEM_BARRIER_SYNC_SIZE],
-    pSync4[SHMEM_BARRIER_SYNC_SIZE];
-
 #define DFLT_NWORDS 128
 #define DFLT_LOOPS 10
 
@@ -85,11 +79,6 @@ main(int argc, char* argv[])
     int  failures=0;
     char *prog_name;
     long *wp,work_sz;
-
-    for(j=0; j < SHMEM_BARRIER_SYNC_SIZE; j++) {
-        pSync0[j] = pSync1[j] = pSync2[j] = pSync3[j] =
-            pSync4[j] = SHMEM_SYNC_VALUE;
-    }
 
     shmem_init();
     my_pe = shmem_my_pe();
@@ -198,7 +187,7 @@ main(int argc, char* argv[])
         if ( Verbose && (j==0 || (j % output_mod) == 0) )
             fprintf(stderr,"[%d] +(%d)\n", my_pe,j);
 #endif
-        shmem_barrier(0, 0, nProcs, pSync0);
+        shmem_barrier_all();
         if ( my_pe == 0 ) {
             int p;
             for(p=1; p < nProcs; p++)
@@ -218,7 +207,7 @@ main(int argc, char* argv[])
         if ( Verbose && (j==0 || (j % output_mod) == 0) )
             fprintf(stderr,"[%d] -(%d)\n", shmem_my_pe(),j);
 #endif
-        shmem_barrier(0, 0, nProcs, pSync1);
+        shmem_barrier_all();
 
         RDprintf("Workers[1 ... %d] verify Target data put by proc0\n",
                  nWorkers);
@@ -239,7 +228,7 @@ main(int argc, char* argv[])
         else /* clear results buffer, workers will put here */
             memset(work, 0, work_sz);
 
-        shmem_barrier(0, 0, nProcs, pSync2);
+        shmem_barrier_all();
 
         RDprintf("Workers[1 ... %d] put Target data to PE0 work "
                  "vector\n",nWorkers);
@@ -262,7 +251,7 @@ main(int argc, char* argv[])
             }
         }
 
-        shmem_barrier(0, 0, nProcs, pSync3);
+        shmem_barrier_all();
 
         if ( my_pe == 0 ) {
             RDprintf("Loop(%d) PE0 verifing work data.\n",j);
@@ -283,7 +272,7 @@ main(int argc, char* argv[])
                     break;
             }
         }
-        shmem_barrier(0, 0, nProcs, pSync4);
+        shmem_barrier_all();
 #if _DEBUG
         if (loops > 1) {
             Rfprintf(stderr,".");

--- a/test/unit/reduce_active_set.c
+++ b/test/unit/reduce_active_set.c
@@ -30,15 +30,45 @@
 
 #define NELEM 10
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long max_psync[SHMEM_REDUCE_SYNC_SIZE];
 long min_psync[SHMEM_REDUCE_SYNC_SIZE];
 
 long min_pwrk[NELEM/2 + SHMEM_REDUCE_MIN_WRKDATA_SIZE];
 long max_pwrk[NELEM/2 + SHMEM_REDUCE_MIN_WRKDATA_SIZE];
+#endif
 
 long src[NELEM];
 long dst_max[NELEM];
 long dst_min[NELEM];
+
+static int validate_max(int i, int me, int npes) {
+    int errors = 0;
+    /* Validate reduced max data */
+    for (int j = 0; j < NELEM; j++) {
+        long expected = npes-1;
+        if (dst_max[j] != expected) {
+	    printf("%d: Max expected dst_max[%d] = %ld, got dst_max[%d] = %ld, iteration %d\n",
+	           me, j, expected, j, dst_max[j], i);
+	    errors++;
+        }
+    }
+    return errors;
+}
+
+static int validate_min(int i, int me, int npes) {
+    int errors = 0;
+    /* Validate reduced min data */
+    for (int j = 0; j < NELEM; j++) {
+        long expected = i;
+        if (dst_min[j] != expected) {
+	    printf("%d: Min expected dst_min[%d] = %ld, got dst_min[%d] = %ld, iteration %d\n",
+	           me, j, expected, j, dst_min[j], i);
+	    errors++;
+        }
+    }
+    return errors;
+}
 
 int main(void)
 {
@@ -56,10 +86,12 @@ int main(void)
         dst_min[i] = -1;
     }
 
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++) {
         max_psync[i] = SHMEM_SYNC_VALUE;
         min_psync[i] = SHMEM_SYNC_VALUE;
     }
+#endif
 
     if (me == 0)
         printf("Shrinking active set test\n");
@@ -68,37 +100,37 @@ int main(void)
 
     /* A total of npes tests are performed, where the active set in each test
      * includes PEs i..npes-1 */
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i <= me; i++) {
-        int j;
 
         if (me == i)
             printf(" + PE_start=%d, logPE_stride=0, PE_size=%d\n", i, npes-i);
 
         shmem_long_max_to_all(dst_max, src, NELEM, i, 0, npes-i, max_pwrk, max_psync);
-
-        /* Validate reduced data */
-        for (j = 0; j < NELEM; j++) {
-            long expected = npes-1;
-            if (dst_max[j] != expected) {
-                printf("%d: Max expected dst_max[%d] = %ld, got dst_max[%d] = %ld, iteration %d\n",
-                       me, j, expected, j, dst_max[j], i);
-                errors++;
-            }
-        }
+	errors += validate_max(i, me, npes);
 
         shmem_long_min_to_all(dst_min, src, NELEM, i, 0, npes-i, min_pwrk, min_psync);
-
-        /* Validate reduced data */
-        for (j = 0; j < NELEM; j++) {
-            long expected = i;
-            if (dst_min[j] != expected) {
-                printf("%d: Min expected dst_min[%d] = %ld, got dst_min[%d] = %ld, iteration %d\n",
-                       me, j, expected, j, dst_min[j], i);
-                errors++;
-            }
-        }
+	errors += validate_min(i, me, npes);
 
     }
+#else
+    shmem_team_t new_team;
+    for (i = 0; i < npes; i++) {
+
+        if (me == i)
+            printf(" + PE_start=%d, PE_stride=1, PE_size=%d\n", i, npes-i);
+
+        shmem_team_split_strided(SHMEM_TEAM_WORLD, i, 1, npes-i, NULL, 0, &new_team);
+        if (new_team != SHMEM_TEAM_INVALID) {
+            shmem_long_max_reduce(new_team, dst_max, src, NELEM);
+	    errors += validate_max(i, me, npes);
+	    
+            shmem_long_min_reduce(new_team, dst_min, src, NELEM);
+	    errors += validate_min(i, me, npes);
+	}
+    }
+#endif
+
 
     shmem_finalize();
 

--- a/test/unit/reduce_in_place.c
+++ b/test/unit/reduce_in_place.c
@@ -30,10 +30,6 @@
 
 #define NELEM 10
 
-long psync[SHMEM_REDUCE_SYNC_SIZE];
-
-long pwrk[NELEM/2 + SHMEM_REDUCE_MIN_WRKDATA_SIZE];
-
 long src[NELEM];
 
 int main(void)
@@ -49,12 +45,9 @@ int main(void)
     for (int i = 0; i < NELEM; i++)
         src[i] = me;
 
-    for (int i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
-        psync[i] = SHMEM_SYNC_VALUE;
-
     shmem_barrier_all();
 
-    shmem_long_max_to_all(src, src, NELEM, 0, 0, npes, pwrk, psync);
+    shmem_long_max_reduce(SHMEM_TEAM_WORLD, src, src, NELEM);
 
     /* Validate reduced data */
     for (int j = 0; j < NELEM; j++) {

--- a/test/unit/repeated_barriers.c
+++ b/test/unit/repeated_barriers.c
@@ -30,8 +30,10 @@
 
 #define NREPS 50
 
+#ifdef ENABLE_DEPRECATED_TESTS
 long barrier_psync0[SHMEM_BARRIER_SYNC_SIZE];
 long barrier_psync1[SHMEM_BARRIER_SYNC_SIZE];
+#endif
 
 int main(void)
 {
@@ -42,15 +44,18 @@ int main(void)
     me = shmem_my_pe();
     npes = shmem_n_pes();
 
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++) {
         barrier_psync0[i] = SHMEM_SYNC_VALUE;
         barrier_psync1[i] = SHMEM_SYNC_VALUE;
     }
+#endif
 
     shmem_barrier_all();
 
     /* A total of npes tests are performed, where the active set in each test
      * includes PEs i..npes-1 */
+#ifdef ENABLE_DEPRECATED_TESTS
     for (i = 0; i <= me; i++) {
         int j;
 
@@ -61,6 +66,24 @@ int main(void)
         for (j = 0; j < NREPS; j++)
             shmem_barrier(i, 0, npes-i, (i % 2) ? barrier_psync0 : barrier_psync1);
     }
+#else
+    shmem_team_t new_team;
+    for (i = 0; i <= npes; i++) {
+        int j;
+
+        if (me == i)
+            printf(" + iteration %d\n", i);
+
+        /* Test that quiet + sync can be called repeatedly*/
+        shmem_team_split_strided(SHMEM_TEAM_WORLD, i, 1, npes-i, NULL, 0, &new_team);
+        if (new_team != SHMEM_TEAM_INVALID) {
+	    for (j = 0; j < NREPS; j++) {
+	        shmem_quiet();
+	        shmem_sync(new_team);
+            }
+	}
+    }
+#endif
 
     shmem_finalize();
 

--- a/test/unit/self_collectives.c
+++ b/test/unit/self_collectives.c
@@ -161,38 +161,80 @@ int main(void) {
     if (me == 0) printf(" + reduction\n");
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_and_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_and_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_and_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_and_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_or_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_or_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_or_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_or_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_xor_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_xor_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_xor_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_xor_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_min_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_min_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_min_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_min_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_max_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_max_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_max_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_max_to_all", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_sum_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_sum_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_sum_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_sum_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     in = me; out = -1;
+#ifdef ENABLE_DEPRECATED_TESTS
     shmem_int_prod_to_all(&in, &out, 1, me, 0, 1, pwrk, reduce_psync);
     CHECK("shmem_int_prod_to_all", in, out);
+#else
+    if (new_team != SHMEM_TEAM_INVALID)
+        shmem_int_prod_reduce(new_team, &in, &out, 1);
+    CHECK("shmem_int_prod_reduce", in, out);
+#endif
     shmem_barrier_all();
 
     /* All-to-all */

--- a/test/unit/shmem_malloc_with_hints.c
+++ b/test/unit/shmem_malloc_with_hints.c
@@ -37,10 +37,6 @@
 
 #define SHMEM_MALLOC_INVALID_HINT ~(SHMEM_MALLOC_ATOMICS_REMOTE)
 
-long pSync[SHMEM_REDUCE_SYNC_SIZE];
-int pWrk[WRK_SIZE];
-
-
 static int sumtoall_with_malloc_hint(long hint, int mype, int npes)
 {
     int failed = 0;
@@ -59,7 +55,7 @@ static int sumtoall_with_malloc_hint(long hint, int mype, int npes)
     }
 
     shmem_barrier_all();
-    shmem_int_sum_to_all(dst, src, N, 0, 0, npes, pWrk, pSync);
+    shmem_int_sum_reduce(SHMEM_TEAM_WORLD, dst, src, N);
 
     if (mype == 0) {
         for (i = 0; i < N; i++) {
@@ -77,7 +73,7 @@ static int sumtoall_with_malloc_hint(long hint, int mype, int npes)
 
 
 int main(int argc, char **argv) {
-    int npes, i, mype;
+    int npes, mype;
     int passed = 0;
     int fail = 0;
 
@@ -85,9 +81,6 @@ int main(int argc, char **argv) {
 
     npes = shmem_n_pes();
     mype = shmem_my_pe();
-
-    for (i = 0; i < SHMEM_REDUCE_SYNC_SIZE; i++)
-        pSync[i] = SHMEM_SYNC_VALUE;
 
     passed = sumtoall_with_malloc_hint(0, mype, npes);
     passed += sumtoall_with_malloc_hint(SHMEM_MALLOC_ATOMICS_REMOTE, mype, npes);

--- a/test/unit/sync-size.c
+++ b/test/unit/sync-size.c
@@ -25,8 +25,6 @@
  * SOFTWARE.
  */
 
-/* Test various collectives using the same pSync array of SHMEM_SYNC_SIZE */
-
 #include <shmem.h>
 #include <stdio.h>
 #include <string.h>
@@ -35,20 +33,12 @@
 #define N 3
 #define MAX(A,B) ((A) > (B)) ? (A) : (B)
 
-long pSync[SHMEM_SYNC_SIZE];
-long pWrk[MAX(N/2 + 1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)];
-
 long src[N];
 long dst[N];
 
 int main(int argc, char* argv[]) {
     int i, j, me, npes;
     int errors = 0;
-
-    for (i = 0; i < SHMEM_SYNC_SIZE; i++) {
-        pSync[i] = SHMEM_SYNC_VALUE;
-        pSync[i] = SHMEM_SYNC_VALUE;
-    }
 
     shmem_init();
 
@@ -62,7 +52,6 @@ int main(int argc, char* argv[]) {
 
     /* Barrier */
 
-    shmem_barrier(0, 0, npes, pSync);
     shmem_barrier_all();
 
     /* Broadcast */
@@ -98,7 +87,7 @@ int main(int argc, char* argv[]) {
 
     /* Reduction */
 
-    shmem_long_max_to_all(dst, src, N, 0, 0, npes, pWrk, pSync);
+    shmem_long_max_reduce(SHMEM_TEAM_WORLD, dst, src, N);
 
     for (i = 0; i < N; i++) {
         if (dst[i] != npes-1) {


### PR DESCRIPTION
Added Deprecated attribute to the active-set based reduction and barrier APIs. Also updated unit tests to either remove deprecated API calls or to wrap them in an ifdef: `ENABLE_DEPRECATED_TESTS`.