### PR TITLE
Error-checking: Add checks for dst/src overlap

### DIFF
--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -221,9 +221,12 @@ shmem_team_sync(shmem_team_t team)
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE)*nreduce);        \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE)*nreduce);        \
         SHMEM_ERR_CHECK_SYMMETRIC(pWrk, sizeof(TYPE) *                  \
-                                  MAX(nreduce/2 + 1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)); \
-        SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_REDUCE_SYNC_SIZE); \
-        SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE)*nreduce, 1); \
+                                  MAX(nreduce/2 + 1,                    \
+                                  SHMEM_REDUCE_MIN_WRKDATA_SIZE));      \
+        SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) *                 \
+                                  SHMEM_REDUCE_SYNC_SIZE);              \
+        SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE)*nreduce,   \
+                                sizeof(TYPE)*nreduce, 1);               \
                                                                         \
         shmem_internal_op_to_all(target, source, nreduce, sizeof(TYPE), \
                                  PE_start, 1 << logPE_stride, PE_size,  \
@@ -240,7 +243,8 @@ shmem_team_sync(shmem_team_t team)
         SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE)*nreduce);          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE)*nreduce);        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, sizeof(TYPE)*nreduce, 1); \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, sizeof(TYPE)*nreduce,     \
+                                sizeof(TYPE)*nreduce, 1);               \
         TYPE *pWrk = NULL;                                              \
                                                                         \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
@@ -286,7 +290,7 @@ shmem_broadcast32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1);
 
     shmem_internal_bcast(target, source, nlong * 4,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
@@ -305,7 +309,7 @@ shmem_broadcast64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1);
 
     shmem_internal_bcast(target, source, nlong * 8,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
@@ -321,7 +325,7 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, BCAST);
@@ -346,7 +350,8 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
         SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
+                                nelems * sizeof(TYPE), 1);               \
                                                                          \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
         long *psync = shmem_internal_team_choose_psync(myteam, BCAST);   \
@@ -371,7 +376,7 @@ shmem_collect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1);
 
     shmem_internal_collect(target, source, nlong * 4,
                       PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -387,7 +392,7 @@ shmem_collect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1);
 
     shmem_internal_collect(target, source, nlong * 8,
                       PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -402,7 +407,8 @@ shmem_collect64(void *target, const void *source, size_t nlong,
         SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
+                                nelems * sizeof(TYPE), 1);               \
                                                                          \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
         long *psync = shmem_internal_team_choose_psync(myteam,           \
@@ -424,7 +430,7 @@ shmem_collectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
@@ -443,7 +449,7 @@ shmem_fcollect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1);
 
     shmem_internal_fcollect(target, source, nlong * 4,
                        PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -459,7 +465,7 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1);
 
     shmem_internal_fcollect(target, source, nlong * 8,
                        PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -474,7 +480,8 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
         SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
+                                nelems * sizeof(TYPE), 1);               \
                                                                          \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
         long *psync = shmem_internal_team_choose_psync(myteam,           \
@@ -496,7 +503,7 @@ shmem_fcollectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
@@ -515,7 +522,7 @@ shmem_alltoall32(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 4, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 4, nelems * 4, 1);
 
     shmem_internal_alltoall(dest, source, nelems * 4,
                             PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -531,7 +538,7 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 8, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 8, nelems * 8, 1);
 
     shmem_internal_alltoall(dest, source, nelems * 8,
                             PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -546,7 +553,8 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
         SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
+                                nelems * sizeof(TYPE), 1);               \
                                                                          \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
         long *psync = shmem_internal_team_choose_psync(myteam,           \
@@ -568,7 +576,7 @@ shmem_alltoallmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
-    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL);

--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -223,6 +223,7 @@ shmem_team_sync(shmem_team_t team)
         SHMEM_ERR_CHECK_SYMMETRIC(pWrk, sizeof(TYPE) *                  \
                                   MAX(nreduce/2 + 1, SHMEM_REDUCE_MIN_WRKDATA_SIZE)); \
         SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_REDUCE_SYNC_SIZE); \
+        SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE)*nreduce, 1); \
                                                                         \
         shmem_internal_op_to_all(target, source, nreduce, sizeof(TYPE), \
                                  PE_start, 1 << logPE_stride, PE_size,  \
@@ -239,6 +240,7 @@ shmem_team_sync(shmem_team_t team)
         SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE)*nreduce);          \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE)*nreduce);        \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, sizeof(TYPE)*nreduce, 1); \
         TYPE *pWrk = NULL;                                              \
                                                                         \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
