### PR TITLE
Add support for a SHMEMX_NO_BARRIER hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,6 @@ config/test-driver
 mpp/shmem.fh
 mpp/shmem.h
 mpp/shmem.h4
-mpp/shmemx.h4
-mpp/pshmem.h4
 mpp/shmemx.fh
 mpp/shmemx.h
 mpp/shmem_c_func.h4

--- a/mpp/pshmem.h4
+++ b/mpp/pshmem.h4
@@ -14,10 +14,6 @@ dnl vi: set ft=m4
  *
  */
 
-/*
- * This is a generated file, do not edit directly.
- */
-
 include(shmem_bind_c.m4)dnl
 #ifndef PSHMEM_H
 #define PSHMEM_H

--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -74,7 +74,7 @@ extern "C" {
 
 #define SHMEM_MALLOC_ATOMICS_REMOTE   (1l<<0)
 #define SHMEM_MALLOC_SIGNAL_REMOTE    (1l<<1)
-#define SHMEMX_MALLOC_NO_BARRIER      (1l<<2)
+/* MAX_HINTS value includes the SHMEMX constant(s) in shmemx-def.h */
 #define SHMEM_MALLOC_MAX_HINTS        ((1l<<3) - 1)
 
 /* Contexts */

--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -74,7 +74,7 @@ extern "C" {
 
 #define SHMEM_MALLOC_ATOMICS_REMOTE   (1l<<0)
 #define SHMEM_MALLOC_SIGNAL_REMOTE    (1l<<1)
-/* MAX_HINTS value includes the SHMEMX constant(s) in shmemx-def.h */
+/* MAX_HINTS value includes the SHMEMX constant(s) in shmemx.h4 */
 #define SHMEM_MALLOC_MAX_HINTS        ((1l<<3) - 1)
 
 /* Contexts */

--- a/mpp/shmem-def.h.in
+++ b/mpp/shmem-def.h.in
@@ -74,7 +74,8 @@ extern "C" {
 
 #define SHMEM_MALLOC_ATOMICS_REMOTE   (1l<<0)
 #define SHMEM_MALLOC_SIGNAL_REMOTE    (1l<<1)
-#define SHMEM_MALLOC_MAX_HINTS        ((1l<<2) - 1)
+#define SHMEMX_MALLOC_NO_BARRIER      (1l<<2)
+#define SHMEM_MALLOC_MAX_HINTS        ((1l<<3) - 1)
 
 /* Contexts */
 typedef struct shmem_impl_ctx_t { int dummy; } * shmem_ctx_t;

--- a/mpp/shmemx-def.h
+++ b/mpp/shmemx-def.h
@@ -22,9 +22,6 @@ typedef struct {
     uint64_t target;
 } shmemx_pcntr_t;
 
-/* SHMEMX constant(s) are included in MAX_HINTS value in shmem-def.h */
-#define SHMEMX_MALLOC_NO_BARRIER (1l<<2)
-
 #ifdef __cplusplus
 }
 #endif

--- a/mpp/shmemx-def.h
+++ b/mpp/shmemx-def.h
@@ -22,6 +22,9 @@ typedef struct {
     uint64_t target;
 } shmemx_pcntr_t;
 
+/* SHMEMX constant(s) are included in MAX_HINTS value in shmem-def.h */
+#define SHMEMX_MALLOC_NO_BARRIER (1l<<2)
+
 #ifdef __cplusplus
 }
 #endif

--- a/mpp/shmemx.h4
+++ b/mpp/shmemx.h4
@@ -35,15 +35,15 @@ include(shmemx_c_func.h4)dnl
 /* Option to enable bounce buffering on a given context */
 #define SHMEMX_CTX_BOUNCE_BUFFER  (1l<<31)
 
+/* SHMEMX constant(s) are included in MAX_HINTS value in shmem-def.h */
+#define SHMEMX_MALLOC_NO_BARRIER (1l<<2)
+
 /* C++ overloaded declarations */
 #ifdef __cplusplus
 } /* extern "C" */
 
 /* C11 Generic Macros */
 #elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(SHMEM_INTERNAL_INCLUDE))
-
-/* SHMEMX constant(s) are included in MAX_HINTS value in shmem-def.h */
-#define SHMEMX_MALLOC_NO_BARRIER (1l<<2)
 
 #endif /* C11 */
 

--- a/mpp/shmemx.h4
+++ b/mpp/shmemx.h4
@@ -14,10 +14,6 @@ dnl vi: set ft=m4
  *
  */
 
-/*
- * This is a generated file, do not edit directly.
- */
-
 include(shmem_bind_c.m4)dnl
 include(shmem_bind_c11.m4)dnl
 include(shmem_bind_cxx.m4)dnl
