### PR TITLE
tests: Replace shmemx_wtime() with tests_sos_wtime

### DIFF
--- a/test/include/Makefile.am
+++ b/test/include/Makefile.am
@@ -13,4 +13,5 @@
 
 noinst_HEADERS = \
 	uthash.h \
-	pthread_barrier.h
+	pthread_barrier.h \
+	tests_sos/wtime.h

--- a/test/include/tests_sos/wtime.h
+++ b/test/include/tests_sos/wtime.h
@@ -14,6 +14,7 @@
 
 /* This is the same implementation as shmemx_wtime() in SOS, but is provided
  * for the convenience of implementations that do not define shmemx_wtime() */
+#ifndef HAVE_SHMEMX_WTIME
 static inline double tests_sos_wtime(void)
 {
     double wtime = 0.0;
@@ -31,3 +32,9 @@ static inline double tests_sos_wtime(void)
 #endif
     return wtime;
 }
+#else
+static inline double tests_sos_wtime(void)
+{
+    return shmemx_wtime();
+}
+#endif /* HAVE_SHMEMX_WTIME */

--- a/test/include/tests_sos/wtime.h
+++ b/test/include/tests_sos/wtime.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011 Sandia Corporation. Under the terms of Contract
+ * DE-AC04-94AL85000 with Sandia Corporation, the U.S.  Government
+ * retains certain rights in this software.
+ *
+ * Copyright (c) 2023 Intel Corporation. All rights reserved.
+ * This software is available to you under the BSD license.
+ *
+ * This file is part of the Sandia OpenSHMEM software package. For license
+ * information, see the LICENSE file in the top level directory of the
+ * distribution. */
+
+#include <sys/time.h>
+
+/* This is the same implementation as shmemx_wtime() in SOS, but is provided
+ * for the convenience of implementations that do not define shmemx_wtime() */
+static inline double tests_sos_wtime(void)
+{
+    double wtime = 0.0;
+
+#ifdef HAVE_CLOCK_GETTIME
+    struct timespec tv;
+    clock_gettime(CLOCK_MONOTONIC, &tv);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_nsec / 1.0e9;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    wtime = tv.tv_sec;
+    wtime += (double)tv.tv_usec / 1.0e6;
+#endif
+    return wtime;
+}

--- a/test/unit/bcast_flood.c
+++ b/test/unit/bcast_flood.c
@@ -39,18 +39,10 @@
 #include <assert.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 static int atoi_scaled(char *s);
 static void usage(char *pgm);
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 int Verbose=0;
 int Serialize;
@@ -141,13 +133,13 @@ main(int argc, char **argv)
 
     for(time_taken = 0.0, i = 0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_broadcast(SHMEM_TEAM_WORLD, target, source, elements, 0);
 
         if (Serialize) shmem_barrier_all();
 
-        time_taken += (shmemx_wtime() - start_time);
+        time_taken += (tests_sos_wtime() - start_time);
 
     }
 

--- a/test/unit/bigget.c
+++ b/test/unit/bigget.c
@@ -40,7 +40,7 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define NUM_ELEMENTS 4194304 // 32 MB by longs
 //#define DFLT_LOOPS 10000
@@ -72,13 +72,6 @@ atoi_scaled(char *s)
     return (int)val;
 }
 
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 static void
 usage(char *pgm)
@@ -197,11 +190,11 @@ main(int argc, char **argv)
 
     for(i=0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_get( Target, Source, elements, target_pe );
 
-        time_taken += shmemx_wtime() - start_time;
+        time_taken += tests_sos_wtime() - start_time;
 
         if (me==0) {
             if ( Track && i > 0 && ((i % 200) == 0))

--- a/test/unit/bigput.c
+++ b/test/unit/bigput.c
@@ -40,7 +40,7 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define NUM_ELEMENTS 4194304 // 32 MB by longs
 //#define DFLT_LOOPS 10000  // reset when Portals4 can achieve this.
@@ -86,14 +86,6 @@ usage(char *pgm)
         pgm,NUM_ELEMENTS,DFLT_LOOPS);
 }
 
