### PR TITLE
Adding ifdef to enable manual progress

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1155,7 +1155,12 @@ int query_for_fabric(struct fabric_info *info)
                                    for put with signal implementation */
 #endif
     hints.addr_format         = FI_FORMAT_UNSPEC;
+    
+#ifdef ENABLE_MANUAL_PROGRESS
+    domain_attr.data_progress = FI_PROGRESS_MANUAL;
+#else    
     domain_attr.data_progress = FI_PROGRESS_AUTO;
+#endif
     domain_attr.resource_mgmt = FI_RM_ENABLED;
 #ifdef ENABLE_MR_SCALABLE
                                 /* Scalable, offset-based addressing, formerly FI_MR_SCALABLE */


### PR DESCRIPTION
Adding an #ifdef statement that will set the domain_attr.data_progress value to FI_PROGRESS_MANUAL when --enable-manual-progress is used as a configure option.

Without this #ifdef, domain_attr.data_progress is always set to FI_PROGRESS_AUTO even if --enable-manual-progress is specified.


Signed-off-by: tmh97 <thomas.huber@cornelis.networks.com>