@@ -284,6 +286,7 @@ shmem_broadcast32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
 
     shmem_internal_bcast(target, source, nlong * 4,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
@@ -302,6 +305,7 @@ shmem_broadcast64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
 
     shmem_internal_bcast(target, source, nlong * 8,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
@@ -317,6 +321,7 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, BCAST);
@@ -325,33 +330,34 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
                          psync, 1);
     shmem_internal_team_release_psyncs(myteam, BCAST);
     int team_root = myteam->start + PE_root * myteam->stride;
-    if (shmem_internal_my_pe == team_root)
+    if (shmem_internal_my_pe == team_root && dest != source)
         memcpy(dest, source, nelems);
     return 0;
 }
 
-#define SHMEM_DEF_BCAST(STYPE,TYPE)                                     \
-    int SHMEM_FUNCTION_ATTRIBUTES                                       \
-    shmem_##STYPE##_broadcast(shmem_team_t team, TYPE *dest,            \
-                              const TYPE *source, size_t nelems,        \
-                              int PE_root)                              \
-    {                                                                   \
-        SHMEM_ERR_CHECK_INITIALIZED();                                  \
-        SHMEM_ERR_CHECK_PE(PE_root);                                    \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));         \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));       \
-                                                                        \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam, BCAST);  \
-        shmem_internal_bcast(dest, source, nelems * sizeof(TYPE),       \
-                             PE_root, myteam->start, myteam->stride,    \
-                             myteam->size, psync, 1);                   \
-        shmem_internal_team_release_psyncs(myteam, BCAST);              \
-        int team_root = myteam->start + PE_root * myteam->stride;       \
-        if (shmem_internal_my_pe == team_root)                          \
-            memcpy(dest, source, nelems * sizeof(TYPE));                \
-        return 0;                                                       \
+#define SHMEM_DEF_BCAST(STYPE,TYPE)                                      \
+    int SHMEM_FUNCTION_ATTRIBUTES                                        \
+    shmem_##STYPE##_broadcast(shmem_team_t team, TYPE *dest,             \
+                              const TYPE *source, size_t nelems,         \
+                              int PE_root)                               \
+    {                                                                    \
+        SHMEM_ERR_CHECK_INITIALIZED();                                   \
+        SHMEM_ERR_CHECK_PE(PE_root);                                     \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+                                                                         \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
+        long *psync = shmem_internal_team_choose_psync(myteam, BCAST);   \
+        shmem_internal_bcast(dest, source, nelems * sizeof(TYPE),        \
+                             PE_root, myteam->start, myteam->stride,     \
+                             myteam->size, psync, 1);                    \
+        shmem_internal_team_release_psyncs(myteam, BCAST);               \
+        int team_root = myteam->start + PE_root * myteam->stride;        \
+        if (shmem_internal_my_pe == team_root && dest != source)         \
+            memcpy(dest, source, nelems * sizeof(TYPE));                 \
+        return 0;                                                        \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_BCAST')
@@ -365,6 +371,7 @@ shmem_collect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
 
     shmem_internal_collect(target, source, nlong * 4,
                       PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -380,29 +387,31 @@ shmem_collect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
 
     shmem_internal_collect(target, source, nlong * 8,
                       PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_COLLECT(STYPE,TYPE)                                  \
-    int SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_collect(shmem_team_t team, TYPE *dest,             \
-                             const TYPE *source, size_t nelems)        \
-    {                                                                  \
-        SHMEM_ERR_CHECK_INITIALIZED();                                 \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                              \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));      \
-                                                                       \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
-        long *psync = shmem_internal_team_choose_psync(myteam,         \
-                                                        COLLECT);      \
-        shmem_internal_collect(dest, source, nelems * sizeof(TYPE),    \
-                               myteam->start, myteam->stride,          \
-                               myteam->size, psync);                   \
-        shmem_internal_team_release_psyncs(myteam, COLLECT);           \
-        return 0;                                                      \
+#define SHMEM_DEF_COLLECT(STYPE,TYPE)                                    \
+    int SHMEM_FUNCTION_ATTRIBUTES                                        \
+    shmem_##STYPE##_collect(shmem_team_t team, TYPE *dest,               \
+                             const TYPE *source, size_t nelems)          \
+    {                                                                    \
+        SHMEM_ERR_CHECK_INITIALIZED();                                   \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+                                                                         \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
+        long *psync = shmem_internal_team_choose_psync(myteam,           \
+                                                        COLLECT);        \
+        shmem_internal_collect(dest, source, nelems * sizeof(TYPE),      \
+                               myteam->start, myteam->stride,            \
+                               myteam->size, psync);                     \
+        shmem_internal_team_release_psyncs(myteam, COLLECT);             \
+        return 0;                                                        \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_COLLECT')
@@ -415,6 +424,7 @@ shmem_collectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
@@ -433,6 +443,7 @@ shmem_fcollect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, 1);
 
     shmem_internal_fcollect(target, source, nlong * 4,
                        PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -448,29 +459,31 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(target, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nlong * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, 1);
 
     shmem_internal_fcollect(target, source, nlong * 8,
                        PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_FCOLLECT(STYPE,TYPE)                                  \
-    int SHMEM_FUNCTION_ATTRIBUTES                                       \
-    shmem_##STYPE##_fcollect(shmem_team_t team, TYPE *dest,             \
-                              const TYPE *source, size_t nelems)        \
-    {                                                                   \
-        SHMEM_ERR_CHECK_INITIALIZED();                                  \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));         \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));       \
-                                                                        \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam,          \
-                                                        COLLECT);       \
-        shmem_internal_fcollect(dest, source, nelems * sizeof(TYPE),    \
-                                myteam->start, myteam->stride,          \
-                                myteam->size, psync);                   \
-        shmem_internal_team_release_psyncs(myteam, COLLECT);            \
-        return 0;                                                       \
+#define SHMEM_DEF_FCOLLECT(STYPE,TYPE)                                   \
+    int SHMEM_FUNCTION_ATTRIBUTES                                        \
+    shmem_##STYPE##_fcollect(shmem_team_t team, TYPE *dest,              \
+                              const TYPE *source, size_t nelems)         \
+    {                                                                    \
+        SHMEM_ERR_CHECK_INITIALIZED();                                   \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+                                                                         \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
+        long *psync = shmem_internal_team_choose_psync(myteam,           \
+                                                        COLLECT);        \
+        shmem_internal_fcollect(dest, source, nelems * sizeof(TYPE),     \
+                                myteam->start, myteam->stride,           \
+                                myteam->size, psync);                    \
+        shmem_internal_team_release_psyncs(myteam, COLLECT);             \
+        return 0;                                                        \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_FCOLLECT')
@@ -483,6 +496,7 @@ shmem_fcollectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
@@ -501,6 +515,7 @@ shmem_alltoall32(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 4);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 4, 1);
 
     shmem_internal_alltoall(dest, source, nelems * 4,
                             PE_start, 1 << logPE_stride, PE_size, pSync);