-#if !defined(HAVE_SHMEMX_WTIME)
-static inline double shmemx_wtime(void)
-{
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return (double)((tv.tv_usec / 1000000.0) + tv.tv_sec);
-}
-#endif
 
 int
 main(int argc, char **argv)
@@ -200,11 +192,11 @@ main(int argc, char **argv)
 
     for(i=0; i < loops; i++) {
 
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
 
         shmem_int_put(Target, Source, elements, target_PE);
 
-        time_taken += (shmemx_wtime() - start_time);
+        time_taken += (tests_sos_wtime() - start_time);
 
         if (me==0) {
             if ( Track && i > 0 && ((i % 200) == 0))

--- a/test/unit/fadd_nbi.c
+++ b/test/unit/fadd_nbi.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <shmem.h>
 #include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 long ctr = 0;
 
@@ -48,14 +49,14 @@ int main(void) {
 
     ctr = 0;
     shmem_barrier_all();
-    t = shmemx_wtime();
+    t = tests_sos_wtime();
 
     for (i = 0; i < npes; i++) {
         out[i] = shmem_long_atomic_fetch_add(&ctr, 1, i);
     }
 
     shmem_barrier_all();
-    t = shmemx_wtime() - t;
+    t = tests_sos_wtime() - t;
 
     if (me == 0) printf("fetch_add     %10.2fus\n", t*1000000);
 
@@ -70,14 +71,14 @@ int main(void) {
 
     ctr = 0;
     shmem_barrier_all();
-    t = shmemx_wtime();
+    t = tests_sos_wtime();
 
     for (i = 0; i < npes; i++) {
         shmem_long_atomic_fetch_add_nbi(&out[i], &ctr, 1, i);
     }
 
     shmem_barrier_all();
-    t = shmemx_wtime() - t;
+    t = tests_sos_wtime() - t;
 
     if (me == 0) printf("fetch_add_nbi %10.2fus\n", t*1000000);
 

--- a/test/unit/fadd_nbi.c
+++ b/test/unit/fadd_nbi.c
@@ -28,7 +28,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <shmem.h>
-#include <shmemx.h>
 #include "tests_sos/wtime.h"
 
 long ctr = 0;

--- a/test/unit/lfinc.c
+++ b/test/unit/lfinc.c
@@ -39,17 +39,9 @@
 #include <sys/time.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 #define LOOPS 25000
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void) {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (double) tv.tv_sec + (double) tv.tv_usec / 1000000.0;
-}
-#endif /* HAVE_SHMEMX_WTIME */
 
 int Verbose;
 double elapsed;
@@ -90,11 +82,11 @@ int main( int argc, char *argv[])
     shmem_barrier_all();
 
     neighbor = (my_pe + 1) % npes;
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(j=0,elapsed=0.0; j < loops; j++) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         lval = shmem_long_atomic_fetch_inc( (void*)&data[1], neighbor );
-        elapsed += shmemx_wtime() - start_time;
+        elapsed += tests_sos_wtime() - start_time;
         if (lval != (long) j) {
             fprintf(stderr,"[%d] Test: FAIL previous val %ld != %d Exit.\n",
                     my_pe, lval, j);

--- a/test/unit/spam.c
+++ b/test/unit/spam.c
@@ -50,7 +50,7 @@
 #include <assert.h>
 
 #include <shmem.h>
-#include <shmemx.h>
+#include "tests_sos/wtime.h"
 
 void one2many_put(int *dst, int *src, int Elems, int me, int npe, int laps);
 void many2one_get(int *dst, int *src, int Elems, int me, int npe, int laps);
@@ -64,10 +64,6 @@ void fcollect(int *dst, int *src, int Elems, int me, int npes, int laps);
 
 static int atoi_scaled(char *s);
 static void usage(char *pgm);
-
-#ifndef HAVE_SHMEMX_WTIME
-static double shmemx_wtime(void);
-#endif
 
 int Verbose=1;
 int All2=0;
@@ -212,12 +208,12 @@ one2many_put(int *target, int *src, int elements, int me, int npes, int loops)
     shmem_barrier_all();
 
     if (me == 0) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         for(i = 0; i < loops; i++) {
             for(pe = 1; pe < npes; pe++)
                 shmem_int_put(target, src, elements, pe);
         }
-        elapsed_time = shmemx_wtime() - start_time;
+        elapsed_time = tests_sos_wtime() - start_time;
 
         if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
@@ -246,12 +242,12 @@ many2one_get(int *target, int *src, int elements, int me, int npes, int loops)
     shmem_barrier_all();
 
     if (me == 0) {
-        start_time = shmemx_wtime();
+        start_time = tests_sos_wtime();
         for(i = 0; i < loops; i++) {
             for(pe = 1; pe < npes; pe++)
                 shmem_int_get(target, src, elements, pe);
         }
-        elapsed_time = shmemx_wtime() - start_time;
+        elapsed_time = tests_sos_wtime() - start_time;
 
         if (Verbose) {
             printf("%7.3f secs\n", elapsed_time);
@@ -278,12 +274,12 @@ all2all_get(int *target, int *src, int elements, int me, int npes, int loops)
     }
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         for(pe = 0; pe < npes; pe++)
             shmem_int_get(target, src, elements, pe);
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -312,12 +308,12 @@ all2all_put(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         for(pe = 0; pe < npes; pe++)
             shmem_int_put(target, src, elements, pe);
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -347,10 +343,10 @@ neighbor_put(int *target, int *src, int elements, int me, int npes, int loops)
 
     neighbor_pe = (me + 1) % npes;
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++)
         shmem_int_put(target, src, elements, neighbor_pe);
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -379,10 +375,10 @@ neighbor_get(int *target, int *src, int elements, int me, int npes, int loops)
 
     neighbor_pe = (me + 1) % npes;
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++)
         shmem_int_get(target, src, elements, neighbor_pe);
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -417,12 +413,12 @@ bcast(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = (i & 1) ? pSync1 : pSync;
         shmem_broadcast32( target, src, elements, 0, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -459,12 +455,12 @@ collect(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = (i & 1) ? pSync1 : pSync;
         shmem_collect32( target, src, elements, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -504,12 +500,12 @@ fcollect(int *target, int *src, int elements, int me, int npes, int loops)
 
     shmem_barrier_all();
 
-    start_time = shmemx_wtime();
+    start_time = tests_sos_wtime();
     for(i = 0; i < loops; i++) {
         ps = &pSync[(i&1)];
         shmem_fcollect32( target, src, elements, 0, 0, npes, ps );
     }
-    elapsed_time = shmemx_wtime() - start_time;
+    elapsed_time = tests_sos_wtime() - start_time;
 
     if (me==0 && Verbose) {
         printf("%7.3f secs\n", elapsed_time);
@@ -563,20 +559,3 @@ usage(char *pgm)
         "    -h             this text.\n",
         pgm,DFLT_LOOPS, N_ELEMENTS);
 }
-
-
-#ifndef HAVE_SHMEMX_WTIME
-
-static double
-shmemx_wtime(void)
-{
-    double wtime;
-    struct timeval tv;
-
-    gettimeofday(&tv, NULL);
-    wtime = tv.tv_sec;
-    wtime += (double)tv.tv_usec / 1000000.0;
-    return wtime;
-}
-
-#endif /* HAVE_SHMEMX_WTIME */


### PR DESCRIPTION
This is intended to help users of the https://github.com/openshmem-org/tests-sos repository to build the test suite even when the OpenSHMEM library does not define `shmemx_wtime()` (e.g., OSHMPI).