### PR TITLE
Compiler wrapper: add -showlibs flag for link line

### DIFF
--- a/src/shmem_compiler_script.in
+++ b/src/shmem_compiler_script.in
@@ -164,12 +164,17 @@ my $want_compile = 1;
 my $want_link = 1;
 my $want_help = 0;
 my $dry_run = 0;
+my $lib_print = 0;
 my $disable_flags = 1;
 my $real_flag = 0;
 my @appargs = ();
 
 while (scalar(@args) > 0) {
     my $arg = shift(@args);
+
+    if ($arg eq "-showlibs") {
+        $lib_print = 1;
+    }
 
     if ($arg eq "-showme" || $arg eq "-show") {
         $dry_run = 1;
@@ -202,6 +207,7 @@ if ($disable_flags == 1 && !($dry_run == 1 && $real_flag == 0)) {
 }
 
 my @exec_argv = ();
+my @libs_list = ();
 
 # assemble command
 push(@exec_argv, split(' ', $comp));
@@ -219,6 +225,10 @@ if ($want_link == 1) {
     push(@exec_argv, split(' ', $linker_flags));
     push(@exec_argv, split(' ', $libs));
 }
+if ($lib_print == 1) {
+    push(@libs_list, split(' ', $linker_flags));
+    push(@libs_list, split(' ', $libs));
+}
 if ($want_help == 1) {
     print("== ",uc $wrapper," HELP ===================================\n");
     print("usage: ",$wrapper," [",$wrapper,"_options] [compiler_arguments]\n\n");
@@ -226,6 +236,7 @@ if ($want_help == 1) {
     print($wrapper," options:\n");
     print("\t--help            Display this information\n");
     print("\t-showme | -show   Print the command that would be run without executing it\n");
+    print("\t-showlibs         Print all library linker flags\n");
     print("\t-E | -M           Disable compilation and linking\n");
     print("\t-S                Disable linking\n");
     print("\t-c                Compile and assemble. Disable linking\n\n");
@@ -235,6 +246,11 @@ if ($want_help == 1) {
 
 if ($dry_run == 1) {
     print join(" ", @exec_argv) . "\n";
+    exit 0;
+}
+
+if ($lib_print == 1) {
+    print join(" ", @libs_list) . "\n";
     exit 0;
 }
 


### PR DESCRIPTION
This adds a `-showlibs` flag to the compiler wrappers, which is useful for getting only the linking flags.