### PR TITLE
num_contexts patch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/tests-sos"]
 	path = modules/tests-sos
-	url = ../../openshmem-org/tests-sos.git
-	branch = main
+	url = ../../ronawho/tests-sos.git
+	branch = fix_team_get_config_test

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -334,10 +334,22 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
         myteam->start       = global_PE_start;
         myteam->stride      = PE_stride;
         myteam->size        = PE_size;
-        if (config) {
-            myteam->config      = *config;
-            myteam->config_mask = config_mask;
+
+        if (config_mask == 0) {
+            shmem_team_config_t default_config;
+            default_config.num_contexts = 0;
+            myteam->config_mask = 0;
+            memcpy(&myteam->config, &default_config, sizeof(shmem_team_config_t));
+        } else {
+            if (config_mask != SHMEM_TEAM_NUM_CONTEXTS) {
+                RAISE_WARN_MSG("Invalid team_split_strided config_mask (%ld)\n", config_mask);
+                return -1;
+            } else {
+                myteam->config      = *config;
+                myteam->config_mask = config_mask;
+            }
         }
+
         myteam->contexts_len = 0;
         myteam->psync_idx = -1;
 

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -336,21 +336,27 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
         myteam->size        = PE_size;
 
         if (config_mask == 0) {
-            shmem_team_config_t default_config;
-            default_config.num_contexts = 0;
-            myteam->config_mask = 0;
-            memcpy(&myteam->config, &default_config, sizeof(shmem_team_config_t));
+            shmem_team_config_t defaults;
+            myteam->config_mask   = 0;
+            myteam->contexts_len  = 0;
+            defaults.num_contexts = 0;
+            memcpy(&myteam->config, &defaults, sizeof(shmem_team_config_t));
         } else {
             if (config_mask != SHMEM_TEAM_NUM_CONTEXTS) {
                 RAISE_WARN_MSG("Invalid team_split_strided config_mask (%ld)\n", config_mask);
                 return -1;
             } else {
-                myteam->config      = *config;
-                myteam->config_mask = config_mask;
+                shmem_internal_assertp(config->num_contexts >= 0);
+                myteam->config       = *config;
+                myteam->config_mask  = config_mask;
+                myteam->contexts_len = config->num_contexts;
+                myteam->contexts     = malloc(config->num_contexts * sizeof(shmem_transport_ctx_t*));
+                for (int i = 0; i < config->num_contexts; i++) {
+                    myteam->contexts[i] = NULL;
+                }
             }
         }
 
-        myteam->contexts_len = 0;
         myteam->psync_idx = -1;
 
         shmem_internal_op_to_all(psync_pool_avail_reduced,

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -336,6 +336,10 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
         myteam->size        = PE_size;
 
         if (config_mask == 0) {
+            if (config != NULL) {
+                RAISE_WARN_MSG("%s %s\n", "team_split_strided operation encountered an unexpected",
+                               "non-NULL config structure passed with a config_mask of 0.");
+            }
             shmem_team_config_t defaults;
             myteam->config_mask   = 0;
             myteam->contexts_len  = 0;

--- a/src/teams_c.c4
+++ b/src/teams_c.c4
@@ -91,6 +91,9 @@ shmem_team_get_config(shmem_team_t team, long config_mask, shmem_team_config_t *
             return -1;
         }
         memcpy(config, &myteam->config, sizeof(shmem_team_config_t));
+    } else if (config != NULL) {
+        RAISE_WARN_MSG("%s %s\n", "shmem_team_get_config encountered an unexpected",
+                       "non-NULL config structure passed with a config_mask of 0.");
     }
 
     return 0;


### PR DESCRIPTION
This resolves the issue discovered by @ronawho regarding unit test `shmem_team_get_config` here:
https://github.com/openshmem-org/tests-sos/pull/37

~~This is just a temporary patch to better align with the API spec.  SOS still effectively ignores the `num_contexts` hint, so #1019 is not quite addressed.~~

This also addresses #1019