### PR TITLE
Bitwise amo cpp bindings: removed fixed width from check

### DIFF
--- a/bindings/generate_bind_cxx_extras.cpp
+++ b/bindings/generate_bind_cxx_extras.cpp
@@ -68,9 +68,7 @@
 #define NEED_BITWISE_AMO_ASSOC(CTYPE)               \
            COMPARE_TYPES_FIRST(unsigned int, CTYPE) \
            COMPARE_TYPES(unsigned long, CTYPE)      \
-           COMPARE_TYPES(unsigned long long, CTYPE) \
-           COMPARE_TYPES(int32_t, CTYPE)            \
-           COMPARE_TYPES(int64_t, CTYPE)            \
+           COMPARE_TYPES(unsigned long long, CTYPE)
 
 /* Note: Mirrors SHMEM_BIND_CXX_SYNC */
 #define NEED_SYNC_ASSOC(CTYPE)                      \
@@ -186,6 +184,8 @@ int main(int argc, char **argv)
     printf("')dnl\n");
 
     printf("define(`SHMEM_BIND_CXX_BITWISE_AMO_EXTRAS',\n`");
+    GEN_AMO_ASSOC(int32,     int32_t,     SHM_INTERNAL_INT32, BITWISE_AMO);
+    GEN_AMO_ASSOC(int64,     int64_t,     SHM_INTERNAL_INT64, BITWISE_AMO);
     GEN_AMO_ASSOC(uint32,   uint32_t,    SHM_INTERNAL_UINT32, BITWISE_AMO);
     GEN_AMO_ASSOC(uint64,   uint64_t,    SHM_INTERNAL_UINT64, BITWISE_AMO);
     printf("')dnl\n");

--- a/bindings/shmem_bind_cxx.m4
+++ b/bindings/shmem_bind_cxx.m4
@@ -51,9 +51,7 @@ define(`SHMEM_BIND_CXX_BITWISE_AMO', dnl args: macro_name, end
 SHMEM_BIND_CXX_BITWISE_AMO_EXTRAS($1,$2)dnl
 `$1(uint,      unsigned int,       `SHM_INTERNAL_UINT')$2
 $1(ulong,      unsigned long,      `SHM_INTERNAL_ULONG')$2
-$1(ulonglong,  unsigned long long, `SHM_INTERNAL_ULONG_LONG')$2
-$1(int32,      int32_t,            `SHM_INTERNAL_INT32')$2
-$1(int64,      int64_t,            `SHM_INTERNAL_INT64')')dnl
+$1(ulonglong,  unsigned long long, `SHM_INTERNAL_ULONG_LONG')')dnl
 dnl
 define(`SHMEM_BIND_CXX_SYNC', dnl args: macro_name, end
 SHMEM_BIND_CXX_SYNC_EXTRAS($1,$2)dnl


### PR DESCRIPTION
@davidozog - The change you pointed out made sense. This PR handles it. Please check.