### PR TITLE
Fix warning comparing ints in signal_wait test

### DIFF
--- a/test/unit/signal_wait_until.c
+++ b/test/unit/signal_wait_until.c
@@ -66,15 +66,15 @@ int main(int argc, char *argv[])
 
     uint64_t retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_LE, npes);
 
-    if (retval > (uint64_t)npes)
+    if (retval > (uint64_t) npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, npes);
-    if (retval != (uint64_t)npes)
+    if (retval != (uint64_t) npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_LT, npes + 1);
-    if (retval != (uint64_t)npes)
+    if (retval != (uint64_t) npes)
         errors++;
 
     for (i = 0; i < MSG_SZ; i++) {
@@ -95,11 +95,11 @@ int main(int argc, char *argv[])
     }
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_GE, npes);
-    if (retval < (uint64_t)npes)
+    if (retval < (uint64_t) npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, npes + 1);
-    if (retval != (uint64_t)npes + 1)
+    if (retval != (uint64_t) npes + 1)
         errors++;
 
     shmem_barrier_all();

--- a/test/unit/signal_wait_until.c
+++ b/test/unit/signal_wait_until.c
@@ -65,15 +65,16 @@ int main(int argc, char *argv[])
     }
 
     uint64_t retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_LE, npes);
-    if (retval > npes)
+
+    if (retval > (uint64_t)npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, npes);
-    if (retval != npes)
+    if (retval != (uint64_t)npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_LT, npes + 1);
-    if (retval != npes)
+    if (retval != (uint64_t)npes)
         errors++;
 
     for (i = 0; i < MSG_SZ; i++) {
@@ -94,11 +95,11 @@ int main(int argc, char *argv[])
     }
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_GE, npes);
-    if (retval < npes)
+    if (retval < (uint64_t)npes)
         errors++;
 
     retval = shmem_signal_wait_until(&sig_addr, SHMEM_CMP_EQ, npes + 1);
-    if (retval != npes + 1)
+    if (retval != (uint64_t)npes + 1)
         errors++;
 
     shmem_barrier_all();


### PR DESCRIPTION
This resolves several compiler warnings when comparing ints in the following unit test:
```
../../../test/unit/signal_wait_until.c:68:16: warning: comparison of integers of different signs: 'uint64_t' (aka 'unsigned long long') and 'int' [-Wsign-compare]
    if (retval > npes)
...
```