### PR TITLE
Remove check for SHMEMX_TESTS for C++ NBI atomics

### DIFF
--- a/test/shmemx/cxx_test_shmem_atomic_add.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_add.cpp
@@ -36,10 +36,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { ADD = 0, ATOMIC_ADD, CTX_ATOMIC_ADD, FADD, ATOMIC_FETCH_ADD,
           CTX_ATOMIC_FETCH_ADD, ATOMIC_FETCH_ADD_NBI, CTX_ATOMIC_FETCH_ADD_NBI };
 
@@ -51,7 +47,6 @@ enum op { ADD = 0, ATOMIC_ADD, CTX_ATOMIC_ADD, FADD, ATOMIC_FETCH_ADD,
 #define DEPRECATED_FADD shmem_atomic_fetch_add
 #endif
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case ATOMIC_FETCH_ADD_NBI:                                      \
           shmem_atomic_fetch_add_nbi(&old, &remote, (TYPE)(mype + 1), i); \
@@ -72,9 +67,6 @@ enum op { ADD = 0, ATOMIC_ADD, CTX_ATOMIC_ADD, FADD, ATOMIC_FETCH_ADD,
             rc = EXIT_FAILURE;                                          \
           }                                                             \
           break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_ADD(OP, TYPE)                                        \
   do {                                                                  \
@@ -218,7 +210,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_ADD(CTX_ATOMIC_FETCH_ADD, size_t);
   TEST_SHMEM_ADD(CTX_ATOMIC_FETCH_ADD, ptrdiff_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_ADD(ATOMIC_FETCH_ADD_NBI, int);
   TEST_SHMEM_ADD(ATOMIC_FETCH_ADD_NBI, long);
   TEST_SHMEM_ADD(ATOMIC_FETCH_ADD_NBI, long long);
@@ -244,7 +235,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_ADD(CTX_ATOMIC_FETCH_ADD_NBI, uint64_t);
   TEST_SHMEM_ADD(CTX_ATOMIC_FETCH_ADD_NBI, size_t);
   TEST_SHMEM_ADD(CTX_ATOMIC_FETCH_ADD_NBI, ptrdiff_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_and.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_and.cpp
@@ -37,10 +37,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { AND = 0, CTX_AND, FETCH_AND, CTX_FETCH_AND, FETCH_AND_NBI,
           CTX_FETCH_AND_NBI };
 
@@ -49,7 +45,6 @@ enum op { AND = 0, CTX_AND, FETCH_AND, CTX_FETCH_AND, FETCH_AND_NBI,
  * The result has the NPES least significant bits cleared, 111...000...b.
  */
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case FETCH_AND_NBI:                                             \
           shmem_atomic_fetch_and_nbi(&old, &remote,                     \
@@ -71,9 +66,6 @@ enum op { AND = 0, CTX_AND, FETCH_AND, CTX_FETCH_AND, FETCH_AND_NBI,
             rc = EXIT_FAILURE;                                          \
           }                                                             \
           break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_AND(OP, TYPE)                                        \
   do {                                                                  \
@@ -156,7 +148,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_AND(CTX_FETCH_AND, uint32_t);
   TEST_SHMEM_AND(CTX_FETCH_AND, uint64_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_AND(FETCH_AND_NBI, unsigned int);
   TEST_SHMEM_AND(FETCH_AND_NBI, unsigned long);
   TEST_SHMEM_AND(FETCH_AND_NBI, unsigned long long);
@@ -172,7 +163,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_AND(CTX_FETCH_AND_NBI, int64_t);
   TEST_SHMEM_AND(CTX_FETCH_AND_NBI, uint32_t);
   TEST_SHMEM_AND(CTX_FETCH_AND_NBI, uint64_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_cswap.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_cswap.cpp
@@ -36,10 +36,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { CSWAP = 0, ATOMIC_COMPARE_SWAP, CTX_ATOMIC_COMPARE_SWAP,
           ATOMIC_COMPARE_SWAP_NBI, CTX_ATOMIC_COMPARE_SWAP_NBI };
 
@@ -49,7 +45,6 @@ enum op { CSWAP = 0, ATOMIC_COMPARE_SWAP, CTX_ATOMIC_COMPARE_SWAP,
 #define DEPRECATED_CSWAP shmem_atomic_compare_swap
 #endif
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case ATOMIC_COMPARE_SWAP_NBI:                                   \
             shmem_atomic_compare_swap_nbi(&old, &remote, (TYPE)npes,    \
@@ -60,9 +55,6 @@ enum op { CSWAP = 0, ATOMIC_COMPARE_SWAP, CTX_ATOMIC_COMPARE_SWAP,
                                            (TYPE)npes, (TYPE)mype,      \
                                            (mype + 1) % npes);          \
             break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_CSWAP(OP, TYPE)                                      \
   do {                                                                  \
@@ -151,7 +143,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_CSWAP(CTX_ATOMIC_COMPARE_SWAP, size_t);
   TEST_SHMEM_CSWAP(CTX_ATOMIC_COMPARE_SWAP, ptrdiff_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_CSWAP(ATOMIC_COMPARE_SWAP_NBI, int);
   TEST_SHMEM_CSWAP(ATOMIC_COMPARE_SWAP_NBI, long);
   TEST_SHMEM_CSWAP(ATOMIC_COMPARE_SWAP_NBI, long long);
@@ -177,7 +168,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_CSWAP(CTX_ATOMIC_COMPARE_SWAP_NBI, uint64_t);
   TEST_SHMEM_CSWAP(CTX_ATOMIC_COMPARE_SWAP_NBI, size_t);
   TEST_SHMEM_CSWAP(CTX_ATOMIC_COMPARE_SWAP_NBI, ptrdiff_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_fetch.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_fetch.cpp
@@ -36,10 +36,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { FETCH = 0, ATOMIC_FETCH, CTX_ATOMIC_FETCH, ATOMIC_FETCH_NBI,
           CTX_ATOMIC_FETCH_NBI };
 
@@ -49,7 +45,6 @@ enum op { FETCH = 0, ATOMIC_FETCH, CTX_ATOMIC_FETCH, ATOMIC_FETCH_NBI,
 #define DEPRECATED_FETCH shmem_atomic_fetch
 #endif
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                           \
       case ATOMIC_FETCH_NBI:                                    \
         shmem_atomic_fetch_nbi(&val, &remote,                   \
@@ -61,9 +56,6 @@ enum op { FETCH = 0, ATOMIC_FETCH, CTX_ATOMIC_FETCH, ATOMIC_FETCH_NBI,
                                 &remote, (mype + 1) % npes);    \
         shmem_quiet();                                          \
         break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_FETCH(OP, TYPE)                              \
   do {                                                          \
@@ -148,7 +140,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_FETCH(CTX_ATOMIC_FETCH, size_t);
   TEST_SHMEM_FETCH(CTX_ATOMIC_FETCH, ptrdiff_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_FETCH(ATOMIC_FETCH_NBI, float);
   TEST_SHMEM_FETCH(ATOMIC_FETCH_NBI, double);
   TEST_SHMEM_FETCH(ATOMIC_FETCH_NBI, int);
@@ -178,7 +169,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_FETCH(CTX_ATOMIC_FETCH_NBI, uint64_t);
   TEST_SHMEM_FETCH(CTX_ATOMIC_FETCH_NBI, size_t);
   TEST_SHMEM_FETCH(CTX_ATOMIC_FETCH_NBI, ptrdiff_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_inc.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_inc.cpp
@@ -36,10 +36,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { INC = 0, ATOMIC_INC, CTX_ATOMIC_INC, FINC, ATOMIC_FETCH_INC,
           CTX_ATOMIC_FETCH_INC, ATOMIC_FETCH_INC_NBI,
           CTX_ATOMIC_FETCH_INC_NBI };
@@ -52,7 +48,6 @@ enum op { INC = 0, ATOMIC_INC, CTX_ATOMIC_INC, FINC, ATOMIC_FETCH_INC,
 #define DEPRECATED_FINC shmem_atomic_fetch_inc
 #endif
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case ATOMIC_FETCH_INC_NBI:                                      \
           shmem_atomic_fetch_inc_nbi(&old, &remote, i);                 \
@@ -72,9 +67,6 @@ enum op { INC = 0, ATOMIC_INC, CTX_ATOMIC_INC, FINC, ATOMIC_FETCH_INC,
             rc = EXIT_FAILURE;                                          \
           }                                                             \
           break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_INC(OP, TYPE)                                        \
   do {                                                                  \
@@ -218,7 +210,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_INC(CTX_ATOMIC_FETCH_INC, size_t);
   TEST_SHMEM_INC(CTX_ATOMIC_FETCH_INC, ptrdiff_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_INC(ATOMIC_FETCH_INC_NBI, int);
   TEST_SHMEM_INC(ATOMIC_FETCH_INC_NBI, long);
   TEST_SHMEM_INC(ATOMIC_FETCH_INC_NBI, long long);
@@ -244,7 +235,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_INC(CTX_ATOMIC_FETCH_INC_NBI, uint64_t);
   TEST_SHMEM_INC(CTX_ATOMIC_FETCH_INC_NBI, size_t);
   TEST_SHMEM_INC(CTX_ATOMIC_FETCH_INC_NBI, ptrdiff_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_or.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_or.cpp
@@ -37,10 +37,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { OR = 0, CTX_OR, FETCH_OR, CTX_FETCH_OR, FETCH_OR_NBI,
           CTX_FETCH_OR_NBI };
 
@@ -49,7 +45,6 @@ enum op { OR = 0, CTX_OR, FETCH_OR, CTX_FETCH_OR, FETCH_OR_NBI,
  * The result has the NPES least significant bits set, 000...111...b.
  */
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case FETCH_OR_NBI:                                              \
           shmem_atomic_fetch_or_nbi(&old, &remote,                      \
@@ -71,9 +66,6 @@ enum op { OR = 0, CTX_OR, FETCH_OR, CTX_FETCH_OR, FETCH_OR_NBI,
             rc = EXIT_FAILURE;                                          \
           }                                                             \
           break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_OR(OP, TYPE)                                         \
   do {                                                                  \
@@ -158,7 +150,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_OR(CTX_FETCH_OR, uint32_t);
   TEST_SHMEM_OR(CTX_FETCH_OR, uint64_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_OR(FETCH_OR_NBI, unsigned int);
   TEST_SHMEM_OR(FETCH_OR_NBI, unsigned long);
   TEST_SHMEM_OR(FETCH_OR_NBI, unsigned long long);
@@ -174,7 +165,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_OR(CTX_FETCH_OR_NBI, int64_t);
   TEST_SHMEM_OR(CTX_FETCH_OR_NBI, uint32_t);
   TEST_SHMEM_OR(CTX_FETCH_OR_NBI, uint64_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_swap.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_swap.cpp
@@ -36,10 +36,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { SWAP = 0, ATOMIC_SWAP, CTX_ATOMIC_SWAP, ATOMIC_SWAP_NBI,
           CTX_ATOMIC_SWAP_NBI };
 
@@ -49,7 +45,6 @@ enum op { SWAP = 0, ATOMIC_SWAP, CTX_ATOMIC_SWAP, ATOMIC_SWAP_NBI,
 #define DEPRECATED_SWAP shmem_atomic_swap
 #endif
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case ATOMIC_SWAP_NBI:                                           \
             shmem_atomic_swap_nbi(&old, &remote,                        \
@@ -59,9 +54,6 @@ enum op { SWAP = 0, ATOMIC_SWAP, CTX_ATOMIC_SWAP, ATOMIC_SWAP_NBI,
             shmem_atomic_swap_nbi(SHMEM_CTX_DEFAULT, &old, &remote,     \
                                    (TYPE)mype, (mype + 1) % npes);      \
             break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_SWAP(OP, TYPE)                                       \
   do {                                                                  \
@@ -153,7 +145,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_SWAP(CTX_ATOMIC_SWAP, size_t);
   TEST_SHMEM_SWAP(CTX_ATOMIC_SWAP, ptrdiff_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_SWAP(ATOMIC_SWAP_NBI, float);
   TEST_SHMEM_SWAP(ATOMIC_SWAP_NBI, double);
   TEST_SHMEM_SWAP(ATOMIC_SWAP_NBI, int);
@@ -183,7 +174,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_SWAP(CTX_ATOMIC_SWAP_NBI, uint64_t);
   TEST_SHMEM_SWAP(CTX_ATOMIC_SWAP_NBI, size_t);
   TEST_SHMEM_SWAP(CTX_ATOMIC_SWAP_NBI, ptrdiff_t);
-#endif
 
   shmem_finalize();
   return rc;

--- a/test/shmemx/cxx_test_shmem_atomic_xor.cpp
+++ b/test/shmemx/cxx_test_shmem_atomic_xor.cpp
@@ -37,10 +37,6 @@
 #include <stdio.h>
 #include <shmem.h>
 
-#ifdef ENABLE_SHMEMX_TESTS
-#include <shmemx.h>
-#endif
-
 enum op { XOR = 0, CTX_XOR, FETCH_XOR, CTX_FETCH_XOR, FETCH_XOR_NBI,
           CTX_FETCH_XOR_NBI };
 
@@ -49,7 +45,6 @@ enum op { XOR = 0, CTX_XOR, FETCH_XOR, CTX_FETCH_XOR, FETCH_XOR_NBI,
  * The result has the NPES least significant bits cleared, 111...000...b.
  */
 
-#ifdef ENABLE_SHMEMX_TESTS
 #define SHMEM_NBI_OPS_CASES(OP, TYPE)                                   \
         case FETCH_XOR_NBI:                                             \
           shmem_atomic_fetch_xor_nbi(&old, &remote,                     \
@@ -71,9 +66,6 @@ enum op { XOR = 0, CTX_XOR, FETCH_XOR, CTX_FETCH_XOR, FETCH_XOR_NBI,
             rc = EXIT_FAILURE;                                          \
           }                                                             \
           break;
-#else
-#define SHMEM_NBI_OPS_CASES(OP, TYPE)
-#endif
 
 #define TEST_SHMEM_XOR(OP, TYPE)                                        \
   do {                                                                  \
@@ -156,7 +148,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_XOR(CTX_FETCH_XOR, uint32_t);
   TEST_SHMEM_XOR(CTX_FETCH_XOR, uint64_t);
 
-#ifdef ENABLE_SHMEMX_TESTS
   TEST_SHMEM_XOR(FETCH_XOR_NBI, unsigned int);
   TEST_SHMEM_XOR(FETCH_XOR_NBI, unsigned long);
   TEST_SHMEM_XOR(FETCH_XOR_NBI, unsigned long long);
@@ -172,7 +163,6 @@ int main(int argc, char* argv[]) {
   TEST_SHMEM_XOR(CTX_FETCH_XOR_NBI, int64_t);
   TEST_SHMEM_XOR(CTX_FETCH_XOR_NBI, uint32_t);
   TEST_SHMEM_XOR(CTX_FETCH_XOR_NBI, uint64_t);
-#endif
 
   shmem_finalize();
   return rc;


### PR DESCRIPTION
Addresses issue #800.

To summarize, we renamed the NBI atomics (ratified in OpenSHMEM v1.5) from `shmemx_` to `shmem` for the v1.5.0 release, but we decided to keep the tests exercising the C++ polymorphic bindings in `test/shmemx`.  We intended to remove the checks for `ENABLE_SHMEMX_TESTS` in those tests, but must have forgotten to do it for v1.5.0.