@@ -516,29 +531,31 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * 8);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 8, 1);
 
     shmem_internal_alltoall(dest, source, nelems * 8,
                             PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_ALLTOALL(STYPE,TYPE)                                 \
-    int SHMEM_FUNCTION_ATTRIBUTES                                      \
-    shmem_##STYPE##_alltoall(shmem_team_t team, TYPE *dest,            \
-                             const TYPE *source, size_t nelems)        \
-    {                                                                  \
-        SHMEM_ERR_CHECK_INITIALIZED();                                 \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                              \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));      \
-                                                                       \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
-        long *psync = shmem_internal_team_choose_psync(myteam,         \
-                                                        ALLTOALL);     \
-        shmem_internal_alltoall(dest, source, nelems * sizeof(TYPE),   \
-                               myteam->start, myteam->stride,          \
-                               myteam->size, psync);                   \
-        shmem_internal_team_release_psyncs(myteam, ALLTOALL);          \
-        return 0;                                                      \
+#define SHMEM_DEF_ALLTOALL(STYPE,TYPE)                                   \
+    int SHMEM_FUNCTION_ATTRIBUTES                                        \
+    shmem_##STYPE##_alltoall(shmem_team_t team, TYPE *dest,              \
+                             const TYPE *source, size_t nelems)          \
+    {                                                                    \
+        SHMEM_ERR_CHECK_INITIALIZED();                                   \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE), 1); \
+                                                                         \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
+        long *psync = shmem_internal_team_choose_psync(myteam,           \
+                                                        ALLTOALL);       \
+        shmem_internal_alltoall(dest, source, nelems * sizeof(TYPE),     \
+                               myteam->start, myteam->stride,            \
+                               myteam->size, psync);                     \
+        shmem_internal_team_release_psyncs(myteam, ALLTOALL);            \
+        return 0;                                                        \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_ALLTOALL')
@@ -551,6 +568,7 @@ shmem_alltoallmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_TEAM_VALID(team);
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
+    SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, 1);
 
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
     long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL);

--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -339,30 +339,30 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
     return 0;
 }
 