@@ -45,6 +41,9 @@ include(shmemx_c_func.h4)dnl
 
 /* C11 Generic Macros */
 #elif (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(SHMEM_INTERNAL_INCLUDE))
+
+/* SHMEMX constant(s) are included in MAX_HINTS value in shmem-def.h */
+#define SHMEMX_MALLOC_NO_BARRIER (1l<<2)
 
 #endif /* C11 */
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -426,7 +426,8 @@ shmem_malloc_with_hints(size_t size, long hints)
     ret = dlmalloc(size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all();
+    if (!(hints & SHMEMX_MALLOC_NO_BARRIER))
+        shmem_internal_barrier_all();
 
     return ret;
 }

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -20,7 +20,7 @@ endif
 
 if SHMEMX_TESTS
 check_PROGRAMS += \
-	perf_counter \
+    perf_counter \
     shmem_malloc_with_hints
 
 if HAVE_PTHREADS

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -20,7 +20,8 @@ endif
 
 if SHMEMX_TESTS
 check_PROGRAMS += \
-	perf_counter
+	perf_counter \
+    shmem_malloc_with_hints
 
 if HAVE_PTHREADS
 check_PROGRAMS += \

--- a/test/shmemx/shmem_malloc_with_hints.c
+++ b/test/shmemx/shmem_malloc_with_hints.c
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <shmem.h>
+
+#define N 128
+#define SHMEM_MALLOC_INVALID_HINT ~(SHMEM_MALLOC_ATOMICS_REMOTE)
+
+int main(int argc, char **argv) {
+    int npes, mype;
+    int errors = 0;
+
+    shmem_init();
+
+    npes = shmem_n_pes();
+    mype = shmem_my_pe();
+
+    int *src = (int *)shmem_malloc_with_hints(N * sizeof(int), SHMEMX_MALLOC_NO_BARRIER);
+    int *dst = (int *)shmem_malloc(N * sizeof(int));
+
+    for (int i = 0; i < N; i++) {
+        src[i] = i;
+        dst[i] = -1;
+    }
+
+    shmem_sync_all();  /* sync sender and receiver */
+
+    if (shmem_my_pe() == 0) {
+        /* put N elements into dst on PE 1 */
+        shmem_int_put(dst, src, N, 1);
+    }
+
+    shmem_barrier_all();  /* sync sender and receiver */
+
+    if (shmem_my_pe() == 1) {
+        for (int i = 0 ; i < N ; ++i) {
+            if (src[i] != dst[i]) {
+                //fprintf(stderr,"[%d] src & dst mismatch?\n",shmem_my_pe());
+                printf("%d,%d ", src[i], dst[i]);
+                ++errors;
+            }
+        }
+        printf("\n");
+        if(errors) {
+            printf("Failed with %d errors\n", errors);
+            shmem_global_exit(errors);
+        }
+    }
+
+    shmem_free(src);
+    shmem_free(dst);
+
+    if (shmem_my_pe() == 0)
+        printf("Passed with 0 errors\n");
+
+    shmem_finalize();
+        
+    return 0;
+}

--- a/test/shmemx/shmem_malloc_with_hints.c
+++ b/test/shmemx/shmem_malloc_with_hints.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <shmem.h>
+#include <shmemx.h>
 
 #define N 128
 #define SHMEM_MALLOC_INVALID_HINT ~(SHMEM_MALLOC_ATOMICS_REMOTE)

--- a/test/unit/shmem_malloc_with_hints.c
+++ b/test/unit/shmem_malloc_with_hints.c
@@ -88,12 +88,13 @@ int main(int argc, char **argv) {
     passed += sumtoall_with_malloc_hint(SHMEM_MALLOC_ATOMICS_REMOTE | SHMEM_MALLOC_SIGNAL_REMOTE, mype, npes);
     passed += sumtoall_with_malloc_hint(SHMEM_MALLOC_INVALID_HINT, mype, npes);
 
-
     fail = NUM_TESTS - passed;
 
     if (mype == 0) {
-        if (passed != NUM_TESTS)
-            printf("%d out of %d tests passed\n", fail, NUM_TESTS);
+        if (passed != NUM_TESTS) {
+            printf("%d out of %d tests failed\n", fail, NUM_TESTS);
+            shmem_global_exit(fail);
+        }
         else
             printf("All %d tests passed\n", passed);
     }


### PR DESCRIPTION
Implemented a SHMEMX_NO_BARRIER hint for shmem_malloc_with_hints. This hint provides users with a way to bypass the barrier that occurs from within a shmem_malloc. Also, added a unit test for this hint.