### PR TITLE
Malloc with varsize (option 1) implementation

### DIFF
--- a/mpp/shmemx_c_func.h4
+++ b/mpp/shmemx_c_func.h4
@@ -36,4 +36,4 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_completed_target(uint64_t
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_all(shmem_ctx_t ctx, shmemx_pcntr_t *pcntr);
 
 SHMEM_FUNCTION_ATTRIBUTES void* SHPRE()shmemx_malloc_varsize(size_t my_size, size_t global_max_size);
-SHMEM_FUNCTION_ATTRIBUTES void* SHPRE()shmemx_calloc_varsize(size_t my_count, size_t my_size, size_t global_max_count, size_t global_max_size);
+SHMEM_FUNCTION_ATTRIBUTES void* SHPRE()shmemx_calloc_varsize(size_t my_count, size_t size, size_t global_max_count);

--- a/mpp/shmemx_c_func.h4
+++ b/mpp/shmemx_c_func.h4
@@ -34,3 +34,6 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_completed_write(shmem_ctx
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_completed_read(shmem_ctx_t ctx, uint64_t *cntr_value);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_completed_target(uint64_t *cntr_value);
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_pcntr_get_all(shmem_ctx_t ctx, shmemx_pcntr_t *pcntr);
+
+SHMEM_FUNCTION_ATTRIBUTES void* SHPRE()shmemx_malloc_varsize(size_t my_size, size_t global_max_size);
+SHMEM_FUNCTION_ATTRIBUTES void* SHPRE()shmemx_calloc_varsize(size_t my_count, size_t my_size, size_t global_max_count, size_t global_max_size);

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -310,8 +310,8 @@ shmemx_malloc_varsize(size_t my_size, size_t global_max_size)
     shmem_internal_assertp(my_size <= global_max_size);
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
-    ret = dlmalloc(my_size);
-    shmem_internal_get_next((intptr_t) (global_max_size - my_size)); 
+    ret = dlmemalign((size_t) 64, global_max_size);
+    munmap((void *)((uintptr_t) ret + my_size), (size_t) (global_max_size - my_size));
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
     shmem_internal_barrier_all();

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -310,7 +310,8 @@ shmemx_malloc_varsize(size_t my_size, size_t global_max_size)
     shmem_internal_assertp(my_size <= global_max_size);
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
-    ret = dlmalloc(global_max_size);
+    ret = dlmalloc(my_size);
+    shmem_internal_get_next((intptr_t) (global_max_size - my_size)); 
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
     shmem_internal_barrier_all();
@@ -339,19 +340,19 @@ shmem_calloc(size_t count, size_t size)
 
 
 void SHMEM_FUNCTION_ATTRIBUTES *
-shmemx_calloc_varsize(size_t my_count, size_t my_size, size_t global_max_count, size_t global_max_size)
+shmemx_calloc_varsize(size_t my_count, size_t size, size_t global_max_count)
 {
     void *ret = NULL;
 
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    if (global_max_size == 0 || global_max_count == 0) return ret;
+    if (size == 0 || global_max_count == 0) return ret;
 
-    shmem_internal_assertp(my_size <= global_max_size);
     shmem_internal_assertp(my_count <= global_max_count);
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
-    ret = dlcalloc(global_max_count, global_max_size);
+    ret = dlcalloc(my_count, size);
+    shmem_internal_get_next((intptr_t) ((global_max_count - my_count) * size));
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
     shmem_internal_barrier_all();

--- a/test/shmemx/Makefile.am
+++ b/test/shmemx/Makefile.am
@@ -20,6 +20,7 @@ endif
 
 if SHMEMX_TESTS
 check_PROGRAMS += \
+	shmemx_malloc_varsize
 	perf_counter
 
 if HAVE_PTHREADS

--- a/test/shmemx/shmemx_malloc_varsize.c
+++ b/test/shmemx/shmemx_malloc_varsize.c
@@ -38,39 +38,66 @@ int main(int argc, char *argv[]) {
   int me = shmem_my_pe();
   int npes = shmem_n_pes();
 
-  int *var_alloc = (int *) shmemx_malloc_varsize((me + 1) * sizeof(int), npes * sizeof(int));
+  int *symm_malloc_1 = (int *) shmem_malloc(npes * sizeof(int));
+  int *var_alloc = (int *) shmemx_malloc_varsize((me + 1) * 1024 * 1024 * sizeof(int), npes * 1024 * 1024 * sizeof(int));
+  int *symm_malloc_2 = (int *) shmem_malloc(npes * sizeof(int));
+
   int *src = (int *) malloc((me + 1) * sizeof(int));
-  int *symm_malloc = (int *) shmem_malloc(npes * sizeof(int));
-  if (!var_alloc || !src || !symm_malloc) {
+
+  if (!var_alloc || !src || !symm_malloc_1 || !symm_malloc_2) {
     fprintf(stdout, "malloc failed\n");
     ret = -1;
     goto fn_end;
   }
 
+  fprintf(stdout, "[PE %d]: symm_1 %p, var %p, symm_2 %p\n", me, symm_malloc_1, var_alloc, symm_malloc_2);
+
   for (i = 0; i <= me; i++) {
     src[i] = me + 1 + i;
+    var_alloc[i] = 0;
   }
 
 
   shmem_barrier_all();
-
-  shmem_int_put(var_alloc, src, (me + 1) % npes, (me + 1) % npes);
-
+  shmem_int_put(var_alloc, src, ((me + 1) % npes) + 1, (me + 1) % npes);
   shmem_barrier_all();
 
-  if (me != 0) {
-    for (i = 0; i < me; i++) {
-      if (var_alloc[i] != (me + i)) {
-        errors++;
-        fprintf(stdout, "[PE %d]: Invalid data found at %d is %d\n", me, i, var_alloc[i]);
-      }
+  for (i = 0; i < me; i++) {
+    if (var_alloc[i] != (me + i)) {
+      errors++;
+      fprintf(stdout, "[PE %d]: Invalid data found for var_alloc at %d is %d\n", me, i, var_alloc[i]);
     }
   }
   ret = errors;
 
-  shmem_free(symm_malloc);
+  shmem_int_put(symm_malloc_1, src, ((me + 1) % npes) + 1, (me + 1) % npes);
+  shmem_barrier_all();
+
+  for (i = 0; i < me; i++) {
+    if (symm_malloc_1[i] != (me + i)) {
+      errors++;
+      fprintf(stdout, "[PE %d]: Invalid data found for symm_malloc_1 at %d is %d\n", me, i, symm_malloc_1[i]);
+    }
+  }
+  ret = errors;
+
+  shmem_int_put(symm_malloc_2, src, ((me + 1) % npes) + 1, (me + 1) % npes);
+  shmem_barrier_all();
+
+  for (i = 0; i < me; i++) {
+    if (symm_malloc_2[i] != (me + i)) {
+      errors++;
+      fprintf(stdout, "[PE %d]: Invalid data found for symm_malloc_2 at %d is %d\n", me, i, symm_malloc_2[i]);
+    }
+  }
+  ret = errors;
+
+  shmem_free(symm_malloc_1);
   free(src);
   shmem_free(var_alloc);
+  shmem_free(symm_malloc_2);
+
+  if (ret == 0) fprintf(stdout, "[PE %d] TEST SUCCESS\n", me);
  
 fn_end:
   shmem_finalize();

--- a/test/shmemx/shmemx_malloc_varsize.c
+++ b/test/shmemx/shmemx_malloc_varsize.c
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *  This software is available to you under the BSD license below:
+ *
+ *      Redistribution and use in source and binary forms, with or
+ *      without modification, are permitted provided that the following
+ *      conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <shmem.h>
+#include <shmemx.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  int ret = 0, i, errors = 0;
+
+  shmem_init();
+
+  int me = shmem_my_pe();
+  int npes = shmem_n_pes();
+
+  int *var_alloc = (int *) shmemx_malloc_varsize((me + 1) * sizeof(int), npes * sizeof(int));
+  int *src = (int *) malloc((me + 1) * sizeof(int));
+  if (!var_alloc || !src) {
+    fprintf(stdout, "malloc failed\n");
+    ret = -1;
+    goto fn_end;
+  }
+
+  for (i = 0; i <= me; i++) {
+    src[i] = me + 1 + i;
+  }
+
+  shmem_barrier_all();
+
+  shmem_int_put(var_alloc, src, me + 1, (me + 1) % npes);
+
+  shmem_barrier_all();
+
+  if (!me) {
+    for (i = 0; i < npes; i++) {
+      if (var_alloc[i] != npes + i) {
+        errors++;
+        fprintf(stdout, "Invalid data found at %d is %d, expected %d\n", i, var_alloc[i], npes + i);
+      }
+    }
+  }
+  ret = errors;
+
+  shmem_free(var_alloc);
+fn_end:
+  shmem_finalize();
+  return ret;
+}


### PR DESCRIPTION
This is a test PR for malloc varsize implementation with the following syntax:
```
void *shmem_malloc_varsize (size_t size, size_t global_max_size);
void *shmem_calloc_varsize (size_t count, size_t global_size, size_t global_max_count);
```
