### PR TITLE
shmem_signal_wait_until

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
           mkdir build; cd build
           ../configure --prefix=${LIBFABRIC_INSTALL_DIR}
           make -j
-          sudo make install
+          make install
 
       # UCX
       - name: Cache UCX install
@@ -338,7 +338,7 @@ jobs:
           mkdir build; cd build
           ../configure --prefix=${UCX_INSTALL_DIR} --enable-mt --disable-numa --without-java
           make -j
-          sudo make install
+          make install
 
       ## Portals4
       - name: Cache Portals4 install
@@ -363,7 +363,7 @@ jobs:
           mkdir build; cd build
           ../configure --prefix=${PORTALS4_INSTALL_DIR} --enable-zero-mrs --enable-reliable-udp --disable-pmi-from-portals ${SOS_BUILD_STATIC_OPTS}
           make -j
-          sudo make install
+          make install
 
       # Libevent
       - name: Cache libevent install

--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -538,6 +538,8 @@ define(`SHMEM_C_TEST_SOME_VECTOR',
 `SHMEM_FUNCTION_ATTRIBUTES size_t SHPRE()shmem_$1_test_some_vector($2 *vars, size_t nelems, size_t *indices, const int *status, int cmp, $2 *values);')dnl
 SHMEM_BIND_C_SYNC(`SHMEM_C_TEST_SOME_VECTOR')
 
+SHMEM_FUNCTION_ATTRIBUTES uint64_t SHPRE()shmem_signal_wait_until(uint64_t *sig_addr, int cmp, uint64_t cmp_value);
+
 /* Memory Ordering Routines */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_quiet(void);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_fence(void);

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -86,7 +86,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
     } while(0)
 
 #define COMP_SIGNAL(type, a, b, ret) ({                  \
-    uint64_t satisfied_val;                              \
+    uint64_t satisfied_val = 0;                          \
     COMP(type, a, b, ret);                               \
     if (ret) satisfied_val = a;                          \
     satisfied_val;                                       \

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -85,12 +85,11 @@ shmem_internal_fence(shmem_ctx_t ctx)
         }                                                \
     } while(0)
 
-#define COMP_SIGNAL(type, a, b, ret) ({                  \
-    uint64_t satisfied_val = 0;                          \
-    COMP(type, a, b, ret);                               \
-    if (ret) satisfied_val = a;                          \
-    satisfied_val;                                       \
-})
+#define COMP_SIGNAL(type, a, b, ret, sat_value)          \
+    do {                                                 \
+        COMP(type, a, b, ret);                           \
+        if (ret) sat_value = a;                          \
+    } while(0)
 
 #ifdef USE_SHR_ATOMICS
 #define SYNC_LOAD(var) __atomic_load_n(var, __ATOMIC_ACQUIRE)
@@ -119,20 +118,17 @@ shmem_internal_fence(shmem_ctx_t ctx)
         }                                                \
     } while(0)
 
-#define SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value) ({               \
-    uint64_t retval;                                                    \
+#define SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value, sat_value)       \
     do {                                                                \
         int cmpret;                                                     \
                                                                         \
-        retval = COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret);      \
+        COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);    \
         while (!cmpret) {                                               \
             shmem_transport_probe();                                    \
             SPINLOCK_BODY();                                            \
-            retval = COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret);  \
+            COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);\
         }                                                               \
-    } while(0);                                                         \
-    retval;                                                             \
-})
+    } while(0)
 
 #define SHMEM_WAIT_BLOCK(var, value)                                    \
     do {                                                                \
@@ -162,33 +158,27 @@ shmem_internal_fence(shmem_ctx_t ctx)
         }                                                               \
     } while(0)
 
-#define SHMEM_SIGNAL_WAIT_UNTIL_BLOCK(var, cond, value) ({              \
-    uint64_t retval;                                                    \
+#define SHMEM_SIGNAL_WAIT_UNTIL_BLOCK(var, cond, value, sat_value)      \
     do {                                                                \
         uint64_t target_cntr;                                           \
         int cmpret;                                                     \
                                                                         \
-        retval = COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret);      \
+        COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);    \
         while (!cmpret) {                                               \
             target_cntr = shmem_transport_received_cntr_get();          \
             COMPILER_FENCE();                                           \
             COMP(cond, SYNC_LOAD(var), value, cmpret);                  \
             if (cmpret) break;                                          \
             shmem_transport_received_cntr_wait(target_cntr + 1);        \
-            retval = COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret);  \
+            COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);\
         }                                                               \
-    } while(0);                                                         \
-    retval;                                                             \
-})
+    } while(0)
 
 #if defined(ENABLE_HARD_POLLING)
 #define SHMEM_INTERNAL_WAIT_UNTIL(var, cond, value)                     \
     SHMEM_WAIT_UNTIL_POLL(var, cond, value)
-#define SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value) ({           \
-    uint64_t retval;                                                    \
-    retval = SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value);            \
-    retval;                                                             \
-})
+#define SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value, sat_value)   \
+    SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value, sat_value)
 #else
 #define SHMEM_INTERNAL_WAIT_UNTIL(var, cond, value)                     \
     if (shmem_internal_thread_level == SHMEM_THREAD_SINGLE) {           \
@@ -196,15 +186,12 @@ shmem_internal_fence(shmem_ctx_t ctx)
     } else {                                                            \
         SHMEM_WAIT_UNTIL_POLL(var, cond, value);                        \
     }
-#define SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value) ({           \
-    uint64_t retval;                                                    \
+#define SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value, sat_value)   \
     if (shmem_internal_thread_level == SHMEM_THREAD_SINGLE) {           \
-        retval = SHMEM_SIGNAL_WAIT_UNTIL_BLOCK(var, cond, value);       \
+        SHMEM_SIGNAL_WAIT_UNTIL_BLOCK(var, cond, value, sat_value);     \
     } else {                                                            \
-        retval = SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value);        \
-    }                                                                   \
-    retval;                                                             \
-})
+        SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value, sat_value);      \
+    }
 #endif
 
 #define SHMEM_WAIT(var, value) do {                                     \
@@ -219,14 +206,11 @@ shmem_internal_fence(shmem_ctx_t ctx)
         shmem_transport_syncmem();                                      \
     } while (0)
 
-#define SHMEM_SIGNAL_WAIT_UNTIL(var, cond, value) ({                    \
-    uint64_t retval;                                                    \
+#define SHMEM_SIGNAL_WAIT_UNTIL(var, cond, value, sat_value)            \
     do {                                                                \
-        retval = SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value);    \
+        SHMEM_INTERNAL_SIGNAL_WAIT_UNTIL(var, cond, value, sat_value);  \
         shmem_internal_membar_acq_rel();                                \
         shmem_transport_syncmem();                                      \
-    } while (0);                                                        \
-    retval;                                                             \
-})
+    } while (0)
 
 #endif

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -167,7 +167,7 @@ shmem_internal_fence(shmem_ctx_t ctx)
         while (!cmpret) {                                               \
             target_cntr = shmem_transport_received_cntr_get();          \
             COMPILER_FENCE();                                           \
-            COMP(cond, SYNC_LOAD(var), value, cmpret);                  \
+            COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);\
             if (cmpret) break;                                          \
             shmem_transport_received_cntr_wait(target_cntr + 1);        \
             COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);\

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -729,9 +729,11 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME_VECTOR')
 uint64_t SHMEM_FUNCTION_ATTRIBUTES
 shmem_signal_wait_until(uint64_t *sig_addr, int cmp, uint64_t cmp_value)
 {
+    uint64_t satisfied_value = 0;
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
     SHMEM_ERR_CHECK_CMP_OP(cmp);
 
-    return SHMEM_SIGNAL_WAIT_UNTIL(sig_addr, cmp, cmp_value);
+    SHMEM_SIGNAL_WAIT_UNTIL(sig_addr, cmp, cmp_value, satisfied_value);
+    return satisfied_value;
 }

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -47,6 +47,9 @@ include(shmem_bind_c.m4)dnl
 #define shmem_wait pshmem_wait
 #pragma weak shmem_wait_until = pshmem_wait_until
 #define shmem_wait_until pshmem_wait_until
+#pragma weak shmem_signal_wait_until = pshmem_signal_wait_until
+#define shmem_signal_wait_until pshmem_signal_wait_until
+
 
 define(`SHMEM_PROF_DEF_WAIT',
 `#pragma weak shmem_$1_wait = pshmem_$1_wait
@@ -722,3 +725,13 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
     }
 
 SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME_VECTOR')
+
+uint64_t SHMEM_FUNCTION_ATTRIBUTES
+shmem_signal_wait_until(uint64_t *sig_addr, int cmp, uint64_t cmp_value)
+{
+    SHMEM_ERR_CHECK_INITIALIZED();
+    SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
+    SHMEM_ERR_CHECK_CMP_OP(cmp);
+
+    return SHMEM_SIGNAL_WAIT_UNTIL(sig_addr, cmp, cmp_value);
+}

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -109,6 +109,7 @@ check_PROGRAMS = \
 	put_signal \
 	put_signal_nbi \
 	signal_fetch \
+	signal_wait_until \
 	shmem_team_b2b_collectives \
 	shmem_team_collect_active_set \
 	shmem_team_max \

--- a/test/unit/signal_wait_until.c
+++ b/test/unit/signal_wait_until.c
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2021 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/* 
+ * Validate signal_wait_until operation using blocking put_signal
+*/
+
+#include <stdio.h>
+#include <shmem.h>
+#include <string.h>
+
+#define MSG_SZ 10
+
+int main(int argc, char *argv[])
+{
+    long source[MSG_SZ];
+    long *target;
+    int me, npes, i;
+    int errors = 0;
+
+    static uint64_t sig_addr = 0;
+
+    shmem_init();
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (i = 0; i < MSG_SZ; i++)
+        source[i] = i;
+
+    target = (long *) shmem_calloc(MSG_SZ, sizeof(long));
+    if (!target) {
+        fprintf(stderr, "Failed to allocate target pointer\n");
+        shmem_global_exit(1);
+    }
+
+    shmem_barrier_all();
+    for (i = 0; i < npes; i++) {
+        shmem_long_put_signal(target, source, MSG_SZ, &sig_addr, 1, SHMEM_SIGNAL_ADD, i);
+    }
+
+    shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, npes);
+
+    if (sig_addr != npes)
+        errors++;
+
+    for (i = 0; i < MSG_SZ; i++) {
+        if (target[i] != source[i]) {
+            fprintf(stderr, "%10d: target[%d] = %ld not matching %ld with SHMEM_SIGNAL_ADD\n",
+                    me, i, target[i], source[i]);
+            errors++;
+        }
+    }
+
+    for (i = 0; i < MSG_SZ; i++)
+        target[i] = 0;
+
+    shmem_barrier_all();
+
+    for (i = 0; i < npes; i++) {
+        shmem_long_put_signal(target, source, MSG_SZ, &sig_addr, 1, SHMEM_SIGNAL_SET, i);
+    }
+
+    shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, 1);
+
+    if (sig_addr != 1)
+        errors++;
+
+    for (i = 0; i < MSG_SZ; i++) {
+        if (target[i] != source[i]) {
+            fprintf(stderr, "%10d: target[%d] = %ld not matching %ld with SHMEM_SIGNAL_SET\n",
+                    me, i, target[i], source[i]);
+            errors++;
+        }
+    }
+
+    shmem_free(target);
+    shmem_finalize();
+
+    return errors;
+} 


### PR DESCRIPTION
This implements `shmem_signal_wait_until` and adds a simple unit test.

`shmem_signal_wait_until` differs from the other `wait_until` operations in that it returns the contents of the signal data object that satisfied the wait condition.  I plumbed that through `shmem_synchronization.h` without affecting the other `wait_until` routines, but there may be a cleaner way to do it.

I also included a fix to the GitHub workflow where "sudo make install" was done in user-space and resulted in some funny permission issues on my fork's CI.  @kholland-intel - there is a chance this could be related to the problem on #1027.  It might be worth trying a cherry-pick of https://github.com/Sandia-OpenSHMEM/SOS/commit/12d3e4b2fe8e668879177827d92ebfe68d955127.