-#define SHMEM_DEF_BCAST(STYPE,TYPE)                                      \
-    int SHMEM_FUNCTION_ATTRIBUTES                                        \
-    shmem_##STYPE##_broadcast(shmem_team_t team, TYPE *dest,             \
-                              const TYPE *source, size_t nelems,         \
-                              int PE_root)                               \
-    {                                                                    \
-        SHMEM_ERR_CHECK_INITIALIZED();                                   \
-        SHMEM_ERR_CHECK_PE(PE_root);                                     \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
-                                nelems * sizeof(TYPE), 1);               \
-                                                                         \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
-        long *psync = shmem_internal_team_choose_psync(myteam, BCAST);   \
-        shmem_internal_bcast(dest, source, nelems * sizeof(TYPE),        \
-                             PE_root, myteam->start, myteam->stride,     \
-                             myteam->size, psync, 1);                    \
-        shmem_internal_team_release_psyncs(myteam, BCAST);               \
-        int team_root = myteam->start + PE_root * myteam->stride;        \
-        if (shmem_internal_my_pe == team_root && dest != source)         \
-            memcpy(dest, source, nelems * sizeof(TYPE));                 \
-        return 0;                                                        \
+#define SHMEM_DEF_BCAST(STYPE,TYPE)                                     \
+    int SHMEM_FUNCTION_ATTRIBUTES                                       \
+    shmem_##STYPE##_broadcast(shmem_team_t team, TYPE *dest,            \
+                              const TYPE *source, size_t nelems,        \
+                              int PE_root)                              \
+    {                                                                   \
+        SHMEM_ERR_CHECK_INITIALIZED();                                  \
+        SHMEM_ERR_CHECK_PE(PE_root);                                    \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));         \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));       \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),    \
+                                nelems * sizeof(TYPE), 1);              \
+                                                                        \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
+        long *psync = shmem_internal_team_choose_psync(myteam, BCAST);  \
+        shmem_internal_bcast(dest, source, nelems * sizeof(TYPE),       \
+                             PE_root, myteam->start, myteam->stride,    \
+                             myteam->size, psync, 1);                   \
+        shmem_internal_team_release_psyncs(myteam, BCAST);              \
+        int team_root = myteam->start + PE_root * myteam->stride;       \
+        if (shmem_internal_my_pe == team_root && dest != source)        \
+            memcpy(dest, source, nelems * sizeof(TYPE));                \
+        return 0;                                                       \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_BCAST')
@@ -398,26 +398,26 @@ shmem_collect64(void *target, const void *source, size_t nlong,
                       PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_COLLECT(STYPE,TYPE)                                    \
-    int SHMEM_FUNCTION_ATTRIBUTES                                        \
-    shmem_##STYPE##_collect(shmem_team_t team, TYPE *dest,               \
-                             const TYPE *source, size_t nelems)          \
-    {                                                                    \
-        SHMEM_ERR_CHECK_INITIALIZED();                                   \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
-                                nelems * sizeof(TYPE), 1);               \
-                                                                         \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
-        long *psync = shmem_internal_team_choose_psync(myteam,           \
-                                                        COLLECT);        \
-        shmem_internal_collect(dest, source, nelems * sizeof(TYPE),      \
-                               myteam->start, myteam->stride,            \
-                               myteam->size, psync);                     \
-        shmem_internal_team_release_psyncs(myteam, COLLECT);             \
-        return 0;                                                        \
+#define SHMEM_DEF_COLLECT(STYPE,TYPE)                                  \
+    int SHMEM_FUNCTION_ATTRIBUTES                                      \
+    shmem_##STYPE##_collect(shmem_team_t team, TYPE *dest,             \
+                             const TYPE *source, size_t nelems)        \
+    {                                                                  \
+        SHMEM_ERR_CHECK_INITIALIZED();                                 \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                              \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));      \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),   \
+                                nelems * sizeof(TYPE), 1);             \
+                                                                       \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
+        long *psync = shmem_internal_team_choose_psync(myteam,         \
+                                                        COLLECT);      \
+        shmem_internal_collect(dest, source, nelems * sizeof(TYPE),    \
+                               myteam->start, myteam->stride,          \
+                               myteam->size, psync);                   \
+        shmem_internal_team_release_psyncs(myteam, COLLECT);           \
+        return 0;                                                      \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_COLLECT')
@@ -471,26 +471,26 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
                        PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_FCOLLECT(STYPE,TYPE)                                   \
