### PR TITLE
Multi-NIC Bug Fix: Set 'next' attribute of list tail to NULL

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1562,7 +1562,7 @@ int query_for_fabric(struct fabric_info *info)
                 multirail_fabric_list_tail = cur_fabric;
             }
         }
-        multirail_fabric_list_tail->next = NULL;
+        if (multirail_fabric_list_tail) multirail_fabric_list_tail->next = NULL;
 
         if (num_nics == 0) {
             info->p_info = fallback;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1562,6 +1562,7 @@ int query_for_fabric(struct fabric_info *info)
                 multirail_fabric_list_tail = cur_fabric;
             }
         }
+        multirail_fabric_list_tail->next = NULL;
 
         if (num_nics == 0) {
             info->p_info = fallback;


### PR DESCRIPTION
This PR makes a minor bug fix to the code that is responsible for generating a list of providers that have NIC information. This should resolve the issues we were seeing on some of our development systems that have a single NIC when SOS is being used with multi-NIC functionality enabled.