### PR TITLE
Update version numbers and NEWS for v1.5.1rc1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,27 @@
 
 Sandia OpenSHMEM NEWS -- history of user-visible changes.
 
+v1.5.1rc1
+---------
+
+- Added deprecation warnings for shmem_barrier, active-set reductions, and
+  other deprecated routines, such as the 32/64-bit collectives.
+- Removed usage of deprecated APIs in shmem_perf_suite, apps, and spec-examples
+- Added missing types for the OpenSHMEM v1.5 reductions (e.g., fixed-width
+  integers, ptrdiff_t, size_t, and schar).
+- Fixed an incorrect function signature for shmem_team_get_config().
+- Resolved some critical issues with the UCX transport.
+- Updated upstream configuration scripts from OpenMPI for UCX, PMI, etc.
+- Fixed issues with the OpenSHMEM teams API (e.g. team-based broadcasts now
+  update the destination object on all PEs including the root).
+- Corrected the return value for shmem_test_all and shmem_test_all_vector.
+- Added support for shmem_signal_wait_until.
+- Resolved a critical build issue on Mac OSX.
+- Fixed several issues in the SOS unit tests and updated them to use the
+  OpenSHMEM v1.5 APIs.
+- Migrated SOS continuous integration from Travis CI to Github
+  Actions and Workflows.
+
 v1.5.0
 ------
 - This full release includes the changes listed below for v1.5.0rc1 and the

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.5.0], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.5.1rc1], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])

--- a/scripts/simple-build-ofi.sh
+++ b/scripts/simple-build-ofi.sh
@@ -13,7 +13,7 @@
 set -e
 
 if [ -z "$SOS_VERSION" ] ; then
-    SOS_VERSION="v1.4.5"
+    SOS_VERSION="v1.5.0"
 fi
 if [ -z "$OFI_VERSION" ] ; then
     OFI_VERSION="v1.8.1"

--- a/scripts/simple-build-ofi.sh
+++ b/scripts/simple-build-ofi.sh
@@ -16,7 +16,7 @@ if [ -z "$SOS_VERSION" ] ; then
     SOS_VERSION="v1.5.0"
 fi
 if [ -z "$OFI_VERSION" ] ; then
-    OFI_VERSION="v1.8.1"
+    OFI_VERSION="v1.14.0"
 fi
 
 HYDRA_URL="http://www.mpich.org/static/downloads/3.2.1/hydra-3.2.1.tar.gz"


### PR DESCRIPTION
This updates the version number according to the [Release Checklist](https://github.com/Sandia-OpenSHMEM/SOS/wiki/Release-Checklist) for v1.5.1 release candidate 1.

After it's merged, I'll tag the repository with `v1.5.1rc1`.