-    int SHMEM_FUNCTION_ATTRIBUTES                                        \
-    shmem_##STYPE##_fcollect(shmem_team_t team, TYPE *dest,              \
-                              const TYPE *source, size_t nelems)         \
-    {                                                                    \
-        SHMEM_ERR_CHECK_INITIALIZED();                                   \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
-                                nelems * sizeof(TYPE), 1);               \
-                                                                         \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
-        long *psync = shmem_internal_team_choose_psync(myteam,           \
-                                                        COLLECT);        \
-        shmem_internal_fcollect(dest, source, nelems * sizeof(TYPE),     \
-                                myteam->start, myteam->stride,           \
-                                myteam->size, psync);                    \
-        shmem_internal_team_release_psyncs(myteam, COLLECT);             \
-        return 0;                                                        \
+#define SHMEM_DEF_FCOLLECT(STYPE,TYPE)                                  \
+    int SHMEM_FUNCTION_ATTRIBUTES                                       \
+    shmem_##STYPE##_fcollect(shmem_team_t team, TYPE *dest,             \
+                              const TYPE *source, size_t nelems)        \
+    {                                                                   \
+        SHMEM_ERR_CHECK_INITIALIZED();                                  \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                               \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));         \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));       \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),    \
+                                nelems * sizeof(TYPE), 1);              \
+                                                                        \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
+        long *psync = shmem_internal_team_choose_psync(myteam,          \
+                                                        COLLECT);       \
+        shmem_internal_fcollect(dest, source, nelems * sizeof(TYPE),    \
+                                myteam->start, myteam->stride,          \
+                                myteam->size, psync);                   \
+        shmem_internal_team_release_psyncs(myteam, COLLECT);            \
+        return 0;                                                       \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_FCOLLECT')
@@ -544,26 +544,26 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
                             PE_start, 1 << logPE_stride, PE_size, pSync);
 }
 
