### PR TITLE
Setting the rx capabilites and tx capabilites to 0

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1290,6 +1290,8 @@ static int shmem_transport_ofi_target_ep_init(void)
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;
+    info->p_info->tx_attr->caps = 0;
+    info->p_info->rx_attr->caps = 0;
 
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_target_ep, NULL);
@@ -1353,6 +1355,8 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;
+    info->p_info->tx_attr->caps = 0;
+    info->p_info->rx_attr->caps = 0;
 
     ctx->id = id;
 #ifdef USE_CTX_LOCK

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1355,8 +1355,8 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;
-    info->p_info->tx_attr->caps = 0;
-    info->p_info->rx_attr->caps = 0;
+    info->p_info->tx_attr->caps = info->p_info->caps;
+    info->p_info->rx_attr->caps = FI_RECV; /* to drive progress on the CQ */;
 
     ctx->id = id;
 #ifdef USE_CTX_LOCK

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1290,8 +1290,8 @@ static int shmem_transport_ofi_target_ep_init(void)
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;
-    info->p_info->tx_attr->caps = 0;
-    info->p_info->rx_attr->caps = 0;
+    info->p_info->tx_attr->caps = FI_RMA | FI_ATOMIC;
+    info->p_info->rx_attr->caps = info->p_info->caps;
 
     ret = fi_endpoint(shmem_transport_ofi_domainfd,
                       info->p_info, &shmem_transport_ofi_target_ep, NULL);


### PR DESCRIPTION
Signed-off-by: Thomas Huber <thomas.huber@cornelisnetworks.com>

In `transport_ofi.c` there are two instances of behavior that might be a small violation of the libfabric man pages. Both instances are related to setting the capabilites (caps) for tx_attr->caps and rx_attr->caps

1. In function `shmem_trasnport_ofi_target_ep_init(void)`
- The general caps are set to `info->p_info->caps = FI_RMA | FI_ATOMIC | FI_REMOTE_READ | FI_REMOTE_WRITE` which overwrites whatever what returned in call to `get_info()`
- Meanwhile, the `info->p_info->tx_attr->caps` are still set to whatever was returned by `get_info()`
- Following this, calls to `fi_endpoint()`, `fi_cq_open_fi_ep_bind()`, and `fi_enable()` are made
- In the manpages for `fi_endpoint()` https://ofiwg.github.io/libfabric/v1.12.0/man/fi_endpoint.3.html under the section **Transmit Context Attributes** is the following:  **The capabilities must be a subset of those requested of the associated endpoint**
- Also stated in the manpages is: "The following capabilities apply to the transmit attributes: `FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_READ, FI_WRITE, FI_SEND, FI_HMEM, FI_TRIGGER, FI_FENCE, FI_MULTICAST, FI_RMA_PMEM, FI_NAMED_RX_CTX, and FI_COLLECTIVE.`"
- I believe the proper way to resolve this manpage violation is to set the `tx_attr->caps `to 0, resulting in `tx_attr->caps` being a subset of the general caps
- Alternatively, another option would be to bitwise OR  the capabilities that apply to transmit attributes (`FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_READ, FI_WRITE, FI_SEND, FI_HMEM, FI_TRIGGER, FI_FENCE, FI_MULTICAST, FI_RMA_PMEM, FI_NAMED_RX_CTX, and FI_COLLECTIVE`) with the capabilities that SOS sets in this function (` FI_RMA | FI_ATOMIC | FI_REMOTE_READ | FI_REMOTE_WRITE`) which would result in` tx_attr->caps = FI_RMA | FI_ATOMIC`

2. In function `shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)` the (almost) exact same situation exists
- The general caps are set to `info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC;` **which is slightly different than the behavior of the above function**
- The same violation occurs
- I believe the proper way to resolve this manpage violation is to set the` tx_attr->caps` to 0, resulting in` tx_attr->caps `being a subset of the general caps
- Alternatively, another option would be to bitwise OR the the capabilities that apply to transmit attributes (`FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_READ, FI_WRITE, FI_SEND, FI_HMEM, FI_TRIGGER, FI_FENCE, FI_MULTICAST, FI_RMA_PMEM, FI_NAMED_RX_CTX, and FI_COLLECTIVE`) with the capabilities that SOS sets in this function (` FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC`) which would result in `tx_attr->caps = FI_RMA | FI_ATOMIC | FI_READ | FI_WRITE `**slightly different from behavior of the above function**
