### PR TITLE
Moving Cornelis License from bottom to top, adding to transport_ofi, …

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,10 @@ Copyright 2011 Sandia Corporation. Under the terms of Contract
 DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
 retains certain rights in this software.
 
-Copyright (c) 2017 Intel Corporation. All rights reserved.
+Copyright (c) 2022 Intel Corporation. All rights reserved.
+
+Copyright (c) 2022 Cornelis Networks, Inc. All rights reserved.
+
 This software is available to you under the BSD license.
 
 COPYRIGHT
@@ -252,13 +255,5 @@ INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
 AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
 ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
 PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS."
-
-======================================================================
-
-Cornelis Network's contributions to the OFI transport layer are under the 
-following license:
-
-Copyright (c) 2022 Cornelis Networks, Inc. All rights reserved. This software
-is available to you under the BSD license.
 
 ======================================================================

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1,6 +1,9 @@
 /* -*- C -*-
  *
- * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2022 Intel Corporation. All rights reserved.
+ *
+ * Copyright (c) 2022 Cornelis Networks, Inc. All rights reserved.
+ *
  * This software is available to you under the BSD license.
  *
  * This file is part of the Sandia OpenSHMEM software package. For license


### PR DESCRIPTION
…updating intel dates

This pull request addresses conversation that occured on already merged pull request-> https://github.com/Sandia-OpenSHMEM/SOS/pull/1070

- Moving Cornelis copyright in LICENSE from the bottom to near the top
- Adding Cornelis copyright in src/transport_ofi.c where we (OPX) have previously made changes to disable bounce buffering when using FI_CONTEXT2
- Updating Intel Copyright dates for @davidozog 

@davidozog @jdinan let me know how this looks, more than happy to make changes if need be :) 

Signed-off-by: Thomas Huber <thomas.huber@cornelisnetworks.com>