### PR TITLE
Update version to v1.5.2rc1 in configure.ac, NEWS file, and simple build script

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,25 @@
 
 Sandia OpenSHMEM NEWS -- history of user-visible changes.
 
+v1.5.2rc1
+---------
+
+- Added support for the CXI libfabric provider, enabling SOS on the Slingshot
+  interconnect.  Setup instructions are on SOS's Github wiki.
+- Added support for shmem_team_ptr routine.
+- Added support for negatives strides in the OpenSHMEM teams APIs.
+- Added checks for incorrect buffer overlap when error-checking is enabled.
+- Added a configure option to enable deprecated tests,
+  --enable-deprecated-tests, which is disabled by default.
+- Added a configure option to enable libfabric manual progress,
+  --enable-ofi-manual-progress, which is disabled by default.
+- Added experimental support for a hint to shmem_malloc_with_hints,
+  SHMEMX_MALLOC_NO_BARRIER, which removes the barrier at exit from the routine.
+  Users must synchronize appropriately after such an operation.
+- Initialized the OFI tx/rx capabilities appropriately to limit what is enabled
+  by providers. This resolves an issue the Omni-Path Express (opx) provider.
+- Patched the symmetric data segment initialization to better support MacOS.
+
 v1.5.1
 ------
 

--- a/NEWS
+++ b/NEWS
@@ -18,7 +18,7 @@ v1.5.2rc1
   SHMEMX_MALLOC_NO_BARRIER, which removes the barrier at exit from the routine.
   Users must synchronize appropriately after such an operation.
 - Initialized the OFI tx/rx capabilities appropriately to limit what is enabled
-  by providers. This resolves an issue the Omni-Path Express (opx) provider.
+  by providers. This resolves an issue with the Omni-Path Express (opx) provider.
 - Patched the symmetric data segment initialization to better support MacOS.
 
 v1.5.1

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@
 
 dnl Init Autoconf/Automake/Libtool
 
-AC_INIT([Sandia OpenSHMEM], [1.5.1], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
+AC_INIT([Sandia OpenSHMEM], [1.5.2rc1], [https://github.com/Sandia-OpenSHMEM/SOS/issues], [sandia-openshmem], [https://github.com/Sandia-OpenSHMEM/SOS])
 AC_PREREQ([2.60])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_MACRO_DIR([config])

--- a/scripts/simple-build-ofi.sh
+++ b/scripts/simple-build-ofi.sh
@@ -13,10 +13,10 @@
 set -e
 
 if [ -z "$SOS_VERSION" ] ; then
-    SOS_VERSION="v1.5.0"
+    SOS_VERSION="v1.5.1"
 fi
 if [ -z "$OFI_VERSION" ] ; then
-    OFI_VERSION="v1.14.0"
+    OFI_VERSION="v1.14.x"
 fi
 
 HYDRA_URL="http://www.mpich.org/static/downloads/3.2.1/hydra-3.2.1.tar.gz"


### PR DESCRIPTION
This updates the version number according to the [Release Checklist](https://github.com/Sandia-OpenSHMEM/SOS/wiki/Release-Checklist) for v1.5.2 release candidate 1.

After it's merged, I'll tag the repository with v1.5.2rc1.