### PR TITLE
workaround for hang at finalize

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1758,7 +1758,10 @@ int shmem_transport_fini(void)
 
     /* The default context is not inserted into the list of contexts on
      * SHMEM_TEAM_WORLD, so it must be destroyed here */
-    shmem_transport_quiet(&shmem_transport_ctx_default);
+
+    for(int i=0; i< 100000; i++) {
+        shmem_transport_quiet(&shmem_transport_ctx_default);
+    }	
     shmem_transport_ctx_destroy(&shmem_transport_ctx_default);
 
     for (e = shmem_transport_ofi_stx_kvs; e != NULL; ) {


### PR DESCRIPTION
At Cornelis Networks we are seeing intermittent hangs at finalize when running e.g the basic ‘pingpong’ test in the unit directory. As we scale up from 2 ranks 1 ppn up to 14 ranks 7 ppn, we almost always run into a case where a process will hang.

Currently, our workaround is to call shmem_transport_quiet not just once, but several thousands of times. With this fix in place, it gives processes enough time to gracefully become inactive.

Obviously, this is not a proper solution, and certainly not scalable, and I am curious what would be the best way to resolve this issue. Also, I’m curious if anyone else has seen this issue, or if this has been discussed in the past.