-#define SHMEM_DEF_ALLTOALL(STYPE,TYPE)                                   \
-    int SHMEM_FUNCTION_ATTRIBUTES                                        \
-    shmem_##STYPE##_alltoall(shmem_team_t team, TYPE *dest,              \
-                             const TYPE *source, size_t nelems)          \
-    {                                                                    \
-        SHMEM_ERR_CHECK_INITIALIZED();                                   \
-        SHMEM_ERR_CHECK_TEAM_VALID(team);                                \
-        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));          \
-        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));        \
-        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),     \
-                                nelems * sizeof(TYPE), 1);               \
-                                                                         \
-        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;   \
-        long *psync = shmem_internal_team_choose_psync(myteam,           \
-                                                        ALLTOALL);       \
-        shmem_internal_alltoall(dest, source, nelems * sizeof(TYPE),     \
-                               myteam->start, myteam->stride,            \
-                               myteam->size, psync);                     \
-        shmem_internal_team_release_psyncs(myteam, ALLTOALL);            \
-        return 0;                                                        \
+#define SHMEM_DEF_ALLTOALL(STYPE,TYPE)                                 \
+    int SHMEM_FUNCTION_ATTRIBUTES                                      \
+    shmem_##STYPE##_alltoall(shmem_team_t team, TYPE *dest,            \
+                             const TYPE *source, size_t nelems)        \
+    {                                                                  \
+        SHMEM_ERR_CHECK_INITIALIZED();                                 \
+        SHMEM_ERR_CHECK_TEAM_VALID(team);                              \
+        SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));        \
+        SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));      \
+        SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),   \
+                                nelems * sizeof(TYPE), 1);             \
+                                                                       \
+        shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
+        long *psync = shmem_internal_team_choose_psync(myteam,         \
+                                                        ALLTOALL);     \
+        shmem_internal_alltoall(dest, source, nelems * sizeof(TYPE),   \
+                               myteam->start, myteam->stride,          \
+                               myteam->size, psync);                   \
+        shmem_internal_team_release_psyncs(myteam, ALLTOALL);          \
+        return 0;                                                      \
     }
 
 SHMEM_BIND_C_RMA(`SHMEM_DEF_ALLTOALL')

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -496,6 +496,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);           \
+    SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, sizeof(TYPE) * nelems,    \
+                            sizeof(uint64_t), 0);                       \
     SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_nb(ctx, target, source,                          \
@@ -525,6 +527,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);                 \
+    SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, (SIZE) * nelems,          \
+                            sizeof(uint64_t), 0);                       \
     SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,         \
@@ -551,6 +555,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);           \
+    SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, sizeof(TYPE) * nelems,    \
+                            sizeof(uint64_t), 0);                       \
     SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_signal_nbi(ctx, target, source,                  \
@@ -569,6 +575,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);                 \
+    SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, (SIZE) * nelems,          \
+                            sizeof(uint64_t), 0);                       \
     SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_signal_nbi(ctx, target, source, (SIZE) * nelems, \

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -286,6 +286,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
+                            nelems, sizeof(TYPE) * nelems, 0);   \
     shmem_internal_put_nb(ctx, target, source,                   \
                           sizeof(TYPE) * nelems, pe,             \
                           &completion);                          \
@@ -304,6 +306,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                  \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
+                            (SIZE) * nelems, 0);               \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,\
                           pe, &completion);                    \
     shmem_internal_put_wait(ctx, &completion);                 \
@@ -319,6 +323,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(source, nelems);                        \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
+                            nelems, sizeof(TYPE) * nelems, 0);   \
     shmem_internal_put_nbi(ctx, target, source,                  \
                            sizeof(TYPE)*nelems,                  \
         pe);                                                     \
@@ -335,6 +341,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                  \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(source, nelems);                      \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
+                            (SIZE) * nelems, 0);               \
     shmem_internal_put_nbi(ctx, target, source, (SIZE)*nelems, \
                            pe);                                \
   }
@@ -350,6 +358,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                 \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *    \
+                            nelems, sizeof(TYPE) * nelems, 0);\
     shmem_internal_get(ctx, target, source,                   \
                        sizeof(TYPE) * nelems, pe);            \
     shmem_internal_get_wait(ctx);                             \
@@ -366,6 +376,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                              \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                  \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE)*nelems, \
+                           (SIZE) * nelems, 0);            \
     shmem_internal_get(ctx, target, source, (SIZE)*nelems, \
                        pe);                                \
     shmem_internal_get_wait(ctx);                          \
@@ -382,6 +394,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                    \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * nelems);    \
     SHMEM_ERR_CHECK_NULL(target, nelems);                        \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
+                            nelems, sizeof(TYPE) * nelems, 0);   \
     shmem_internal_get(ctx, target, source, sizeof(TYPE)*nelems, \
                        pe);                                      \
   }
@@ -397,6 +411,8 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                  \
     SHMEM_ERR_CHECK_SYMMETRIC(source, (SIZE) * nelems);        \
     SHMEM_ERR_CHECK_NULL(target, nelems);                      \
+    SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
+                            (SIZE) * nelems, 0);               \
     shmem_internal_get(ctx, target, source, (SIZE)*nelems, pe);\
   }
 
@@ -412,6 +428,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_POSITIVE(sst);                            \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                     \
+    SHMEM_ERR_CHECK_OVERLAP(target, source,                   \
+                   sizeof(TYPE) * ((nelems-1) * tst + 1),     \
+                   sizeof(TYPE) * ((nelems-1) * sst + 1), 0); \
     for ( ; nelems > 0 ; --nelems) {                          \
       shmem_internal_put_scalar(ctx, target, source,          \
                                sizeof(TYPE), pe);             \
@@ -431,8 +450,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                                \
     SHMEM_ERR_CHECK_POSITIVE(tst);                           \
     SHMEM_ERR_CHECK_POSITIVE(sst);                           \
-    SHMEM_ERR_CHECK_SYMMETRIC(target, SIZE * ((nelems-1) * tst + 1)); \
+    SHMEM_ERR_CHECK_SYMMETRIC(target,                        \
+                           (SIZE) * ((nelems-1) * tst + 1)); \
     SHMEM_ERR_CHECK_NULL(source, nelems);                    \
+    SHMEM_ERR_CHECK_OVERLAP(target, source,                  \
+                        (SIZE) * ((nelems-1) * tst + 1),     \
+                        (SIZE) * ((nelems-1) * sst + 1), 0); \
     for ( ; nelems > 0 ; --nelems) {                         \
       shmem_internal_put_scalar(ctx, target, source, (SIZE), \
                                pe);                          \
@@ -455,6 +478,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_POSITIVE(sst);                            \
     SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE) * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                     \
+    SHMEM_ERR_CHECK_OVERLAP(target, source,                   \
+                   sizeof(TYPE) * ((nelems-1) * tst + 1),     \
+                   sizeof(TYPE) * ((nelems-1) * sst + 1), 0); \
     for ( ; nelems > 0 ; --nelems) {                          \
       shmem_internal_get(ctx, target, source, sizeof(TYPE),   \
                          pe);                                 \
@@ -475,8 +501,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_CTX(ctx);                             \
     SHMEM_ERR_CHECK_POSITIVE(tst);                        \
     SHMEM_ERR_CHECK_POSITIVE(sst);                        \
-    SHMEM_ERR_CHECK_SYMMETRIC(source, SIZE * ((nelems-1) * sst + 1)); \
+    SHMEM_ERR_CHECK_SYMMETRIC(source,                     \
+                        (SIZE) * ((nelems-1) * sst + 1)); \
     SHMEM_ERR_CHECK_NULL(target, nelems);                 \
+    SHMEM_ERR_CHECK_OVERLAP(target, source,               \
+                     (SIZE) * ((nelems-1) * tst + 1),     \
+                     (SIZE) * ((nelems-1) * sst + 1), 0); \
     for ( ; nelems > 0 ; --nelems) {                      \
       shmem_internal_get(ctx, target, source, (SIZE), pe);\
       target = (uint8_t*)target + tst*(SIZE);             \
@@ -496,9 +526,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);           \
+    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, sizeof(TYPE) * nelems,    \
                             sizeof(uint64_t), 0);                       \
-    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_nb(ctx, target, source,                          \
                           sizeof(TYPE) * nelems, pe,                    \
@@ -527,9 +557,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);                 \
+    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, (SIZE) * nelems,          \
                             sizeof(uint64_t), 0);                       \
-    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,         \
                           pe, &completion);                             \
@@ -555,9 +585,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE) * nelems);           \
+    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, sizeof(TYPE) * nelems,    \
                             sizeof(uint64_t), 0);                       \
-    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_signal_nbi(ctx, target, source,                  \
                                   sizeof(TYPE) * nelems, sig_addr,      \
@@ -575,9 +605,9 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                             \
     SHMEM_ERR_CHECK_CTX(ctx);                                           \
     SHMEM_ERR_CHECK_SYMMETRIC(target, (SIZE) * nelems);                 \
+    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, (SIZE) * nelems,          \
                             sizeof(uint64_t), 0);                       \
-    SHMEM_ERR_CHECK_NULL(source, nelems);                               \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
     shmem_internal_put_signal_nbi(ctx, target, source, (SIZE) * nelems, \
                                   sig_addr, signal, sig_op, pe);        \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -285,6 +285,24 @@ extern unsigned int shmem_internal_rand_seed;
         }                                                                               \
     } while (0)
 
+#define SHMEM_ERR_CHECK_OVERLAP(dest, source, size, complete_overlap_allowed)           \
+    do {                                                                                \
+        const void *dst = (void*)(dest);                                                \
+        const void *src = (void*)(source);                                              \
+        const void *ptr_low  = dst > src ? src : dst;                                   \
+        const void *ptr_high = dst > src ? dst : src;                                   \
+        const void *ptr_extent = (void *)((char *)(ptr_low) + (size));                  \
+        if (size == 0 || (complete_overlap_allowed && src == dst)) {                    \
+            break; /* Skip this check when size is 0 or buffers completely overlap  */  \
+        }                                                                               \
+        if (ptr_extent > ptr_high) {                                                    \
+            fprintf(stderr, "ERROR: %s(): Argument \"%s\" [%p..%p) overlaps "           \
+                            "argument (%p)\n",                                          \
+                    __func__, #dest, ptr_low, ptr_extent, ptr_high);                    \
+            shmem_runtime_abort(100, PACKAGE_NAME " exited in error");                  \
+        }                                                                               \
+    } while (0)
+
 #define SHMEM_ERR_CHECK_NULL(ptr, nelems)                                               \
     do {                                                                                \
         if (nelems > 0 && (ptr) == NULL) {                                              \
@@ -336,6 +354,7 @@ extern unsigned int shmem_internal_rand_seed;
 #define SHMEM_ERR_CHECK_CTX(ctx)
 #define SHMEM_ERR_CHECK_SYMMETRIC(ptr, len)
 #define SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr)
+#define SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, complete_overlap_allowed)
 #define SHMEM_ERR_CHECK_NULL(ptr, nelems)
 #define SHMEM_ERR_CHECK_CMP_OP(op)
 #define SHMEM_ERR_CHECK_SIG_OP(op)                                                      \

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -221,6 +221,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -255,6 +256,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -290,6 +292,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, found_idx = SIZE_MAX, num_ignored = 0;                                   \
@@ -339,6 +342,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, found_idx = SIZE_MAX, num_ignored = 0;                                   \
@@ -388,6 +392,9 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -430,6 +437,9 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -495,6 +505,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
         size_t ncompleted = 0;                                                                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -537,6 +548,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
         size_t ncompleted = 0;                                                                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -578,6 +590,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t found_idx = SIZE_MAX, i = 0;                                                    \
@@ -616,6 +629,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t found_idx = SIZE_MAX, i = 0;                                                    \
@@ -654,6 +668,9 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -694,6 +711,9 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
+        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -221,7 +221,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -256,7 +256,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -292,7 +292,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, found_idx = SIZE_MAX, num_ignored = 0;                                   \
@@ -342,7 +342,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, found_idx = SIZE_MAX, num_ignored = 0;                                   \
@@ -392,9 +392,12 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
-        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
+        SHMEM_ERR_CHECK_OVERLAP(indices, status, sizeof(size_t) * nelems,                      \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems,                           \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems,                          \
+                                sizeof(size_t) * nelems, 0);                                   \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -437,9 +440,12 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
-        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
+        SHMEM_ERR_CHECK_OVERLAP(indices, status, sizeof(size_t) * nelems,                      \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems,                           \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems,                          \
+                                sizeof(size_t) * nelems, 0);                                   \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -505,7 +511,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
         size_t ncompleted = 0;                                                                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -548,7 +554,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
         size_t ncompleted = 0;                                                                 \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, num_ignored = 0;                                                         \
@@ -590,7 +596,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t found_idx = SIZE_MAX, i = 0;                                                    \
@@ -629,7 +635,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, sizeof(int) * nelems, 0); \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t found_idx = SIZE_MAX, i = 0;                                                    \
@@ -668,9 +674,12 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
-        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
+        SHMEM_ERR_CHECK_OVERLAP(indices, status, sizeof(size_t) * nelems,                      \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems,                           \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems,                          \
+                                sizeof(size_t) * nelems, 0);                                   \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \
@@ -711,9 +720,12 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
     {                                                                                          \
         SHMEM_ERR_CHECK_INITIALIZED();                                                         \
         SHMEM_ERR_CHECK_SYMMETRIC(vars, sizeof(TYPE));                                         \
-        SHMEM_ERR_CHECK_OVERLAP(status, indices, sizeof(TYPE) * nelems, 0);                    \
-        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems, 0);                       \
-        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems, 0);                      \
+        SHMEM_ERR_CHECK_OVERLAP(indices, status, sizeof(size_t) * nelems,                      \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, status, sizeof(TYPE) * nelems,                           \
+                                sizeof(int) * nelems, 0);                                      \
+        SHMEM_ERR_CHECK_OVERLAP(vars, indices, sizeof(TYPE) * nelems,                          \
+                                sizeof(size_t) * nelems, 0);                                   \
         SHMEM_ERR_CHECK_CMP_OP(cond);                                                          \
                                                                                                \
         size_t i = 0, ncompleted = 0, num_ignored = 0;                                         \

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -96,6 +96,7 @@ check_PROGRAMS = \
 	broadcast_active_set \
 	reduce_active_set \
 	reduce_in_place \
+	bcast_in_place \
 	collect_active_set \
 	atomic_bitwise \
 	nop_collectives \

--- a/test/unit/bcast_in_place.c
+++ b/test/unit/bcast_in_place.c
@@ -34,13 +34,12 @@ long src[NELEM];
 
 int main(void)
 {
-    int me, npes;
+    int me;
     int errors = 0;
 
     shmem_init();
 
     me = shmem_my_pe();
-    npes = shmem_n_pes();
 
     for (int i = 0; i < NELEM; i++)
         src[i] = me + i;
@@ -49,7 +48,7 @@ int main(void)
 
     shmem_long_broadcast(SHMEM_TEAM_WORLD, src, src, NELEM, 0);
 
-    /* Validate reduced data */
+    /* Validate broadcast data */
     for (int j = 0; j < NELEM; j++) {
         long expected = j;
         if (src[j] != expected) {

--- a/test/unit/bcast_in_place.c
+++ b/test/unit/bcast_in_place.c
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2022 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <shmem.h>
+
+#define NELEM 10
+
+long src[NELEM];
+
+int main(void)
+{
+    int me, npes;
+    int errors = 0;
+
+    shmem_init();
+
+    me = shmem_my_pe();
+    npes = shmem_n_pes();
+
+    for (int i = 0; i < NELEM; i++)
+        src[i] = me + i;
+
+    shmem_barrier_all();
+
+    shmem_long_broadcast(SHMEM_TEAM_WORLD, src, src, NELEM, 0);
+
+    /* Validate reduced data */
+    for (int j = 0; j < NELEM; j++) {
+        long expected = j;
+        if (src[j] != expected) {
+            printf("%d: Expected src[%d] = %ld, got src[%d] = %ld\n", me, j, expected, j, src[j]);
+            errors++;
+        }
+    }
+
+    shmem_finalize();
+
+    return errors != 0;
+}

--- a/test/unit/waituntil.c
+++ b/test/unit/waituntil.c
@@ -84,9 +84,10 @@ main(int argc, char* argv[])
     shmem_barrier_all();
 
     if (me == 0) {
-        memset(target, 0, sizeof(target));
+        DataType zeros[10];
+        memset(zeros, 0, sizeof(zeros));
         for(pe=1; pe < num_pes; pe++)
-            SHM_PUT(target, target, 10, pe);
+            SHM_PUT(target, zeros, 10, pe);
 
         shmem_fence();
 


### PR DESCRIPTION
Features:
  * Fixes bug for in-place broadcasts (on the root PE).
  * Adds error-checking macro for proper buffer overlap.
  * No support yet for the strided APIs and put w/ signal.
  * Adds a simple unit test for in-place broadcast.
