### PR TITLE
OFI MR flags selection based on the provider 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,13 +194,15 @@ AM_CONDITIONAL([HAVE_LONG_FORTRAN_HEADER], [test "$enable_long_fortran_header" =
 
 AC_ARG_ENABLE([ofi-mr],
     [AC_HELP_STRING([--enable-ofi-mr=MODE],
-                    [OFI memory registration mode: basic, scalable, or rma-event (default: scalable)])])
+                    [OFI memory registration mode: none, basic, scalable, or rma-event (default: none)])])
 
-AS_IF([test -z "$enable_ofi_mr"], [enable_ofi_mr="scalable"])
+AS_IF([test -z "$enable_ofi_mr"], [enable_ofi_mr="none"])
 
 AS_CASE([$enable_ofi_mr],
+        [none],
+            [AC_DEFINE([ENABLE_MR_NONE], [1], [If defined, the OFI transport will use MR mode based on provider])],
         [basic],
-            [],
+            [AC_DEFINE([ENABLE_MR_BASIC], [1], [If defined, the OFI transport will use FI_MR_BASIC])],
         [scalable],
             [AC_DEFINE([ENABLE_MR_SCALABLE], [1], [If defined, the OFI transport will use FI_MR_SCALABLE])],
         [rma?event],

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -87,8 +87,6 @@ SHMEM_INTERNAL_ENV_DEF(OFI_ATOMIC_CHECKS_WARN, bool, false, SHMEM_INTERNAL_ENV_C
                        "Display warnings about unsupported atomic operations")
 SHMEM_INTERNAL_ENV_DEF(OFI_PROVIDER, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Provider that should be used by the OFI transport")
-SHMEM_INTERNAL_ENV_DEF(OFI_USE_PROVIDER, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
-                       "Deprecated, replaced by SHMEM_OFI_PROVIDER")
 SHMEM_INTERNAL_ENV_DEF(OFI_FABRIC, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Fabric that should be used by the OFI transport")
 SHMEM_INTERNAL_ENV_DEF(OFI_DOMAIN, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSPORT,

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -46,7 +46,7 @@ extern struct fid_cntr*                 shmem_transport_ofi_target_cntrfd;
 #if ENABLE_MANUAL_PROGRESS
 extern struct fid_cq*                   shmem_transport_ofi_target_cq;
 #endif
-#ifndef ENABLE_MR_SCALABLE
+
 extern uint64_t*                        shmem_transport_ofi_target_heap_keys;
 extern uint64_t*                        shmem_transport_ofi_target_data_keys;
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
@@ -55,7 +55,6 @@ extern int                              shmem_transport_ofi_use_absolute_address
 extern uint8_t**                        shmem_transport_ofi_target_heap_addrs;
 extern uint8_t**                        shmem_transport_ofi_target_data_addrs;
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
-#endif /* ENABLE_MR_SCALABLE */
 extern uint64_t                         shmem_transport_ofi_max_poll;
 extern long                             shmem_transport_ofi_put_poll_limit;
 extern long                             shmem_transport_ofi_get_poll_limit;
@@ -65,6 +64,8 @@ extern size_t                           shmem_transport_ofi_bounce_buffer_size;
 extern long                             shmem_transport_ofi_max_bounce_buffers;
 
 extern pthread_mutex_t                  shmem_transport_ofi_progress_lock;
+
+static int                              shmem_transport_ofi_mr_mode = 0;
 
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -118,73 +119,70 @@ extern pthread_mutex_t                  shmem_transport_ofi_progress_lock;
     } while (0)
 
 
-#ifdef ENABLE_MR_SCALABLE
 static inline
 void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
                                 uint8_t **mr_addr, uint64_t *key) {
+
+    if (shmem_transport_ofi_mr_mode == 0) {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    *key = 0;
-    *mr_addr = (uint8_t*) addr;
+        *key = 0;
+        *mr_addr = (uint8_t*) addr;
 #else
-    if ((void*) addr >= shmem_internal_data_base &&
-        (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
+        if ((void*) addr >= shmem_internal_data_base &&
+            (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
 
-        *key = 0;
-        *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
+            *key = 0;
+            *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
 
-    } else if ((void*) addr >= shmem_internal_heap_base &&
-               (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
+        } else if ((void*) addr >= shmem_internal_heap_base &&
+                   (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
 
-        *key = 1;
-        *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
-    } else {
-        *key = 0;
-        *mr_addr = NULL;
-        RAISE_ERROR_MSG("address (%p) outside of symmetric areas\n", addr);
-    }
+            *key = 1;
+            *mr_addr = (uint8_t*) ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
+        } else {
+            *key = 0;
+            *mr_addr = NULL;
+            RAISE_ERROR_MSG("address (%p) outside of symmetric areas\n", addr);
+        }
 #endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 
-}
-
-#else
-static inline
-void shmem_transport_ofi_get_mr(const void *addr, int dest_pe,
-                                uint8_t **mr_addr, uint64_t *key) {
-    if ((void*) addr >= shmem_internal_data_base &&
-        (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
-        *key = shmem_transport_ofi_target_data_keys[dest_pe];
-#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-        if (shmem_transport_ofi_use_absolute_address)
-            *mr_addr = (uint8_t *) addr;
-        else
-            *mr_addr = (void *) ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
-#else
-        *mr_addr = shmem_transport_ofi_target_data_addrs[dest_pe] +
-            ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
-#endif
     }
-
-    else if ((void*) addr >= shmem_internal_heap_base &&
-             (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
-        *key = shmem_transport_ofi_target_heap_keys[dest_pe];
-#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-        if (shmem_transport_ofi_use_absolute_address)
-            *mr_addr = (uint8_t *) addr;
-        else
-            *mr_addr = (void *) ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
-#else
-        *mr_addr = shmem_transport_ofi_target_heap_addrs[dest_pe] +
-            ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
-#endif
-    }
-
     else {
-        *key = -1;
-        *mr_addr = NULL;
-        RAISE_ERROR_MSG("address (%p) outside of symmetric areas\n", addr);
+        if ((void*) addr >= shmem_internal_data_base &&
+            (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
+            *key = shmem_transport_ofi_target_data_keys[dest_pe];
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+            if (shmem_transport_ofi_use_absolute_address)
+                *mr_addr = (uint8_t *) addr;
+            else
+                *mr_addr = (void *) ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
+#else
+            *mr_addr = shmem_transport_ofi_target_data_addrs[dest_pe] +
+                ((uint8_t *) addr - (uint8_t *) shmem_internal_data_base);
+#endif
+        }
+
+        else if ((void*) addr >= shmem_internal_heap_base &&
+                 (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
+            *key = shmem_transport_ofi_target_heap_keys[dest_pe];
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+            if (shmem_transport_ofi_use_absolute_address)
+                *mr_addr = (uint8_t *) addr;
+            else
+                *mr_addr = (void *) ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
+#else
+            *mr_addr = shmem_transport_ofi_target_heap_addrs[dest_pe] +
+                ((uint8_t *) addr - (uint8_t *) shmem_internal_heap_base);
+#endif
+        }
+
+        else {
+            *key = -1;
+            *mr_addr = NULL;
+            RAISE_ERROR_MSG("address (%p) outside of symmetric areas\n", addr);
+        }
     }
 }
-#endif
 
 /* Datatypes */
 extern int shmem_transport_dtype_table[];


### PR DESCRIPTION
For most of the OFI providers, SOS uses a specific MR mode selection. However, user still has the option to select a different mode that may not be supported. This is an attempt to select the MR mode based on the provider by default. User may still choose a different mode during configuration.