### PR TITLE
NOMERGE: Add bare-minimum Session API from proposal draft

### DIFF
--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -116,6 +116,14 @@ typedef struct {
 #define SHMEM_SIGNAL_SET        0
 #define SHMEM_SIGNAL_ADD        1
 
+#define SHMEM_SESSION_OP_PUT          (1l<<0)
+#define SHMEM_SESSION_OP_GET          (1l<<1)
+#define SHMEM_SESSION_OP_PUT_SIGNAL   (1l<<2)
+#define SHMEM_SESSION_OP_AMO          (1l<<3)
+#define SHMEM_SESSION_OP_AMO_FETCH    (1l<<4)
+#define SHMEM_SESSION_CHAIN           (1l<<5)
+#define SHMEM_SESSION_UNIFORM_AMO     (1l<<6)
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -99,6 +99,10 @@ typedef struct {
     int num_contexts;
 } shmem_team_config_t;
 
+typedef struct {
+    size_t total_ops;
+} shmem_session_config_t;
+
 #if SHMEM_HAVE_ATTRIBUTE_VISIBILITY == 1
     __attribute__((visibility("default"))) extern shmem_team_t SHMEM_TEAM_WORLD;
     __attribute__((visibility("default"))) extern shmem_team_t SHMEM_TEAM_SHARED;
@@ -116,13 +120,9 @@ typedef struct {
 #define SHMEM_SIGNAL_SET        0
 #define SHMEM_SIGNAL_ADD        1
 
-#define SHMEM_SESSION_OP_PUT          (1l<<0)
-#define SHMEM_SESSION_OP_GET          (1l<<1)
-#define SHMEM_SESSION_OP_PUT_SIGNAL   (1l<<2)
-#define SHMEM_SESSION_OP_AMO          (1l<<3)
-#define SHMEM_SESSION_OP_AMO_FETCH    (1l<<4)
-#define SHMEM_SESSION_CHAIN           (1l<<5)
-#define SHMEM_SESSION_UNIFORM_AMO     (1l<<6)
+#define SHMEM_SESSION_TOTAL_OPS       (1l<<0)
+#define SHMEM_SESSION_BATCH           (1l<<0)
+#define SHMEM_SESSION_SAME_AMO        (1l<<1)
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -639,8 +639,8 @@ define(`SHMEM_C_CTX_FETCH_OR_NBI',
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_OR_NBI')
 
 /* Session Routines */
-void SHPRE()shmem_session_start(long options, shmem_ctx_t ctx);
-void SHPRE()shmem_session_stop(shmem_ctx_t ctx);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_session_start(long options, shmem_ctx_t ctx);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_session_stop(shmem_ctx_t ctx);
 
 /* Team Management Routines */
 SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_team_my_pe(shmem_team_t team);

--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -639,7 +639,7 @@ define(`SHMEM_C_CTX_FETCH_OR_NBI',
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_OR_NBI')
 
 /* Session Routines */
-SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_session_start(long options, shmem_ctx_t ctx);
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_session_start(shmem_ctx_t ctx, long options, const shmem_session_config_t *config, long config_mask);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_session_stop(shmem_ctx_t ctx);
 
 /* Team Management Routines */

--- a/mpp/shmem_c_func.h4
+++ b/mpp/shmem_c_func.h4
@@ -638,6 +638,10 @@ define(`SHMEM_C_CTX_FETCH_OR_NBI',
 `SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmem_ctx_$1_atomic_fetch_or_nbi(shmem_ctx_t ctx, $2 *fetch, $2 *target, $2 value, int pe)')dnl
 SHMEM_DECLARE_FOR_BITWISE_AMO(`SHMEM_C_CTX_FETCH_OR_NBI')
 
+/* Session Routines */
+void SHPRE()shmem_session_start(long options, shmem_ctx_t ctx);
+void SHPRE()shmem_session_stop(shmem_ctx_t ctx);
+
 /* Team Management Routines */
 SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmem_team_my_pe(shmem_team_t team);
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,7 @@ libsma_la_SOURCES = \
 	shmem_env_defs.h \
 	contexts_c.c \
 	contexts.c \
+	sessions_c.c \
 	perf_counters_c.c \
 	backtrace.c \
 	shmem_team.c \

--- a/src/sessions_c.c
+++ b/src/sessions_c.c
@@ -1,0 +1,60 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2022 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution.
+ *
+ */
+
+#include "config.h"
+
+#define SHMEM_INTERNAL_INCLUDE
+#include "shmem.h"
+#include "shmem_internal.h"
+#include "transport.h"
+//#include "shmem_synchronization.h"
+//#include "shmem_team.h"
+
+#ifdef ENABLE_PROFILING
+#include "pshmem.h"
+
+#pragma weak shmem_session_start = pshmem_session_start
+#define shmem_session_start pshmem_session_start
+
+#pragma weak shmem_session_stop = pshmem_session_stop
+#define shmem_session_stop pshmem_session_stop
+
+#endif /* ENABLE_PROFILING */
+
+SHMEM_FUNCTION_ATTRIBUTES void
+shmem_session_start(long options, shmem_ctx_t ctx)
+{
+    SHMEM_ERR_CHECK_INITIALIZED();
+
+    int ret = shmem_transport_session_start(options, (shmem_transport_ctx_t *) ctx);
+    if (0 != ret) {
+        DEBUG_MSG("Session did not start correctly (%d)\n", ret);
+    } else {
+        DEBUG_MSG("Session started correctly, but all hints are currently ignored\n");
+    }
+
+    return;
+}
+
+SHMEM_FUNCTION_ATTRIBUTES void
+shmem_session_stop(shmem_ctx_t ctx)
+{
+    SHMEM_ERR_CHECK_INITIALIZED();
+
+    int ret = shmem_transport_session_stop((shmem_transport_ctx_t *) ctx);
+    if (0 != ret) {
+        DEBUG_MSG("Session didn't stop correctly (%d)\n", ret);
+    } else {
+        DEBUG_MSG("Session stopped successfully\n");
+    }
+
+    return;
+}

--- a/src/sessions_c.c
+++ b/src/sessions_c.c
@@ -1,6 +1,6 @@
 /* -*- C -*-
  *
- * Copyright (c) 2022 Intel Corporation. All rights reserved.
+ * Copyright (c) 2024 Intel Corporation. All rights reserved.
  * This software is available to you under the BSD license.
  *
  * This file is part of the Sandia OpenSHMEM software package. For license
@@ -28,11 +28,11 @@
 #endif /* ENABLE_PROFILING */
 
 SHMEM_FUNCTION_ATTRIBUTES void
-shmem_session_start(long options, shmem_ctx_t ctx)
+shmem_session_start(shmem_ctx_t ctx, long options, const shmem_session_config_t *config, long config_mask)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    int ret = shmem_transport_session_start(options, (shmem_transport_ctx_t *) ctx);
+    int ret = shmem_transport_session_start((shmem_transport_ctx_t *) ctx, options, config, config_mask);
     if (0 != ret) {
         DEBUG_MSG("Session did not start correctly (%d)\n", ret);
     } else {

--- a/src/sessions_c.c
+++ b/src/sessions_c.c
@@ -15,8 +15,6 @@
 #include "shmem.h"
 #include "shmem_internal.h"
 #include "transport.h"
-//#include "shmem_synchronization.h"
-//#include "shmem_team.h"
 
 #ifdef ENABLE_PROFILING
 #include "pshmem.h"

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -370,4 +370,18 @@ void shmem_transport_pcntr_get_all(shmem_transport_ctx_t *ctx, shmemx_pcntr_t *p
     return;
 }
 
+static inline
+void
+shmem_transport_session_start(long options, shmem_transport_ctx_t ctx)
+{
+    return;
+}
+
+static inline
+void
+shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
+{
+    return;
+}
+
 #endif /* TRANSPORT_NONE_H */

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -372,7 +372,7 @@ void shmem_transport_pcntr_get_all(shmem_transport_ctx_t *ctx, shmemx_pcntr_t *p
 
 static inline
 int
-shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask)
 {
     return 0;
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -371,17 +371,17 @@ void shmem_transport_pcntr_get_all(shmem_transport_ctx_t *ctx, shmemx_pcntr_t *p
 }
 
 static inline
-void
-shmem_transport_session_start(long options, shmem_transport_ctx_t ctx)
+int
+shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
 {
-    return;
+    return 0;
 }
 
 static inline
-void
+int
 shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
 {
-    return;
+    return 0;
 }
 
 #endif /* TRANSPORT_NONE_H */

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -2123,6 +2123,16 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 }
 
+int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+int shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
 int shmem_transport_fini(void)
 {
     int ret;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -2123,7 +2123,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 }
 
-int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+int shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask)
 {
     return 0;
 }

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -348,6 +348,9 @@ void shmem_transport_probe(void)
 int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
+int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx);
+int shmem_transport_session_stop(shmem_transport_ctx_t *ctx);
+
 int shmem_transport_init(void);
 int shmem_transport_startup(void);
 int shmem_transport_fini(void);

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -348,7 +348,7 @@ void shmem_transport_probe(void)
 int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
-int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx);
+int shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask);
 int shmem_transport_session_stop(shmem_transport_ctx_t *ctx);
 
 int shmem_transport_init(void);

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -356,7 +356,7 @@ shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
 }
 
 int
-shmem_transport_session_stop(shmem_transport_ctx_t ctx)
+shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
 {
     return 0;
 }

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -350,7 +350,7 @@ shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 }
 
 int
-shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask)
 {
     return 0;
 }

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -349,6 +349,18 @@ shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     return;
 }
 
+int
+shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+{
+    return 0;
+}
+
+int
+shmem_transport_session_stop(shmem_transport_ctx_t ctx)
+{
+    return 0;
+}
+
 static
 void
 init_bounce_buffer(shmem_free_list_item_t *item)

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -150,7 +150,7 @@ extern shmem_transport_ctx_t shmem_transport_ctx_default;
 int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
-int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx);
+int shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask);
 int shmem_transport_session_stop(shmem_transport_ctx_t *ctx);
 
 /*

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -150,6 +150,9 @@ extern shmem_transport_ctx_t shmem_transport_ctx_default;
 int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options, shmem_transport_ctx_t **ctx);
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx);
 
+int shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx);
+int shmem_transport_session_stop(shmem_transport_ctx_t *ctx);
+
 /*
  * PORTALS4_GET_REMOTE_ACCESS is used to get the correct PT and offset
  * from the base of the list entry on that PT for a given target

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -209,6 +209,18 @@ static inline
 int
 shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
 {
+      return 0;
+}
+
+static inline
+int
+shmem_transport_quiet(shmem_transport_ctx_t* ctx)
+{
+    ucs_status_t status;
+
+    status = ucp_worker_flush(shmem_transport_ucp_worker);
+    UCX_CHECK_STATUS(status);
+
     return 0;
 }
 

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -200,13 +200,15 @@ shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 
 static inline
 int
-shmem_transport_quiet(shmem_transport_ctx_t* ctx)
+shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
 {
-    ucs_status_t status;
+    return 0;
+}
 
-    status = ucp_worker_flush(shmem_transport_ucp_worker);
-    UCX_CHECK_STATUS(status);
-
+static inline
+int
+shmem_transport_session_stop(shmem_transport_ctx_t *ctx)
+{
     return 0;
 }
 

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -200,7 +200,7 @@ shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 
 static inline
 int
-shmem_transport_session_start(long options, shmem_transport_ctx_t *ctx)
+shmem_transport_session_start(shmem_transport_ctx_t *ctx, long options, const shmem_session_config_t *config, long config_mask)
 {
     return 0;
 }

--- a/test/spec-example/shmem_session_example.c
+++ b/test/spec-example/shmem_session_example.c
@@ -3,8 +3,8 @@
  */
 
 #include <shmem.h>
-#include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #define N_UPDATES (1lu << 18)
 #define N_INDICES (1lu << 10)
@@ -27,18 +27,18 @@ int main(void) {
       shmem_global_exit(1);
   }
 
-  shmem_config_t config;
+  shmem_session_config_t config;
   long config_mask;
   config.total_ops = N_UPDATES;
   config_mask = SHMEM_SESSION_TOTAL_OPS;
 
-  shmem_session_start(ctx, SHMEM_SESSION_SAME_AMO, config, config_mask);
+  shmem_session_start(ctx, SHMEM_SESSION_SAME_AMO, &config, config_mask);
 
   for (size_t i = 0; i < N_UPDATES; i++) {
       int random_pe = rand() % npes;
       size_t random_idx = rand() % N_INDICES;
       uint64_t random_val = rand() % N_VALUES;
-      shmem_uint64_atomic_xor(ctx, &table[random_idx], random_val, random_pe);
+      shmem_ctx_uint64_atomic_xor(ctx, &table[random_idx], random_val, random_pe);
   }
 
   shmem_session_stop(ctx);

--- a/test/spec-example/shmem_session_example.c
+++ b/test/spec-example/shmem_session_example.c
@@ -1,8 +1,12 @@
+/*                                                                                                                                                                                                                                           *  This test program is derived from an example program in the
+ *  OpenSHMEM specification.
+ */
+
 #include <shmem.h>
 #include <stdint.h>
 #include <stdlib.h>
 
-#define N_UPDATES (1lu << 17)
+#define N_UPDATES (1lu << 18)
 #define N_INDICES (1lu << 10)
 #define N_VALUES  (1lu << 31)
 
@@ -16,17 +20,34 @@ int main(void) {
   int npes = shmem_n_pes();
   srand(mype);
 
-  shmem_session_start(SHMEM_SESSION_UNIFORM_AMO, SHMEM_CTX_DEFAULT);
+  shmem_ctx_t ctx;
+  int ret = shmem_ctx_create(0, &ctx);
+  if (ret != 0) {
+      printf("%d: Error creating context (%d)\n", mype, ret);
+      shmem_global_exit(1);
+  }
+
+  shmem_config_t config;
+  long config_mask;
+  config.total_ops = N_UPDATES;
+  config_mask = SHMEM_SESSION_TOTAL_OPS;
+
+  shmem_session_start(ctx, SHMEM_SESSION_SAME_AMO, config, config_mask);
 
   for (size_t i = 0; i < N_UPDATES; i++) {
       int random_pe = rand() % npes;
       size_t random_idx = rand() % N_INDICES;
       uint64_t random_val = rand() % N_VALUES;
-      shmem_uint64_atomic_xor(&table[random_idx], random_val, random_pe);
+      shmem_uint64_atomic_xor(ctx, &table[random_idx], random_val, random_pe);
   }
 
-  shmem_session_stop(SHMEM_CTX_DEFAULT);
+  shmem_session_stop(ctx);
+  shmem_ctx_quiet(ctx);    /* shmem_session_stop() does not quiet the context. */
+  shmem_sync_all();        /* shmem_session_stop() does not synchronize.       */
 
+  /* At this point, it is safe to check and/or validate the table result... */
+
+  shmem_ctx_destroy(ctx);
   shmem_free(table);
   shmem_finalize();
   return 0;

--- a/test/spec-example/shmem_session_example.c
+++ b/test/spec-example/shmem_session_example.c
@@ -2,7 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#define N_UPDATES (1lu << 18)
+#define N_UPDATES (1lu << 17)
 #define N_INDICES (1lu << 10)
 #define N_VALUES  (1lu << 31)
 

--- a/test/spec-example/shmem_session_example.c
+++ b/test/spec-example/shmem_session_example.c
@@ -1,0 +1,33 @@
+#include <shmem.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define N_UPDATES (1lu << 18)
+#define N_INDICES (1lu << 10)
+#define N_VALUES  (1lu << 31)
+
+int main(void) {
+
+  shmem_init();
+
+  uint64_t *table = shmem_calloc(N_INDICES, sizeof(uint64_t));
+
+  int mype = shmem_my_pe();
+  int npes = shmem_n_pes();
+  srand(mype);
+
+  shmem_session_start(SHMEM_SESSION_UNIFORM_AMO, SHMEM_CTX_DEFAULT);
+
+  for (size_t i = 0; i < N_UPDATES; i++) {
+      int random_pe = rand() % npes;
+      size_t random_idx = rand() % N_INDICES;
+      uint64_t random_val = rand() % N_VALUES;
+      shmem_uint64_atomic_xor(&table[random_idx], random_val, random_pe);
+  }
+
+  shmem_session_stop(SHMEM_CTX_DEFAULT);
+
+  shmem_free(table);
+  shmem_finalize();
+  return 0;
+}


### PR DESCRIPTION
This is an example of bare-minimum support for the OpenSHMEM Sessions proposal (https://github.com/openshmem-org/specification/pull/493).  It's a work-in-progress, and we might prefer to put it in `shmemx`, depending on committee feedback and the spec release timeline.