### PR TITLE
Patch data segment init for M1 (and M2?) Macs

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -45,7 +45,6 @@
 #ifdef __APPLE__
 #include <mach/mach.h>
 #include <mach/mach_vm.h>
-#include <assert.h>
 #else
 /* Declare data_start and end as weak to avoid a linker error if the symbols
  * are not present.  During initialization we check if the symbols exist. */
@@ -69,7 +68,7 @@ vm_address_t get_base_address(mach_port_t task, size_t *region_size, void *addr)
     kret = mach_vm_region(task, &address, (mach_vm_size_t *)&size,
                           VM_REGION_BASIC_INFO, (vm_region_info_t)&info,
                           &count, &object_name);
-    assert(kret == KERN_SUCCESS);
+    shmem_internal_assertp(kret == KERN_SUCCESS);
 
     *region_size = (size_t) size;
     return address;

--- a/test/unit/iput128.c
+++ b/test/unit/iput128.c
@@ -38,7 +38,7 @@
 
 #define IPUT shmem_iput128
 #ifndef __APPLE__
-#define DataType long long double
+#define DataType long double
 #else
 #define DataType __int128
 #endif

--- a/test/unit/iput128.c
+++ b/test/unit/iput128.c
@@ -35,11 +35,13 @@
 
 #include <stdio.h>
 #include <shmem.h>
-#define _IPUT(a) shmem_##a##_iput
 
-//#define IPUT _IPUT(double)
 #define IPUT shmem_iput128
-#define DataType long double
+#ifndef __APPLE__
+#define DataType long long double
+#else
+#define DataType __int128
+#endif
 
 static DataType source[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
 static DataType target[10];
@@ -68,10 +70,12 @@ int main(int argc, char **argv)
             target[3] != 7 ||
             target[4] != 9)
         {
+#ifndef __APPLE__
             printf("ERR: target on PE %d is %Lf %Lf %Lf %Lf %Lf\n"
                    "  Expected 1,3,5,7,9?\n",
                    me, target[0], target[1], target[2],
                    target[3], target[4] );
+#endif
             rc = 1;
         }
     }


### PR DESCRIPTION
On MacOS, there's a problem with the initialization of the symmetric data segment (the symmetric heap is fine).  I can reproduce it on a 2020 M1 MacBook Pro, but not a 2016 Intel MacBook Pro.

SOS uses `get_etext` and `get_end` to find the data segment region, but [the manpage says](https://www.manpagez.com/man/3/get_etext/), "Use of these routines is very strongly discouraged.  The problem is that any program that is using UNIX link editor defined symbols (_end, _etext or _edata) is making assumptions that the program has the memory layout of a UNIX program."  I can tell that the determined memory layout is wrong on the M1 Mac, which causes any use of a global or static variable in an SOS communication routine to go out of bounds. 

It seems `mach_vm_region` is the standard API for gathering the segment properties (and it's very [poorly documented here](https://developer.apple.com/documentation/kernel/1402149-mach_vm_region)).

Oh, also `long double` is only 8 bytes on the M1 Mac, so I adjusted the iput128 unit test to use `__int128`.

Side note: MacOS is not a supported OS by any means, but it is an important environment for some developers (especially myself!).  This patch is just a best-effort hack to support laptop development of SOS on Macs.