### PR TITLE
configury: update much configury to OMPI main

### DIFF
--- a/config/getdate.sh
+++ b/config/getdate.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved.
+
+# Provide a way to override build date for reproducible build results
+# See https://reproducible-builds.org/ for why this is good.
+
+# There are several different flavors of date(1) out there.
+# Try a few different CLI options for date(1) to see which one works.
+
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+date -u -d "@$SOURCE_DATE_EPOCH" "$@" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "$@" 2>/dev/null || date -u "$@"

--- a/config/ompi_check_ucx.m4
+++ b/config/ompi_check_ucx.m4
@@ -7,6 +7,7 @@
 # Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -20,156 +21,129 @@
 # LDFLAGS, LIBS} as needed and runs action-if-found if there is
 # support, otherwise executes action-if-not-found
 AC_DEFUN([OMPI_CHECK_UCX],[
-    OPAL_VAR_SCOPE_PUSH([ompi_check_ucx_dir])
+    OPAL_VAR_SCOPE_PUSH([ompi_check_ucx_happy ompi_check_ucx_CPPFLAGS_save ompi_check_ucx_LDFLAGS_save ompi_check_ucx_LIBS_save])
 
-    AS_IF([test -z "$ompi_check_ucx_happy"],
-          [AC_ARG_WITH([ucx],
-		       [AC_HELP_STRING([--with-ucx(=DIR)],
-				       [Build with Unified Communication X library support])])
-	   OPAL_CHECK_WITHDIR([ucx], [$with_ucx], [include/ucp/api/ucp.h])
-	   AC_ARG_WITH([ucx-libdir],
-		       [AC_HELP_STRING([--with-ucx-libdir=DIR],
-				       [Search for Unified Communication X libraries in DIR])])
-	   OPAL_CHECK_WITHDIR([ucx-libdir], [$with_ucx_libdir], [libucp.*])
+    m4_ifblank([$1], [m4_fatal([First argument to OMPI_CHECK_UCX cannot be blank])])
 
-	   AS_IF([test "$with_ucx" != "no"],
-                 [AS_IF([test -n "$with_ucx" && test "$with_ucx" != "yes"],
-                        [ompi_check_ucx_dir="$with_ucx"],
-                        [PKG_CHECK_MODULES_STATIC([ucx],[ucx],
-                                             [ompi_check_ucx_dir=`$PKG_CONFIG --variable=prefix ucx`
-                                              AS_IF([test "$ompi_check_ucx_dir" = "/usr"],
-                                                    [ompi_check_ucx_dir=])],
-                                             [true])])
-                  ompi_check_ucx_happy="no"
-                  AS_IF([test -z "$ompi_check_ucx_dir"],
-                        [OPAL_CHECK_PACKAGE([ompi_check_ucx],
-                                   [ucp/api/ucp.h],
-                                   [ucp],
-                                   [ucp_cleanup],
-                                   [-luct -lucm -lucs],
-                                   [],
-                                   [],
-                                   [ompi_check_ucx_happy="yes"],
-                                   [ompi_check_ucx_happy="no"])
-                         AS_IF([test "$ompi_check_ucx_happy" = yes],
-                               [AC_MSG_CHECKING(for UCX version compatibility)
-                                AC_REQUIRE_CPP
-                                AC_COMPILE_IFELSE(
-                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
-                                    [ompi_check_ucx_happy="yes"],
-                                    [ompi_check_ucx_happy="no"])
+    AC_ARG_WITH([ucx],
+                [AS_HELP_STRING([--with-ucx(=DIR)],
+                                [Build with Unified Communication X library support])])
+    AC_ARG_WITH([ucx-libdir],
+                [AS_HELP_STRING([--with-ucx-libdir=DIR],
+                                [Search for Unified Communication X libraries in DIR])])
 
-                                AC_MSG_RESULT([$ompi_check_ucx_happy])])
-                         AS_IF([test "$ompi_check_ucx_happy" = "no"],
-                               [ompi_check_ucx_dir=/opt/ucx])])
-                  AS_IF([test "$ompi_check_ucx_happy" != yes],
-                        [AS_IF([test -n "$with_ucx_libdir"],
-                               [ompi_check_ucx_libdir="$with_ucx_libdir"],
-                               [files=`ls $ompi_check_ucx_dir/lib64/libucp.* 2> /dev/null | wc -l`
-                                AS_IF([test "$files" -gt 0],
-                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib64],
-                                      [ompi_check_ucx_libdir=$ompi_check_ucx_dir/lib])])
+    OAC_CHECK_PACKAGE([ucx],
+                      [$1],
+                      [ucp/api/ucp.h],
+                      [ucp -luct -lucm -lucs],
+                      [ucp_cleanup],
+                      [ompi_check_ucx_happy="yes"],
+                      [ompi_check_ucx_happy="no"])
 
-                         ompi_check_ucx_$1_save_CPPFLAGS="$CPPFLAGS"
-                         ompi_check_ucx_$1_save_LDFLAGS="$LDFLAGS"
-                         ompi_check_ucx_$1_save_LIBS="$LIBS"
+    ompi_check_ucx_CPPFLAGS_save=${CPPFLAGS}
+    ompi_check_ucx_LDFLAGS_save=${LDFLAGS}
+    ompi_check_ucx_LIBS_save=${LIBS}
 
-                         OPAL_CHECK_PACKAGE([ompi_check_ucx],
-                                            [ucp/api/ucp.h],
-                                            [ucp],
-                                            [ucp_cleanup],
-                                            [-luct -lucm -lucs],
-                                            [$ompi_check_ucx_dir],
-                                            [$ompi_check_ucx_libdir],
-                                            [ompi_check_ucx_happy="yes"],
-                                            [ompi_check_ucx_happy="no"])
+    OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${$1_CPPFLAGS}])
+    OPAL_FLAGS_APPEND_UNIQ([LDFLAGS], [${$1_LDFLAGS}])
+    OPAL_FLAGS_APPEND_MOVE([LIBS], [${$1_LIBS}])
 
-                         CPPFLAGS="$ompi_check_ucx_$1_save_CPPFLAGS"
-                         LDFLAGS="$ompi_check_ucx_$1_save_LDFLAGS"
-                         LIBS="$ompi_check_ucx_$1_save_LIBS"
+    AS_IF([test "$ompi_check_ucx_happy" = yes],
+          [AC_CACHE_CHECK([for UCX version header],
+               [ompi_check_ucx_cv_have_version_header],
+               [AC_REQUIRE_CPP
+                AC_COMPILE_IFELSE(
+                   [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
+                   [ompi_check_ucx_cv_have_version_header="yes"],
+                   [ompi_check_ucx_cv_have_version_header="no"])])
+           AS_IF([test "${ompi_check_ucx_cv_have_version_header}" != "yes"],
+                 [ompi_check_ucx_happy=no])])
 
-                         AS_IF([test "$ompi_check_ucx_happy" = yes],
-                               [AC_MSG_CHECKING(for UCX version compatibility)
-                                AC_REQUIRE_CPP
-                                old_CPPFLAGS="$CPPFLAGS"
-                                CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"
-                                AC_COMPILE_IFELSE(
-                                    [AC_LANG_PROGRAM([[#include <uct/api/version.h>]],[[]])],
-                                    [ompi_check_ucx_happy="yes"],
-                                    [ompi_check_ucx_happy="no"])
+    AS_IF([test "$ompi_check_ucx_happy" = yes],
+          [# Turn off UCX version v1.8 due to issue #8321
+           AC_CACHE_CHECK([UCX version 1.8.x],
+               [ompi_check_ucx_cv_have_version_1_8],
+               [AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
+#include <ucp/api/ucp_version.h>
+                                 ]], [[
+#if (UCP_API_MAJOR == 1) && (UCP_API_MINOR == 8)
+#error "Invalid version"
+#endif
+                                 ]])],
+                             [ompi_check_ucx_cv_have_version_1_8=no],
+                             [ompi_check_ucx_cv_have_version_1_8=yes])])
+           AS_IF([test "${ompi_check_ucx_cv_have_version_1_8}" = "yes"],
+                 [AC_MSG_WARN([UCX support skipped because version 1.8.x was found, which has a known catastrophic issue.])
+                  ompi_check_ucx_happy=no])])
+           AC_PREPROC_IFELSE([AC_LANG_PROGRAM([[
+#include <ucp/api/ucp_version.h>
+                             ]], [[
+#if (UCP_API_MAJOR < 1) || ((UCP_API_MAJOR == 1) && (UCP_API_MINOR < 9))
+#error "Version too low"
+#endif
+                             ]])],
+                             [], [AC_MSG_WARN([UCX version is too old, please upgrade to 1.9 or higher.])])
 
-                                AC_MSG_RESULT([$ompi_check_ucx_happy])
-                                CPPFLAGS=$old_CPPFLAGS])])
+    AS_IF([test "$ompi_check_ucx_happy" = yes],
+          [AC_CHECK_DECLS([ucp_tag_send_nbr],
+                          [AC_DEFINE([HAVE_UCP_TAG_SEND_NBR],[1],
+                                     [have ucp_tag_send_nbr()])], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb,
+                           ucp_request_check_status, ucp_put_nb, ucp_get_nb,
+                           ucp_put_nbx, ucp_get_nbx, ucp_atomic_op_nbx,
+                           ucp_ep_flush_nbx],
+                          [], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([ucm_test_events,
+                           ucm_test_external_events],
+                          [], [],
+                          [#include <ucm/api/ucm.h>])
+           AC_CHECK_DECLS([UCP_ATOMIC_POST_OP_AND,
+                           UCP_ATOMIC_POST_OP_OR,
+                           UCP_ATOMIC_POST_OP_XOR,
+                           UCP_ATOMIC_FETCH_OP_FAND,
+                           UCP_ATOMIC_FETCH_OP_FOR,
+                           UCP_ATOMIC_FETCH_OP_FXOR,
+                           UCP_PARAM_FIELD_ESTIMATED_NUM_PPN,
+                           UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK,
+                           UCP_OP_ATTR_FLAG_MULTI_SEND,
+                           UCS_MEMORY_TYPE_RDMA,
+                           UCP_MEM_MAP_SYMMETRIC_RKEY],
+                          [], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],
+                          [AC_DEFINE([HAVE_UCP_WORKER_ADDRESS_FLAGS], [1],
+                                     [have worker address attribute])], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([UCP_ATTR_FIELD_MEMORY_TYPES],
+                          [AC_DEFINE([HAVE_UCP_ATTR_MEMORY_TYPES], [1],
+                                     [have memory types attribute])], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([UCP_EP_ATTR_FIELD_TRANSPORTS],
+                          [], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_DECLS([ucp_tag_send_nbx,
+                           ucp_tag_send_sync_nbx,
+                           ucp_tag_recv_nbx,
+                           ucp_rkey_compare],
+                          [], [],
+                          [#include <ucp/api/ucp.h>])
+           AC_CHECK_TYPES([ucp_request_param_t],
+                          [], [],
+                          [[#include <ucp/api/ucp.h>]])
+           ])
 
-                  old_CPPFLAGS="$CPPFLAGS"
-                  AS_IF([test -n "$ompi_check_ucx_dir"],
-                        [CPPFLAGS="$CPPFLAGS -I$ompi_check_ucx_dir/include"])
-                  # Turn off UCX version v1.8 due to issue #8321
-                  AC_MSG_CHECKING([UCX version])
-                  AC_PREPROC_IFELSE([AC_LANG_PROGRAM([#include <ucp/api/ucp_version.h>
-                                                      #if (UCP_API_MAJOR == 1) && (UCP_API_MINOR == 8)
-                                                      #error "Invalid version"
-                                                      #endif], [])],
-                                    [AC_MSG_RESULT([ok (not 1.8.x)])],
-                                    [AC_MSG_RESULT([bad (1.8.x)])
-                                     AC_MSG_WARN([UCX support skipped because version 1.8.x was found, which has a known catastrophic issue.])
-                                     AC_MSG_WARN([Please upgrade to UCX version 1.9 or higher.])
-                                     ompi_check_ucx_happy=no])
-                  AS_IF([test "$ompi_check_ucx_happy" = yes],
-                        [
-                         AC_CHECK_DECLS([ucp_tag_send_nbr],
-                                        [AC_DEFINE([HAVE_UCP_TAG_SEND_NBR],[1],
-                                                   [have ucp_tag_send_nbr()])], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_DECLS([ucp_ep_flush_nb, ucp_worker_flush_nb,
-                                         ucp_request_check_status, ucp_put_nb, ucp_get_nb,
-                                         ucp_put_nbx, ucp_get_nbx, ucp_atomic_op_nbx],
-                                        [], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_DECLS([ucm_test_events,
-                                         ucm_test_external_events],
-                                        [], [],
-                                        [#include <ucm/api/ucm.h>])
-                         AC_CHECK_DECLS([UCP_ATOMIC_POST_OP_AND,
-                                         UCP_ATOMIC_POST_OP_OR,
-                                         UCP_ATOMIC_POST_OP_XOR,
-                                         UCP_ATOMIC_FETCH_OP_FAND,
-                                         UCP_ATOMIC_FETCH_OP_FOR,
-                                         UCP_ATOMIC_FETCH_OP_FXOR,
-                                         UCP_PARAM_FIELD_ESTIMATED_NUM_PPN,
-                                         UCP_WORKER_FLAG_IGNORE_REQUEST_LEAK],
-                                        [], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_DECLS([UCP_WORKER_ATTR_FIELD_ADDRESS_FLAGS],
-                                        [AC_DEFINE([HAVE_UCP_WORKER_ADDRESS_FLAGS], [1],
-                                                   [have worker address attribute])], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_DECLS([UCP_ATTR_FIELD_MEMORY_TYPES],
-                                        [AC_DEFINE([HAVE_UCP_ATTR_MEMORY_TYPES], [1],
-                                                   [have memory types attribute])], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_DECLS([ucp_tag_send_nbx,
-                                         ucp_tag_send_sync_nbx,
-                                         ucp_tag_recv_nbx],
-                                        [], [],
-                                        [#include <ucp/api/ucp.h>])
-                         AC_CHECK_TYPES([ucp_request_param_t],
-                                        [], [],
-                                        [[#include <ucp/api/ucp.h>]])
-                        ])
-                  CPPFLAGS=$old_CPPFLAGS
+    CPPFLAGS=${ompi_check_ucx_CPPFLAGS_save}
+    LDFLAGS=${ompi_check_ucx_LDFLAGS_save}
+    LIBS=${ompi_check_ucx_LIBS_save}
 
-                  OPAL_SUMMARY_ADD([[Transports]],[[Open UCX]],[$1],[$ompi_check_ucx_happy])])])
+    OPAL_SUMMARY_ADD([Transports], [Open UCX], [], [$ompi_check_ucx_happy])
 
     AS_IF([test "$ompi_check_ucx_happy" = "yes"],
-          [$1_CPPFLAGS="[$]$1_CPPFLAGS $ompi_check_ucx_CPPFLAGS"
-           $1_LDFLAGS="[$]$1_LDFLAGS $ompi_check_ucx_LDFLAGS"
-           $1_LIBS="[$]$1_LIBS $ompi_check_ucx_LIBS"
-           AC_DEFINE([HAVE_UCX], [1], [have ucx])
-           $2],
+          [$2],
           [AS_IF([test ! -z "$with_ucx" && test "$with_ucx" != "no"],
                  [AC_MSG_ERROR([UCX support requested but not found.  Aborting])])
-           AC_DEFINE([HAVE_UCX], [0], [have ucx])
            $3])
 
     OPAL_VAR_SCOPE_POP

--- a/config/opal_case_sensitive_fs_setup.m4
+++ b/config/opal_case_sensitive_fs_setup.m4
@@ -10,6 +10,7 @@ dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
 dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
+dnl Copyright (c) 2022      Cisco Systems, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -59,9 +60,11 @@ rm -f conf_fs_test.$$ CONF_FS_TEST.$$
 # Now see what the user wants to do...
 #
 AC_MSG_CHECKING([if configuring for case sensitive filesystem])
-AC_ARG_WITH(cs_fs,
-            AC_HELP_STRING([--with-cs-fs],
-                           [Destination FS is case sensitive (default: set to value of the build FS's case sensitivity)]))
+AC_ARG_WITH([cs_fs],
+            [AS_HELP_STRING([--with-cs-fs],
+                           [Destination FS is case sensitive (default: set to value of the build FS's case sensitivity)])])
+
+dnl Stupid emacs syntax highlighting: '
 
 if test "$with_cs_fs" = "yes"; then
     OPAL_WANT_CS_FS=1
@@ -78,26 +81,12 @@ else
 fi
 
 AM_CONDITIONAL(CASE_SENSITIVE_FS, test "$OPAL_WANT_CS_FS" = "1")
-
-if test "$OPAL_WANT_CS_FS" = "0"; then
-	cat <<EOF
-
-*******************************************************************************
-NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
-*******************************************************************************
-
-Because OPAL is being installed on a non-case sensitive file
-system, the C++ wrapper compiler will be named opalc++ instead of the
-traditional opalCC.
-
-Please update any makefiles appropriately.
-
-*******************************************************************************
-NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE
-*******************************************************************************
-
-EOF
-fi
+# There is a case in the ompi/tools/wrappers/Makefile.am where we need
+# to know if there is a case sensitive filesystem *and* if we have a
+# C++ compiler.  Since we can't use operators like "&&" or "and" to
+# join together AM CONDITIONALs in a Makefile.am, effectively make a
+# combo CONDITIONAL here.
+AM_CONDITIONAL([CASE_SENSITIVE_FS_AND_HAVE_CXX_COMPILER], [test "$OPAL_WANT_CS_FS" = "1" && test "$CXX" != "no"])
 
 # Clean up
 unset have_cs_fs])dnl

--- a/config/opal_check_attributes.m4
+++ b/config/opal_check_attributes.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
-dnl Copyright (c) 2010-2018 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2010-2021 Cisco Systems, Inc.  All rights reserved
 dnl Copyright (c) 2013      Mellanox Technologies, Inc.
 dnl                         All rights reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
@@ -64,7 +64,7 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
         #
         # Try to compile using the C compiler, then C++
         #
-        AC_TRY_COMPILE([$2],[],
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$2],[])],
                        [
                         #
                         # In case we did succeed: Fine, but was this due to the
@@ -82,10 +82,10 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
         m4_ifdef([project_ompi],
                  [if test "$opal_cv___attribute__[$1]" = "1" ; then
                       AC_LANG_PUSH(C++)
-                      AC_TRY_COMPILE([
+                      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
                            extern "C" {
                            $2
-                           }],[],
+                           }],[])],
                            [
                             opal_cv___attribute__[$1]=1
                             _OPAL_ATTRIBUTE_FAIL_SEARCH([$1])
@@ -103,11 +103,11 @@ AC_DEFUN([_OPAL_CHECK_SPECIFIC_ATTRIBUTE], [
             CFLAGS_safe=$CFLAGS
             CFLAGS="$CFLAGS [$4]"
 
-            AC_TRY_COMPILE([$3],
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([$3],
                 [
                  int i=4711;
                  i=usage(&i);
-                ],
+                ])],
                 [opal_cv___attribute__[$1]=0],
                 [
                  #
@@ -161,7 +161,7 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
   AC_MSG_CHECKING(for __attribute__)
 
   AC_CACHE_VAL(opal_cv___attribute__, [
-    AC_TRY_COMPILE(
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
       [#include <stdlib.h>
        /* Check for the longest available __attribute__ (since gcc-2.3) */
        struct foo {
@@ -169,13 +169,13 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
            int x[2] __attribute__ ((__packed__));
         };
       ],
-      [],
+      [])],
       [opal_cv___attribute__=1],
       [opal_cv___attribute__=0],
     )
 
     if test "$opal_cv___attribute__" = "1" ; then
-        AC_TRY_COMPILE(
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
           [#include <stdlib.h>
            /* Check for the longest available __attribute__ (since gcc-2.3) */
            struct foo {
@@ -183,7 +183,7 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
                int x[2] __attribute__ ((__packed__));
             };
           ],
-          [],
+          [])],
           [opal_cv___attribute__=1],
           [opal_cv___attribute__=0],
         )
@@ -559,6 +559,14 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
         [],
         [])
 
+    _OPAL_CHECK_SPECIFIC_ATTRIBUTE([constructor],
+        [
+        void foo(void) __attribute__ ((__constructor__));
+        void foo(void) { return ; }
+        ],
+        [],
+        [])
+
     _OPAL_CHECK_SPECIFIC_ATTRIBUTE([destructor],
         [
         void foo(void) __attribute__ ((__destructor__));
@@ -631,6 +639,8 @@ AC_DEFUN([OPAL_CHECK_ATTRIBUTES], [
                      [Whether your compiler has __attribute__ warn unused result or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_WEAK_ALIAS, [$opal_cv___attribute__weak_alias],
                      [Whether your compiler has __attribute__ weak alias or not])
+  AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_CONSTRUCTOR, [$opal_cv___attribute__constructor],
+                     [Whether your compiler has __attribute__ constructor or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_DESTRUCTOR, [$opal_cv___attribute__destructor],
                      [Whether your compiler has __attribute__ destructor or not])
   AC_DEFINE_UNQUOTED(OPAL_HAVE_ATTRIBUTE_OPTNONE, [$opal_cv___attribute__optnone],

--- a/config/opal_check_libnl.m4
+++ b/config/opal_check_libnl.m4
@@ -3,6 +3,7 @@ dnl
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2017      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -23,7 +24,7 @@ dnl cannot assume is always present) or we need to look in a
 dnl particular directory for the right libnl3 include files.  For
 dnl now, just hard code the special path into this logic.
 dnl
-dnl _OPAL_CHECK_PACKAGE_LIB() invokes OPAL_LIBNL_SANITY_CHECK() in order
+dnl OAC_CHEC_PACKAGE() invokes OPAL_LIBNL_CHECK_PACKAGE_CALLBACK() in order
 dnl to keep track of which libraries depend on libnl and which libraries
 dnl depend on libnl3.
 dnl Open MPI will not be able to build a component vs a given version of libnl
@@ -37,35 +38,25 @@ AC_DEFUN([OPAL_LIBNL_SANITY_INIT], [
     opal_libnl_version=0
     opal_libnlv1_libs=
     opal_libnlv3_libs=
-    AC_ARG_WITH([libnl],
-                [AC_HELP_STRING([--with-libnl(=DIR)],
-                                [Directory prefix for libnl (typically only necessary if libnl is installed in a location that the compiler/linker will not search by default)])])
 
-    # The --with options carry two pieces of information: 1) do
-    # you want a specific version of libnl, and 2) where that
-    # version of libnl lives.  For simplicity, let's separate
-    # those two pieces of information.
-    case "$with_libnl" in
-        no)
-            # Nope, don't want it
-            opal_want_libnl=no
-            ;;
-        "")
-            # Just try to build with libnl
-            opal_want_libnl=try
-            opal_libnl_location=
-            ;;
-        yes)
-            # Yes, definitely want it
-            opal_want_libnl=yes
-            opal_libnl_location=
-            ;;
-        *)
-            # Yes, definitely want it -- at a specific location
-            opal_want_libnl=yes
-            opal_libnl_location=$with_libnl
-            ;;
-    esac
+    AC_ARG_WITH([libnl],
+                [AS_HELP_STRING([--with-libnl(=DIR)],
+                                [Directory prefix for libnlv3 (typically only necessary if libnl is installed in a location that the compiler/linker will not search by default)])])
+    AC_ARG_WITH([libn-libdirl],
+                [AS_HELP_STRING([--with-libnl-libdir=DIR],
+                                [Directory prefix for libnlv3 libs(typically only necessary if libnl is installed in a location that the compiler/linker will not search by default)])])
+
+    # ugly hack to deal with potentially alternate locations for
+    # libnl3 headers.  Note that if the pkg-config file is found,
+    # this ugly hack won't be used.
+    AS_IF([test -n "$with_libnl_incdir"],
+          [# skip check if someone above set incdir],
+          [test -d "/usr/include/libnl3"],
+          [with_libnl_incdir="/usr/include/libnl3"],
+          [test -d "/usr/local/include/libnl3"],
+          [with_libnl_incdir="/usr/local/include/libnl3"])
+
+    OAC_CHECK_PACKAGE_VERIFY_COMMANDS([[OPAL_LIBNL_CHECK_PACKAGE_CALLBACK]])
 ])
 
 dnl OPAL_LIBNL_SANITY_FAIL_MSG(lib)
@@ -79,39 +70,31 @@ AC_DEFUN([OPAL_LIBNL_SANITY_FAIL_MSG], [
     AC_MSG_WARN([Open MPI will therefore skip using lib$1.])
 ])
 
-dnl OPAL_LIBNL_SANITY_CHECK(lib, function, LIBS, libnl_check_ok)
+dnl OPAL_LIBNL_CHECK_PACKAGE_CALLBACK(package name, prefix,
+dnl                   headers, function name,
+dnl                   action if happy, action if not happy)
 dnl
-dnl This macro is invoked from OPAL_CHECK_PACKAGE to make sure that
-dnl new libraries that are added to LIBS do not pull in conflicting
-dnl versions of libnl.  E.g., if we already have a library in LIBS
-dnl that pulls in libnl v3, if OPAL_CHECK_PACKAGE is later called that
-dnl pulls in a library that pulls in libnl v1, this macro will detect
-dnl the conflict and will abort configure.
-dnl
-dnl We abort rather than silently ignore this library simply because
-dnl we are now multiple levels deep in the M4 "call stack", and this
-dnl layer does not know the intent of the user.  Hence, all we can do
-dnl is abort with a hopefully helpful error message (that we aborted
-dnl because Open MPI would have been built in a configuration that is
-dnl known to crash).
-dnl
-dnl --------------------------------------------------------------------
-AC_DEFUN([OPAL_LIBNL_SANITY_CHECK], [
+dnl Callback from OAC_CHECK_PACKAGE to verify that there is
+dnl not a conflict.  Note that CPPFLAGS, LDFLAGS, and LIBS
+dnl are setup to compile/link package.
+AC_DEFUN([OPAL_LIBNL_CHECK_PACKAGE_CALLBACK], [
     OPAL_VAR_SCOPE_PUSH([opal_libnl_sane])
     opal_libnl_sane=1
     case $host in
         *linux*)
-            OPAL_LIBNL_SANITY_CHECK_LINUX($1, $2, $3, opal_libnl_sane)
+            OPAL_LIBNL_SANITY_CHECK_LINUX([$1], [$4], [], [opal_libnl_sane])
             ;;
     esac
 
-    $4=$opal_libnl_sane
+    AS_IF([test ${opal_libnl_sane} -eq 1],
+          [$5], [$6])
+
     OPAL_VAR_SCOPE_POP([opal_libnl_sane])
 ])
 
 dnl
 dnl Simple helper for OPAL_LIBNL_SANITY_CHECK
-dnl $1: library name
+dnl $1: package name
 dnl $2: function
 dnl $3: LIBS
 dnl $4: output variable (1=ok, 0=not ok)
@@ -119,10 +102,12 @@ dnl
 AC_DEFUN([OPAL_LIBNL_SANITY_CHECK_LINUX], [
     OPAL_VAR_SCOPE_PUSH([this_requires_v1 libnl_sane this_requires_v3 ldd_output result_msg])
 
-    AC_LANG_PUSH(C)
+    AS_VAR_PUSHDEF([libnl_check_lib], [opal_libnl_sanity_check_cv_$1])
 
-    AC_MSG_CHECKING([if lib$1 requires libnl v1 or v3])
-    cat > conftest_c.$ac_ext << EOF
+    AC_CACHE_CHECK([if $1 requires libnl v1 or v3],
+        [libnl_check_lib],
+        [AC_LANG_PUSH([C])
+         cat > conftest_c.$ac_ext << EOF
 extern void $2 (void);
 int main(int argc, char *argv[[]]) {
     $2 ();
@@ -130,21 +115,25 @@ int main(int argc, char *argv[[]]) {
 }
 EOF
 
+         result_msg=
+         OPAL_LOG_COMMAND([$CC -o conftest $CFLAGS $CPPFLAGS conftest_c.$ac_ext $LDFLAGS $LIBS $3],
+             [ldd_output=`ldd conftest`
+              AS_IF([echo $ldd_output | grep -q libnl-3.so],
+                    [result_msg="v3"])
+              AS_IF([echo $ldd_output | grep -q libnl.so],
+                    [OPAL_APPEND([result_msg], ["v1"])])
+              AS_IF([test -z "${result_msg}"], [result_msg="none"])],
+             [AC_MSG_WARN([Could not link a simple program with lib $1])])
+         AC_LANG_POP([C])
+         AS_VAR_SET([libnl_check_lib], [${result_msg}])
+         rm -f conftest conftest_c.$ac_ext])
+    AS_VAR_COPY([result_msg], [libnl_check_lib])
     this_requires_v1=0
     this_requires_v3=0
-    result_msg=
-    OPAL_LOG_COMMAND([$CC -o conftest $CFLAGS $CPPFLAGS conftest_c.$ac_ext $LDFLAGS -l$1 $LIBS $3],
-        [ldd_output=`ldd conftest`
-         AS_IF([echo $ldd_output | grep -q libnl-3.so],
-               [this_requires_v3=1
-                result_msg="v3"])
-         AS_IF([echo $ldd_output | grep -q libnl.so],
-               [this_requires_v1=1
-                result_msg="v1 $result_msg"])
-         AC_MSG_RESULT([$result_msg])
-         ],
-        [AC_MSG_WARN([Could not link a simple program with lib $1])
-        ])
+    AS_IF([echo "${result_msg}" | grep -q v1], [this_requires_v1=1])
+    AS_IF([echo "${result_msg}" | grep -q v3], [this_requires_v3=1])
+
+    AS_VAR_POPDEF([libnl_check_lib])
 
     # Assume that our configuration is sane; this may get reset below
     libnl_sane=1
@@ -156,7 +145,7 @@ EOF
 
     # Does this library require both v1 and v3?  If so, fail.
     AS_IF([test $this_requires_v1 -eq 1 && test $this_requires_v3 -eq 1],
-          [AC_MSG_WARN([Unfortunately, lib$1 links to both libnl and libnl-3.])
+          [AC_MSG_WARN([Unfortunately, $1 links to both libnl and libnl-3.])
            OPAL_LIBNL_SANITY_FAIL_MSG($1)
            libnl_sane=0])
 
@@ -176,7 +165,7 @@ EOF
     # v1?  If so, fail.
     AS_IF([test $libnl_sane -eq 1 && test $this_requires_v3 -eq 1],
           [AS_IF([test $opal_libnl_version -eq 1],
-                 [AC_MSG_WARN([libnl version conflict: $opal_libnlv1_libs requires libnl whereas lib$1 requires libnl-3])
+                 [AC_MSG_WARN([libnl version conflict: $opal_libnlv1_libs requires libnl whereas $1 requires libnl-3])
                   OPAL_LIBNL_SANITY_FAIL_MSG($1)
                   libnl_sane=0],
                  [opal_libnlv3_libs="$opal_libnlv3_libs $1"
@@ -184,165 +173,9 @@ EOF
                   opal_libnl_version=3])
           ])
 
-    AC_LANG_POP(C)
-    rm -f conftest conftest_c.$ac_ext
-
     $4=$libnl_sane
 
     OPAL_VAR_SCOPE_POP([ldd_output libnl_sane this_requires_v1 this_requires_v3 result_msg])
-])
-
-dnl
-dnl Check for libnl-3.
-dnl
-dnl Inputs:
-dnl
-dnl $1: prefix where to look for libnl-3
-dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
-dnl
-dnl Outputs:
-dnl
-dnl - Set $2_CPPFLAGS necessary to compile with libnl-3
-dnl - Set $2_LDFLAGS necessary to link with libnl-3
-dnl - Set $2_LIBS necessary to link with libnl-3
-dnl - Set OPAL_HAVE_LIBNL3 1 if libnl-3 will be used
-dnl
-AC_DEFUN([OPAL_CHECK_LIBNL_V3],[
-    OPAL_VAR_SCOPE_PUSH([CPPFLAGS_save opal_tmp_CPPFLAGS LIBS_save LDFLAGS_save])
-    AC_MSG_NOTICE([checking for libnl v3])
-
-    AS_IF([test "$opal_want_libnl" != "no"],
-          [AS_IF([test -z "$opal_libnl_location"],
-                 [AC_MSG_CHECKING([for /usr/include/libnl3])
-                  AS_IF([test -d "/usr/include/libnl3"],
-                        [opal_tmp_CPPFLAGS=-I/usr/include/libnl3
-                         opal_libnlv3_happy=1
-                         AC_MSG_RESULT([found])],
-                        [AC_MSG_RESULT([not found])
-                         AC_MSG_CHECKING([for /usr/local/include/libnl3])
-                         AS_IF([test -d "/usr/local/include/libnl3"],
-                               [opal_tmp_CPPFLAGS=-I/usr/local/include/netlink3
-                                opal_libnlv3_happy=1
-                                AC_MSG_RESULT([found])],
-                               [opal_libnlv3_happy=0
-                                AC_MSG_RESULT([not found])])])],
-                 [AC_MSG_CHECKING([for $1/include/libnl3])
-                  AS_IF([test -d "$1/include/libnl3"],
-                        [opal_tmp_CPPFLAGS="-I$1/include/libnl3"
-                         opal_libnlv3_happy=1
-                         AC_MSG_RESULT([found])],
-                        [opal_libnlv3_happy=0
-                         AC_MSG_RESULT([not found])])])
-           CPPFLAGS_save=$CPPFLAGS
-           CPPFLAGS="$opal_tmp_CPPFLAGS $CPPFLAGS"
-
-           # Random note: netlink/version.h is only in libnl v3 - it is not in libnl v1.
-           # Also, nl_recvmsgs_report is only in libnl v3.
-           AS_IF([test $opal_libnlv3_happy -eq 1],
-                 [OPAL_CHECK_PACKAGE([$2],
-                                     [netlink/version.h],
-                                     [nl-3],
-                                     [nl_recvmsgs_report],
-                                     [],
-                                     [$1],
-                                     [],
-                                     [],
-                                     [opal_libnlv3_happy=0])
-
-                  # Note that OPAL_CHECK_PACKAGE is going to add
-                  # -I$dir/include into $2_CPPFLAGS.  But because libnl v3
-                  # puts the headers in $dir/include/libnl3, we need to
-                  # overwrite $2_CPPFLAGS with -I$dir/include/libnl3.  We can do
-                  # this unconditionally; we don't have to check for
-                  # success (checking for success occurs below).
-                  $2_CPPFLAGS=$opal_tmp_CPPFLAGS])
-
-           # If we found libnl-3, we *also* need libnl-route-3
-           LIBS_save=$LIBS
-           LDFLAGS_save=$LDFLAGS
-           AS_IF([test -n "$$2_LDFLAGS"],
-                 [LDFLAGS="$$2_LDFLAGS $LDFLAGS"])
-           AS_IF([test $opal_libnlv3_happy -eq 1],
-                 [AC_SEARCH_LIBS([nl_rtgen_request],
-                                 [nl-route-3],
-                                 [],
-                                 [opal_libnlv3_happy=0])])
-           LIBS=$LIBS_save
-           LDFLAGS=$LDFLAGS_save
-
-           # Just because libnl* is evil, double check that the
-           # netlink/version.h we found was for libnl v3.  As far as we
-           # know, netlink/version.h only first appeared in version
-           # 3... but let's really be sure.
-           AS_IF([test $opal_libnlv3_happy -eq 1],
-                 [AC_MSG_CHECKING([to ensure these really are libnl v3 headers])
-                  AS_IF([test -n "$$2_CPPFLAGS"],
-                        [CPPFLAGS="$$2_CPPFLAGS $CPPFLAGS"])
-                  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-#include <netlink/netlink.h>
-#include <netlink/version.h>
-#ifndef LIBNL_VER_MAJ
-#error "LIBNL_VER_MAJ not defined!"
-#endif
-/* to the best of our knowledge, version.h only exists in libnl v3 */
-#if LIBNL_VER_MAJ != 3
-#error "LIBNL_VER_MAJ != 3, I am sad"
-#endif
-                                     ]])],
-                                    [AC_MSG_RESULT([yes])],
-                                    [AC_MSG_RESULT([no])
-                                     opal_libnlv3_happy=0])])
-
-           CPPFLAGS=$CPPFLAGS_save],
-
-          [opal_libnlv3_happy=0])
-
-    # If we found everything
-    AS_IF([test $opal_libnlv3_happy -eq 1],
-          [$2_LIBS="-lnl-3 -lnl-route-3"
-           OPAL_HAVE_LIBNL3=1],
-          [# OPAL_CHECK_PACKAGE(...,nl_recvmsgs_report,...) might have set the variables below
-           # so reset them if libnl v3 cannot be used
-           $2_CPPFLAGS=""
-           $2_LDFLAGS=""
-           $2_LIBS=""])
-
-   OPAL_VAR_SCOPE_POP
-])
-
-dnl
-dnl Check for libnl.
-dnl
-dnl Inputs:
-dnl
-dnl $1: prefix where to look for libnl
-dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
-dnl
-dnl Outputs:
-dnl
-dnl - Set $2_CPPFLAGS necessary to compile with libnl
-dnl - Set $2_LDFLAGS necessary to link with libnl
-dnl - Set $2_LIBS necessary to link with libnl
-dnl - Set OPAL_HAVE_LIBNL3 0 if libnl will be used
-dnl
-AC_DEFUN([OPAL_CHECK_LIBNL_V1],[
-    AC_MSG_NOTICE([checking for libnl v1])
-
-    AS_IF([test "$opal_want_libnl" != "no"],
-          [OPAL_CHECK_PACKAGE([$2],
-                              [netlink/netlink.h],
-                              [nl],
-                              [nl_connect],
-                              [-lm],
-                              [$1],
-                              [],
-                              [opal_libnlv1_happy=1],
-                              [opal_libnlv1_happy=0])],
-          [opal_libnlv1_happy=0])
-
-    AS_IF([test $opal_libnlv1_happy -eq 1],
-          [$2_LIBS="-lnl -lm"
-           OPAL_HAVE_LIBNL3=0])
 ])
 
 dnl
@@ -364,5 +197,5 @@ AC_DEFUN([OPAL_CHECK_LIBNL_SUMMARY],[
           [AC_MSG_RESULT([(none)])])
     AS_IF([test -n "$opal_libnlv1_libs" && test -n "$opal_libnlv3_libs"],
           [AC_MSG_WARN([libnl v1 and libnl v3 have been found as dependent libraries])
-           AC_ERROR([This is a configuration that is known to cause run-time crashes])])
+           AC_MSG_ERROR([This is a configuration that is known to cause run-time crashes])])
 ])

--- a/config/opal_check_ofi.m4
+++ b/config/opal_check_ofi.m4
@@ -1,7 +1,10 @@
-dnl -*- shell-script -*-
+dnl -*- autoconf -*-
 dnl
 dnl Copyright (c) 2015-2020 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2021-2022 Amazon.com, Inc. or its affiliates.  All Rights reserved.
+dnl Copyright (c) 2023      Triad National Security, LLC. All rights
 dnl                         reserved.
 dnl $COPYRIGHT$
 dnl
@@ -23,160 +26,163 @@ dnl $3: action if OFI API version is < $1
 AC_DEFUN([OPAL_CHECK_OFI_VERSION_GE],[
     OPAL_VAR_SCOPE_PUSH([opal_ofi_ver_ge_save_CPPFLAGS opal_ofi_ver_ge_happy])
 
-    AC_MSG_CHECKING([if OFI API version number is >= $1])
-    opal_ofi_ver_ge_save_CPPFLAGS=$CPPFLAGS
-    CPPFLAGS=$opal_ofi_CPPFLAGS
+    AS_LITERAL_WORD_IF([$1], [], [m4_fatal([OPAL_CHECK_OFI_VERSION_GE called with non-literal first argument])])dnl
+    AS_VAR_PUSHDEF([version_cache_var], [opal_ofi_ver_ge_cv_$1])dnl
+    m4_pushdef([version_pretty_print], [m4_translit([$1], [,], [.])])dnl
 
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fabric.h>]],
-[[
+    AC_CACHE_CHECK([if OFI API version number is >= version_pretty_print],
+        [version_cache_var],
+        [opal_ofi_ver_ge_save_CPPFLAGS=$CPPFLAGS
+         CPPFLAGS=$opal_ofi_internal_CPPFLAGS
+
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                [[#include <rdma/fabric.h>
+]], [[
 #if !defined(FI_MAJOR_VERSION)
 #error "we cannot check the version -- sad panda"
 #elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION($1))
 #error "version is too low -- nopes"
 #endif
 ]])],
-                      [opal_ofi_ver_ge_happy=1],
-                      [opal_ofi_ver_ge_happy=0])
+                      [version_cache_var=yes],
+                      [version_cache_var=no])])
 
-    AS_IF([test $opal_ofi_ver_ge_happy -eq 1],
-          [AC_MSG_RESULT([yes])
-           $2],
-          [AC_MSG_RESULT([no])
-           $3])
+    AS_IF([test "${version_cache_var}" = "yes"],
+          [$2],
+          [$3])
 
     CPPFLAGS=$opal_ofi_ver_ge_save_CPPFLAGS
 
+    m4_popdef([version_pretty_print])
+    AS_VAR_POPDEF([version_cache_var])
     OPAL_VAR_SCOPE_POP
 ])dnl
 
-dnl
-dnl _OPAL_CHECK_OFI
+
+dnl OPAL_CHECK_OFI(prefix, [action if found], [action if not found])
 dnl --------------------------------------------------------
 dnl Do the real work of checking for OFI libfabric.
 dnl Upon return:
 dnl
-dnl - opal_ofi_happy: will be "yes" or "no"
-dnl - opal_ofi_{CPPFLAGS|LDFLAGS|LIBS} will be loaded (if relevant)
+dnl opal_ofi_{CPPFLAGS, LDFLAGS, LIBS} and prefix_{CPPFLAGS, LDFLAGS,
+dnl LIBS} will be set as needed.
 dnl
-AC_DEFUN([_OPAL_CHECK_OFI],[
+dnl This macro intentionally leaks opal_ofi_happy = yes/no as well as
+dnl evaluating the action if found / action if not found
+dnl
+AC_DEFUN([OPAL_CHECK_OFI],[
+    OPAL_VAR_SCOPE_PUSH([opal_check_ofi_save_CPPFLAGS opal_check_ofi_save_LDFLAGS opal_check_ofi_save_LIBS opal_check_fi_info_pci])
+
+    m4_ifblank([$1], [m4_fatal([First argument must be set for call to OPAL_CHECK_OFI])])
+
     # Add --with options
     AC_ARG_WITH([libfabric],
-                [AC_HELP_STRING([--with-libfabric=DIR],
+                [AS_HELP_STRING([--with-libfabric=DIR],
                                 [Deprecated synonym for --with-ofi])])
     AC_ARG_WITH([libfabric-libdir],
-                [AC_HELP_STRING([--with-libfabric-libdir=DIR],
+                [AS_HELP_STRING([--with-libfabric-libdir=DIR],
                                 [Deprecated synonym for --with-ofi-libdir])])
 
     AC_ARG_WITH([ofi],
-                [AC_HELP_STRING([--with-ofi=DIR],
+                [AS_HELP_STRING([--with-ofi=DIR],
                                 [Specify location of OFI libfabric installation, adding DIR/include to the default search location for libfabric headers, and DIR/lib or DIR/lib64 to the default search location for libfabric libraries.  Error if libfabric support cannot be found.])])
-
     AC_ARG_WITH([ofi-libdir],
-                [AC_HELP_STRING([--with-ofi-libdir=DIR],
+                [AS_HELP_STRING([--with-ofi-libdir=DIR],
                                 [Search for OFI libfabric libraries in DIR])])
 
-    if test "$with_ofi" = ""; then
-         with_ofi=$with_libfabric
-    fi
+    AS_IF([test -z "${with_ofi}"], [with_ofi=${with_libfabric}])
+    AS_IF([test -z "${with_ofi_libdir}"], [with_ofi_libdir=${with_libfabric_libdir}])
 
-    if test "$with_ofi_libdir" = ""; then
-         with_ofi_libdir=$with_libfabric_libdir
-    fi
+    opal_check_ofi_save_CPPFLAGS=${CPPFLAGS}
+    opal_check_ofi_save_LDFLAGS=${LDFLAGS}
+    opal_check_ofi_save_LIBS=${LIBS}
 
-    # Sanity check the --with values
-    OPAL_CHECK_WITHDIR([ofi], [$with_ofi],
-                       [include/rdma/fabric.h])
-    OPAL_CHECK_WITHDIR([ofi-libdir], [$with_ofi_libdir],
-                       [libfabric.*])
-
-    OPAL_VAR_SCOPE_PUSH([opal_check_ofi_save_CPPFLAGS opal_check_ofi_save_LDFLAGS opal_check_ofi_save_LIBS opal_check_fi_info_pci])
-    opal_check_ofi_save_CPPFLAGS=$CPPFLAGS
-    opal_check_ofi_save_LDFLAGS=$LDFLAGS
-    opal_check_ofi_save_LIBS=$LIBS
     opal_check_fi_info_pci=0
 
-    opal_ofi_happy=yes
-    AS_IF([test "$with_ofi" = "no"],
-          [opal_ofi_happy=no])
+    dnl OMPI has used ofi everywhere for some time, but the pkg-config
+    dnl module name is libfabric.  Easier to set the pkg-config module
+    dnl name explicitly than change everything in OMPI.
+    m4_define([ofi_pkgconfig_module], [libfabric])
+    OAC_CHECK_PACKAGE([ofi],
+                      [$1],
+                      [rdma/fabric.h],
+                      [fabric],
+                      [fi_getinfo],
+                      [opal_ofi_happy=yes],
+                      [opal_ofi_happy=no])
+
+    OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${$1_CPPFLAGS}])
 
     AS_IF([test $opal_ofi_happy = yes],
-          [AC_MSG_CHECKING([looking for OFI libfabric in])
-           AS_IF([test "$with_ofi" != "yes"],
-                 [opal_ofi_dir=$with_ofi
-                  AC_MSG_RESULT([($opal_ofi_dir)])],
-                 [AC_MSG_RESULT([(default search paths)])])
-           AS_IF([test ! -z "$with_ofi_libdir" && \
-                         test "$with_ofi_libdir" != "yes"],
-                 [opal_ofi_libdir=$with_ofi_libdir])
-          ])
+          [AC_CHECK_HEADERS([rdma/fi_ext.h])
 
-    AS_IF([test $opal_ofi_happy = yes],
-          [OPAL_CHECK_PACKAGE([opal_ofi],
-                              [rdma/fabric.h],
-                              [fabric],
-                              [fi_getinfo],
-                              [],
-                              [$opal_ofi_dir],
-                              [$opal_ofi_libdir],
-                              [],
-                              [opal_ofi_happy=no])])
-
-    CPPFLAGS="$CPPFLAGS $opal_ofi_CPPFLAGS"
-
-    AS_IF([test $opal_ofi_happy = yes],
-          [AC_CHECK_MEMBER([struct fi_info.nic],
+           AC_CHECK_MEMBER([struct fi_info.nic],
                            [opal_check_fi_info_pci=1],
                            [opal_check_fi_info_pci=0],
-                           [[#include <rdma/fabric.h>]])])
+                           [[#include <rdma/fabric.h>]])
 
-    AC_DEFINE_UNQUOTED([OPAL_OFI_PCI_DATA_AVAILABLE],
-                       [$opal_check_fi_info_pci],
-                       [check if pci data is available in ofi])
+           AC_DEFINE_UNQUOTED([OPAL_OFI_PCI_DATA_AVAILABLE],
+                              [${opal_check_fi_info_pci}],
+                              [check if pci data is available in ofi])
 
-    AC_CHECK_DECLS([PMIX_PACKAGE_RANK],
-                   [],
-                   [],
-                   [#include <pmix.h>])
+           AC_CHECK_DECLS([FI_OPT_FI_HMEM_P2P],
+                          [], [],
+                          [#include <rdma/fi_endpoint.h>])
 
-    CPPFLAGS=$opal_check_ofi_save_CPPFLAGS
-    LDFLAGS=$opal_check_ofi_save_LDFLAGS
-    LIBS=$opal_check_ofi_save_LIBS
+           AC_CHECK_TYPES([struct fi_ops_mem_monitor], [], [],
+                          [#ifdef HAVE_RDMA_FI_EXT_H
+#include <rdma/fi_ext.h>
+#endif
+                           ])
 
-    AC_SUBST([opal_ofi_CPPFLAGS])
-    AC_SUBST([opal_ofi_LDFLAGS])
-    AC_SUBST([opal_ofi_LIBS])
+           OPAL_FLAGS_APPEND_UNIQ([CPPFLAGS], [${opal_pmix_CPPFLAGS}])
+           AC_CHECK_DECLS([PMIX_PACKAGE_RANK],
+                          [],
+                          [],
+                          [#include <pmix.h>])
 
-    OPAL_SUMMARY_ADD([[Transports]],[[OpenFabrics OFI Libfabric]],[],[$opal_ofi_happy])
+           AC_CHECK_MEMBER([struct fi_mr_attr.iface],
+                           [opal_check_fi_mr_attr_iface=1],
+                           [opal_check_fi_mr_attr_iface=0],
+                           [[#include <rdma/fi_domain.h>]])
 
-    OPAL_VAR_SCOPE_POP
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_MR_IFACE],
+                              [${opal_check_fi_mr_attr_iface}],
+                              [check if iface avaiable in fi_mr_attr])
 
-    AS_IF([test $opal_ofi_happy = no],
-          [AS_IF([test -n "$with_ofi" && test "$with_ofi" != "no"],
+           AC_CHECK_DECL([FI_HMEM_ROCR],
+                         [opal_check_fi_hmem_rocr=1],
+                         [opal_check_fi_hmem_rocr=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ROCR],
+                              [${opal_check_fi_hmem_rocr}],
+                              [check if FI_HMEM_ROCR avaiable in fi_hmem_iface])
+
+           AC_CHECK_DECL([FI_HMEM_ZE],
+                         [opal_check_fi_hmem_ze=1],
+                         [opal_check_fi_hmem_ze=0],
+                         [#include <rdma/fi_domain.h>])
+
+           AC_DEFINE_UNQUOTED([OPAL_OFI_HAVE_FI_HMEM_ZE],
+                              [${opal_check_fi_hmem_ze}],
+                              [check if FI_HMEM_ZE avaiable in fi_hmem_iface])])
+
+    CPPFLAGS=${opal_check_ofi_save_CPPFLAGS}
+    LDFLAGS=${opal_check_ofi_save_LDFLAGS}
+    LIBS=${opal_check_ofi_save_LIBS}
+
+    dnl for version compare tests
+    opal_ofi_internal_CPPFLAGS="${$1_CPPFLAGS}"
+
+    OPAL_SUMMARY_ADD([Transports], [OpenFabrics OFI Libfabric], [], [${$1_SUMMARY}])
+
+    AS_IF([test "${opal_ofi_happy}" = "yes"],
+          [$2],
+          [AS_IF([test -n "${with_ofi}" && test "${with_ofi}" != "no"],
                  [AC_MSG_WARN([OFI libfabric support requested (via --with-ofi or --with-libfabric), but not found.])
                   AC_MSG_ERROR([Cannot continue.])])
-           ])
+           $3])
+
+    OPAL_VAR_SCOPE_POP
 ])dnl
-
-
-dnl
-dnl OPAL_CHECK_OFI
-dnl --------------------------------------------------------
-dnl Check to see if OFI libfabric is available.
-dnl
-dnl This is a simple wrapper around _OPAL_CHECK_OFI that just
-dnl ensures to only run the checks once.  We do not use AC_REQUIRE
-dnl because that re-orders the texts and makes ordering in stdout
-dnl quite confusing / difficult to grok.
-dnl
-AC_DEFUN([OPAL_CHECK_OFI],[
-    # Check for OFI libfabric.  Note that $opal_ofi_happy is used in
-    # other configure.m4's to know if OFI/libfabric configured
-    # successfully.  We only need to run the back-end checks once, but
-    # at least emit a "checking..." statement each subsequent time
-    # this macro is invoked so that configure's stdout has
-    # sensible/logical output.
-    AS_IF([test -z "$opal_ofi_happy"],
-        [_OPAL_CHECK_OFI],
-        [AC_MSG_CHECKING([if OFI libfabric is available])
-         AC_MSG_RESULT([$opal_ofi_happy])])
-])

--- a/config/opal_check_pmi.m4
+++ b/config/opal_check_pmi.m4
@@ -134,13 +134,11 @@ AC_DEFUN([OPAL_CHECK_PMI],[
     OPAL_VAR_SCOPE_PUSH([check_pmi_install_dir check_pmi_lib_dir default_pmi_loc default_pmi_libloc slurm_pmi_found])
 
     AC_ARG_WITH([pmi],
-                [AC_HELP_STRING([--with-pmi(=DIR)],
-                                [Build PMI support, optionally adding DIR to the search path (default: no)])],
+                [AS_HELP_STRING([--with-pmi(=DIR)],[Build PMI support, optionally adding DIR to the search path (default: no)])],
                                 [], with_pmi=no)
 
     AC_ARG_WITH([pmi-libdir],
-                [AC_HELP_STRING([--with-pmi-libdir(=DIR)],
-                                [Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
+                [AS_HELP_STRING([--with-pmi-libdir(=DIR)],[Look for libpmi or libpmi2 in the given directory, DIR/lib or DIR/lib64])])
 
     AC_ARG_ENABLE([pmi1],
                 [AS_HELP_STRING([--enable-pmi1],
@@ -162,7 +160,7 @@ AC_DEFUN([OPAL_CHECK_PMI],[
 
         AS_IF([test -z "$with_pmi" -o "$with_pmi" = "yes"],
                 [ompi_check_pmi_dir="$with_portals4"])
-        OMPI_CHECK_PACKAGE([],
+        OAC_CHECK_PACKAGE([],
                 [portals4/pmi.h],
                 [portals_runtime],
                 [PMI_Init],
@@ -262,8 +260,7 @@ AC_DEFUN([OPAL_CHECK_PMIX],[
     OPAL_VAR_SCOPE_PUSH([opal_external_pmix_save_CPPFLAGS opal_external_pmix_save_LDFLAGS opal_external_pmix_save_LIBS])
 
     AC_ARG_WITH([pmix],
-                [AC_HELP_STRING([--with-pmix(=DIR)],
-                                [Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
+                [AS_HELP_STRING([--with-pmix(=DIR)],[Build PMIx support.  DIR can take one of three values: "internal", "external", or a valid directory name.  "internal" (or no DIR value) forces Open MPI to use its internal copy of PMIx.  "external" forces Open MPI to use an external installation of PMIx.  Supplying a valid directory name also forces Open MPI to use an external installation of PMIx, and adds DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries. Note that Open MPI does not support --without-pmix.])])
 
     AS_IF([test "$with_pmix" = "no"],
           [AC_MSG_WARN([Open MPI requires PMIx support. It can be built])

--- a/config/opal_check_portals4.m4
+++ b/config/opal_check_portals4.m4
@@ -16,6 +16,7 @@ dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
 dnl                         reserved.
+dnl Copyright (c) 2022      Amazon.com, Inc. or its affiliates.  All Rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -29,81 +30,61 @@ dnl
 # LDFLAGS, LIBS} as needed and runs action-if-found if there is
 # support, otherwise executes action-if-not-found
 AC_DEFUN([OPAL_CHECK_PORTALS4],[
-    if test -z "$ompi_check_portals4_happy" ; then
-	AC_ARG_WITH([portals4],
-		    [AC_HELP_STRING([--with-portals4(=DIR)],
-				    [Build Portals4 support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
-	OPAL_CHECK_WITHDIR([portals4], [$with_portals4], [include/portals4.h])
-	AC_ARG_WITH([portals4-libdir],
-		    [AC_HELP_STRING([--with-portals4-libdir=DIR],
-				    [Search for Portals4 libraries in DIR])])
-	OPAL_CHECK_WITHDIR([portals4-libdir], [$with_portals4_libdir], [libportals.*])
+    OPAL_VAR_SCOPE_PUSH([ompi_check_portals4_happy max_md_size max_va_size])
 
-	ompi_check_portals4_$1_save_CPPFLAGS="$CPPFLAGS"
-	ompi_check_portals4_$1_save_LDFLAGS="$LDFLAGS"
-	ompi_check_portals4_$1_save_LIBS="$LIBS"
+    AC_ARG_WITH([portals4],
+                [AS_HELP_STRING([--with-portals4(=DIR)],
+                                [Build Portals4 support, optionally adding DIR/include, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+    AC_ARG_WITH([portals4-libdir],
+                [AS_HELP_STRING([--with-portals4-libdir=DIR],
+                                [Search for Portals4 libraries in DIR])])
 
-	AS_IF([test "$with_portals4" != "no"],
-              [AS_IF([test ! -z "$with_portals4" && test "$with_portals4" != "yes"],
-                     [ompi_check_portals4_dir="$with_portals4"])
-               AS_IF([test ! -z "$with_portals4_libdir" && test "$with_portals4_libdir" != "yes"],
-                     [ompi_check_portals4_libdir="$with_portals4_libdir"])
+    OAC_CHECK_PACKAGE([portals4],
+                      [$1],
+                      [portals4.h],
+                      [portals],
+                      [PtlLEAppend],
+                      [ompi_check_portals4_happy="yes"],
+                      [ompi_check_portals4_happy="no"])
 
-               OPAL_CHECK_PACKAGE([opal_check_portals4],
-				  [portals4.h],
-				  [portals],
-				  [PtlLEAppend],
-				  [],
-				  [$ompi_check_portals4_dir],
-				  [$ompi_check_portals4_libdir],
-				  [ompi_check_portals4_happy="yes"],
-				  [ompi_check_portals4_happy="no"])],
-              [ompi_check_portals4_happy="no"])
+    max_md_size=0
+    AC_ARG_WITH([portals4-max-md-size],
+                [AS_HELP_STRING([--with-portals4-max-md-size=SIZE],
+                                [Log base 2 of the maximum size in bytes of a memory descriptor.  Should only be set for implementations which do not support binding all of virtual address space.])])
+    AS_IF([test "$with_portals4_max_md_size" = "yes" || test "$with_portals4_max_md_size" = "no"],
+          [AC_MSG_ERROR([--with-portals4-max-md-size requires an integer argument])],
+          [AS_IF([test -n "$with_portals4_max_md_size"],
+                 [max_md_size="$with_portals4_max_md_size"])])
+    AC_DEFINE_UNQUOTED([OPAL_PORTALS4_MAX_MD_SIZE], [$max_md_size],
+                       [Log base 2 of the maximum size in bytes of a memory descriptor.  Set to 0 if MD can bind all of memory.])
 
-	CPPFLAGS="$ompi_check_portals4_$1_save_CPPFLAGS"
-	LDFLAGS="$ompi_check_portals4_$1_save_LDFLAGS"
-	LIBS="$ompi_check_portals4_$1_save_LIBS"
+    max_va_size=0
+    AC_ARG_WITH([portals4-max-va-size],
+                [AS_HELP_STRING([--with-portals4-max-va-size=SIZE],
+                                [Log base 2 of the maximum size in bytes of the user virtual address space.  Should only be set for implementations which do not support binding all of virtual address space.])])
+    AS_IF([test "$with_portals4_max_va_size" = "yes" || test "$with_portals4_max_va_size" = "no"],
+          [AC_MSG_ERROR([--with-portals4-max-va-size requires an integer argument])],
+          [AS_IF([test -n "$with_portals4_max_va_size"],
+                 [max_va_size="$with_portals4_max_va_size"])])
+    AC_DEFINE_UNQUOTED([OPAL_PORTALS4_MAX_VA_SIZE], [$max_va_size],
+                       [Log base 2 of the maximum size in bytes of the user virtual address space.  Set to 0 if MD can bind all of memory.])
 
-	max_md_size=0
-	AC_ARG_WITH([portals4-max-md-size],
-		    [AC_HELP_STRING([--with-portals4-max-md-size=SIZE],
-				    [Log base 2 of the maximum size in bytes of a memory descriptor.  Should only be set for implementations which do not support binding all of virtual address space.])])
-	AS_IF([test "$with_portals4_max_md_size" = "yes" || test "$with_portals4_max_md_size" = "no"],
-              [AC_MSG_ERROR([--with-portals4-max-md-size requires an integer argument])],
-              [AS_IF([test -n "$with_portals4_max_md_size"],
-                     [max_md_size="$with_portals4_max_md_size"])])
-	AC_DEFINE_UNQUOTED([OPAL_PORTALS4_MAX_MD_SIZE], [$max_md_size],
-			   [Log base 2 of the maximum size in bytes of a memory descriptor.  Set to 0 if MD can bind all of memory.])
+    AS_IF([(test $max_md_size -eq 0 && test $max_va_size -ne 0 ) || (test $max_md_size -ne 0 && test $max_va_size -eq 0 )],
+          [AC_MSG_ERROR([If either --with-portals4-max-md-size or --with-portals4-max-va-size is set, both must be set.])])
+    AS_IF([test $max_md_size -ge $max_va_size],
+          [max_md_size=0
+           max_va_size=0])
+    AS_IF([test $max_md_size -ne 0 && test $max_va_size -ne 0],
+          [AC_MSG_NOTICE([Portals 4 address space size: $max_md_size, $max_va_size])])
 
-	max_va_size=0
-	AC_ARG_WITH([portals4-max-va-size],
-		    [AC_HELP_STRING([--with-portals4-max-va-size=SIZE],
-				    [Log base 2 of the maximum size in bytes of the user virtual address space.  Should only be set for implementations which do not support binding all of virtual address space.])])
-	AS_IF([test "$with_portals4_max_va_size" = "yes" || test "$with_portals4_max_va_size" = "no"],
-              [AC_MSG_ERROR([--with-portals4-max-va-size requires an integer argument])],
-              [AS_IF([test -n "$with_portals4_max_va_size"],
-                     [max_va_size="$with_portals4_max_va_size"])])
-	AC_DEFINE_UNQUOTED([OPAL_PORTALS4_MAX_VA_SIZE], [$max_va_size],
-			   [Log base 2 of the maximum size in bytes of the user virtual address space.  Set to 0 if MD can bind all of memory.])
-
-	AS_IF([(test $max_md_size -eq 0 && test $max_va_size -ne 0 ) || (test $max_md_size -ne 0 && test $max_va_size -eq 0 )],
-          [AC_ERROR([If either --with-portals4-max-md-size or --with-portals4-max-va-size is set, both must be set.])])
-	AS_IF([test $max_md_size -ge $max_va_size],
-              [max_md_size=0
-               max_va_size=0])
-	AS_IF([test $max_md_size -ne 0 && test $max_va_size -ne 0],
-              [AC_MSG_NOTICE([Portals 4 address space size: $max_md_size, $max_va_size])])
-
-	OPAL_SUMMARY_ADD([[Transports]],[[Portals4]],[$1],[$ompi_check_portals4_happy])
-    fi
+    OPAL_SUMMARY_ADD([Transports], [Portals4], [], [${$1_SUMMARY}])
 
     AS_IF([test "$ompi_check_portals4_happy" = "yes"],
-          [$1_LDFLAGS="[$]$1_LDFLAGS $opal_check_portals4_LDFLAGS"
-	   $1_CPPFLAGS="[$]$1_CPPFLAGS $opal_check_portals4_CPPFLAGS"
-	   $1_LIBS="[$]$1_LIBS $opal_check_portals4_LIBS"
-	   $2],
+          [$2],
           [AS_IF([test ! -z "$with_portals4" && test "$with_portals4" != "no"],
                  [AC_MSG_ERROR([Portals4 support requested but not found.  Aborting])])
            $3])
-])
+
+    OPAL_VAR_SCOPE_POP
+])dnl
 

--- a/config/opal_check_visibility.m4
+++ b/config/opal_check_visibility.m4
@@ -26,9 +26,9 @@ AC_DEFUN([OPAL_CHECK_VISIBILITY],[
 
     # Check if the compiler has support for visibility, like some
     # versions of gcc, icc Sun Studio cc.
-    AC_ARG_ENABLE(visibility,
-        AC_HELP_STRING([--enable-visibility],
-            [enable visibility feature of certain compilers/linkers (default: enabled)]))
+    AC_ARG_ENABLE([visibility],
+        [AS_HELP_STRING([--enable-visibility],
+            [enable visibility feature of certain compilers/linkers (default: enabled)])])
 
     opal_visibility_define=0
     opal_msg="whether to enable symbol visibility"

--- a/config/opal_functions.m4
+++ b/config/opal_functions.m4
@@ -259,10 +259,10 @@ dnl #######################################################################
 # ~/.whatever file (and we do not want the error messages to be part
 # of the assignment in foo=`which <prog>`). This macro ensures that we
 # get a sane executable value.
+#
+# 1 is the variable name to do "which" on
+# 2 is the variable name to assign the return value to
 AC_DEFUN([OPAL_WHICH],[
-    # 1 is the variable name to do "which" on
-    # 2 is the variable name to assign the return value to
-
     OPAL_VAR_SCOPE_PUSH([opal_prog opal_file opal_dir opal_sentinel])
 
     opal_prog=$1
@@ -319,69 +319,8 @@ dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
-AC_DEFUN([OPAL_VAR_SCOPE_INIT],
-[opal_var_scope_push()
-{
-    opal_var_scope_push_lineno=$[]1
-    shift
-    # First, check to see if any of these variables are already set.
-    # This is a simple sanity check to ensure we're not already
-    # overwriting pre-existing variables (that have a non-empty
-    # value).  It's not a perfect check, but at least it's something.
-    for opal_var_scope_tmp_var in $[]@; do
-        AS_VAR_SET_IF([$opal_var_scope_tmp_var],
-            [AS_VAR_COPY([opal_var_scope_tmp_var_val], [$opal_var_scope_tmp_var])
-             AC_MSG_WARN([Found configure shell variable clash at line $opal_var_scope_push_lineno!])
-             AC_MSG_WARN([[OPAL_VAR_SCOPE_PUSH] called on "$opal_var_scope_tmp_var",])
-             AC_MSG_WARN([but it is already defined with value "$opal_var_scope_tmp_var_val"])
-             AC_MSG_WARN([This usually indicates an error in configure.])
-             AC_MSG_ERROR([Cannot continue])])
-    done
-    AS_UNSET([opal_var_scope_push_lineno])
-    AS_UNSET([opal_var_scope_tmp_var])
-    AS_UNSET([opal_var_scope_tmp_var_val])
-}
-
-opal_var_scope_pop()
-{
-    # Iterate over all the variables and unset them all
-    for opal_var_scope_tmp_var in $[]@; do
-        AS_UNSET([$opal_var_scope_tmp_var])
-    done
-    AS_UNSET([opal_var_scope_tmp_var])
-}])
-
-# OPAL_VAR_SCOPE_PUSH(vars list)
-# ------------------------------
-# Scope-check that the vars in the space-separated vars list are not already
-# in use.  Generate a configure-time error if a conflict is found.  Note that
-# the in use check is defined as "defined", so even if a var in vars list is
-# set outside of OPAL_VAR_SCOPE_PUSH, the check will still trip.
-AC_DEFUN([OPAL_VAR_SCOPE_PUSH],[
-    AC_REQUIRE([OPAL_VAR_SCOPE_INIT])dnl
-    m4_pushdef([opal_var_scope_stack], [$1])dnl
-    m4_foreach_w([opal_var_scope_var], [$1],
-                 [m4_set_add([opal_var_scope_active_set], opal_var_scope_var,
-                             [], [m4_fatal([OPAL_VAR_SCOPE_PUSH found the variable ]opal_var_scope_var[
-active in a previous scope.])])])dnl
-    opal_var_scope_push ${LINENO} $1
-])dnl
-
-# OPAL_VAR_SCOPE_POP()
-# --------------------
-# Unset the last set of variables set in OPAL_VAR_SCOPE_POP.  Every call to
-# OPAL_VAR_SCOPE_PUSH should have a matched call to this macro.
-AC_DEFUN([OPAL_VAR_SCOPE_POP],[
-    AC_REQUIRE([OPAL_VAR_SCOPE_INIT])dnl
-    m4_ifdef([opal_var_scope_stack], [],
-             [m4_fatal([OPAL_VAR_SCOPE_POP was called without a defined
-variable stack.  This usually means that OPAL_VAR_SCOPE_POP was called more
-times than OPAL_VAR_SCOPE_PUSH.])])dnl
-    m4_foreach_w([opal_var_scope_var], opal_var_scope_stack,
-                 [m4_set_remove([opal_var_scope_active_set], opal_var_scope_var)])dnl
-    opal_var_scope_pop opal_var_scope_stack
-    m4_popdef([opal_var_scope_stack])dnl
-])dnl
+m4_copy([OAC_VAR_SCOPE_PUSH], [OPAL_VAR_SCOPE_PUSH])
+m4_copy([OAC_VAR_SCOPE_POP], [OPAL_VAR_SCOPE_POP])
 
 dnl #######################################################################
 dnl #######################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,8 @@ AC_CANONICAL_HOST
 
 OPAL_CONFIGURE_SETUP
 
+OPAL_BASIC_SETUP
+
 OPAL_CHECK_ATTRIBUTES
 AS_IF([test "$opal_cv___attribute__deprecated" = 1],
       [SHMEM_AC_HAVE_ATTRIBUTE_DEPRECATED=1],
@@ -49,45 +51,45 @@ AC_SUBST(SHMEM_AC_HAVE_ATTRIBUTE_DEPRECATED)
 OPAL_CHECK_PMIX
 
 AC_ARG_ENABLE([picky],
-    [AC_HELP_STRING([--enable-picky],
+    [AS_HELP_STRING([--enable-picky],
                     [Enable developer-level compiler pickyness when building (default: disabled)])])
 
 AC_ARG_ENABLE([debug],
-    [AC_HELP_STRING([--enable-debug],
+    [AS_HELP_STRING([--enable-debug],
                     [Include debugging symbols in the build (default: disabled)])])
 
 AC_ARG_ENABLE([error-checking],
-    [AC_HELP_STRING([--enable-error-checking],
+    [AS_HELP_STRING([--enable-error-checking],
                     [Enable error checking for SHMEM calls (default:disabled)])])
 AS_IF([test "$enable_error_checking" = "yes"], [AC_DEFINE([ENABLE_ERROR_CHECKING], [1], [Enable argument checking])])
 AM_CONDITIONAL([ENABLE_ERROR_CHECKING], [test "$enable_error_checking" = "yes"])
 
 AC_ARG_ENABLE([deprecated-tests],
-    [AC_HELP_STRING([--enable-deprecated-tests],
+    [AS_HELP_STRING([--enable-deprecated-tests],
                     [Enable deprecated SHMEM API calls in tests (default:disabled)])])
 AM_CONDITIONAL([ENABLE_DEPRECATED_TESTS], [test "$enable_deprecated_tests" = "yes"])
 
 AC_ARG_ENABLE([hard-polling],
-    [AC_HELP_STRING([--enable-hard-polling],
+    [AS_HELP_STRING([--enable-hard-polling],
                     [Enable hard polling of wait calls (default:automatic)])])
 AS_IF([test "$enable_hard_polling" = "yes"], [AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])])
 
 AC_ARG_ENABLE([completion-polling],
-    [AC_HELP_STRING([--enable-completion-polling],
+    [AS_HELP_STRING([--enable-completion-polling],
                     [Enable polling in quiet, fence, and local completion operations (default:disabled)])])
 
 AC_ARG_ENABLE([hwloc-enforce-single-socket],
-    [AC_HELP_STRING([--enable-hwloc-enforce-single-socket],
+    [AS_HELP_STRING([--enable-hwloc-enforce-single-socket],
                     [Repin process to ensure it has affinity to cores within a single socket (default:disabled)])])
 AS_IF([test "$enable_hwloc_enforce_single_socket" = "yes"], [AC_DEFINE([HWLOC_ENFORCE_SINGLE_SOCKET], [1], [Repin process to ensure it has affinity to cores within a single socket])])
 
 AC_ARG_ENABLE([hwloc-enforce-single-numa-node],
-    [AC_HELP_STRING([--enable-hwloc-enforce-single-numa-node],
+    [AS_HELP_STRING([--enable-hwloc-enforce-single-numa-node],
                     [Repin process to ensure it has affinity to cores within a single NUMA node (default:disabled)])])
 AS_IF([test "$enable_hwloc_enforce_single_numa_node" = "yes"], [AC_DEFINE([HWLOC_ENFORCE_SINGLE_NUMA_NODE], [1], [Repin process to ensure it has affinity to cores within a single NUMA node])])
 
 AC_ARG_ENABLE([manual-progress],
-    [AC_HELP_STRING([--enable-manual-progress],
+    [AS_HELP_STRING([--enable-manual-progress],
                     [Enable intermittent progress calls inside transport layer (default:disabled)])])
 AS_IF([test "$enable_completion_polling" = "yes" -o "$enable_manual_progress" = "yes"],
       [AC_DEFINE([DEFAULT_POLL_LIMIT], [-1], [Poll limit for local/remote completions])],
@@ -97,7 +99,7 @@ AS_IF([test "$enable_manual_progress" = "yes"],
       [AC_DEFINE([ENABLE_MANUAL_PROGRESS], [1], [Enable manual progress])])
 
 AC_ARG_ENABLE([total-data-ordering],
-    [AC_HELP_STRING([--enable-total-data-ordering],
+    [AS_HELP_STRING([--enable-total-data-ordering],
        [Configure handling of total data ordering option.  "no" or "never" to build with the assumption total data ordering will never be available.  "yes" or "always" to build with the assumption total data ordering will always be available (if not, applications will abort in start_pes()).  "check" to build with no assumptions, which may lead to a slight performance decrease on high performance networks.  (default: disabled)])])
 AS_CASE([x$enable_total_data_ordering],
   [xyes|xalways], [ordering=1; msg="assume always available"],
@@ -109,7 +111,7 @@ AC_MSG_CHECKING([For total data ordering behavior])
 AC_MSG_RESULT([$msg])
 
 AC_ARG_ENABLE([threads],
-    [AC_HELP_STRING([--disable-threads],
+    [AS_HELP_STRING([--disable-threads],
                     [Disable threading support (default:enabled)])])
 
 AS_IF([test "$enable_threads" != "no"], [
@@ -171,42 +173,42 @@ AS_IF([test "$enable_threads" != "no"], [
 AM_CONDITIONAL([HAVE_OPENMP], [test "$enable_threads" != "no" -a "$enable_openmp" != "no" -a "$ac_cv_prog_c_openmp" != "unsupported"])
 
 AC_ARG_ENABLE([pthread-mutexes],
-    [AC_HELP_STRING([--enable-pthread-mutexes],
+    [AS_HELP_STRING([--enable-pthread-mutexes],
                     [Use pthread mutexes instead of internal queueing locks (default:disabled)])])
 AS_IF([test "$enable_pthread_mutexes" = "yes"], [AC_DEFINE([ENABLE_PTHREAD_MUTEX], [1], [Enable pthread mutexes])])
 
 AC_ARG_ENABLE([thread-completion],
-    [AC_HELP_STRING([--enable-thread-completion],
+    [AS_HELP_STRING([--enable-thread-completion],
         [Support SHMEM_THREAD_MULTIPLE in OFI transport using FI_THREAD_COMPLETION thread safety model instead of FI_THREAD_SAFE (default: disabled)])])
 
 AC_ARG_ENABLE([remote-virtual-addressing],
-    [AC_HELP_STRING([--enable-remote-virtual-addressing],
+    [AS_HELP_STRING([--enable-remote-virtual-addressing],
                     [Enable optimizations assuming the symmetric heap and data segments are located at identical addresses at all PEs.  This may cause erroneous behavior if this assumption is violated, but will reduce the instruction count for some operations.  On Linux systems, this optimization requires disabling ASLR.  This optimization also requires that the Portals 4 implementation support BIND_INACCESSIBLE on LEs. (default: disabled)])])
 AS_IF([test "$enable_remote_virtual_addressing" = "yes"],
       [AC_DEFINE([ENABLE_REMOTE_VIRTUAL_ADDRESSING], [1], [If defined, the implementation will use one LE/PT to cover all of the symmetric data and heap, setup so that no offset transformation is needed on the target virtual address.])])
 
 AC_ARG_ENABLE([aslr-check],
-    [AC_HELP_STRING([--disable-aslr-check],
+    [AS_HELP_STRING([--disable-aslr-check],
                     [Disable check for address space layout randomization (ASLR).  This can be useful when ASLR is enabled, but position-independent executable generation is disabled by compiler or linker flags. (default: enabled)])])
 AS_IF([test "$enable_aslr_check" = "no"],
       [AC_DEFINE(DISABLE_ASLR_CHECK_AC, [1], [Disable ASLR check])])
 
 
 AC_ARG_ENABLE([lengthy-tests],
-    [AC_HELP_STRING([--enable-lengthy-tests],
+    [AS_HELP_STRING([--enable-lengthy-tests],
                     [Execute long running tests as part of "make check" (default: disabled)])])
 AM_CONDITIONAL([ENABLE_LENGTHY_TESTS], [test "$enable_lengthy_tests" = "yes"])
 
 AC_ARG_ENABLE([fortran],
-    [AC_HELP_STRING([--disable-fortran],
+    [AS_HELP_STRING([--disable-fortran],
                     [Disable building the Fortran bindings (default: enabled)])])
 
 AC_ARG_ENABLE([cxx],
-    [AC_HELP_STRING([--disable-cxx],
+    [AS_HELP_STRING([--disable-cxx],
                     [Disable building the C++ bindings (default: enabled)])])
 
 AC_ARG_ENABLE([c11-checks],
-    [AC_HELP_STRING([--disable-c11-checks],
+    [AS_HELP_STRING([--disable-c11-checks],
                     [Disable build-time type checks for C11 bindings (default: enabled)])])
 
 AC_ARG_ENABLE([libtool-wrapper],
@@ -222,7 +224,7 @@ AS_IF([test "$enable_rpath" = "no"], [], [enable_wrapper_rpath="yes"])
 
 
 AC_ARG_ENABLE([profiling],
-    [AC_HELP_STRING([--enable-profiling],
+    [AS_HELP_STRING([--enable-profiling],
                     [Enable profiling (pshmem) interface (default:disabled)])])
 AS_IF([test "$enable_profiling" = "yes"],
       [OPAL_C_WEAK_SYMBOLS()
@@ -232,14 +234,14 @@ AS_IF([test "$enable_profiling" = "yes"],
        ])
 
 AC_ARG_ENABLE([long-fortran-header],
-    [AC_HELP_STRING([--enable-long-fortran-header],
+    [AS_HELP_STRING([--enable-long-fortran-header],
                     [Enable long Fortran header, including all function declarations (default:disabled)])])
 AS_IF([test "$enable_long_fortran_header" = "yes"], [FORTRAN_LONG_HEADER=" "], [FORTRAN_LONG_HEADER="!"])
 AC_SUBST([FORTRAN_LONG_HEADER])
 AM_CONDITIONAL([HAVE_LONG_FORTRAN_HEADER], [test "$enable_long_fortran_header" = "yes"])
 
 AC_ARG_ENABLE([ofi-mr],
-    [AC_HELP_STRING([--enable-ofi-mr=MODE],
+    [AS_HELP_STRING([--enable-ofi-mr=MODE],
                     [OFI memory registration mode: basic, scalable, or rma-event (default: scalable)])])
 
 AS_IF([test -z "$enable_ofi_mr"], [enable_ofi_mr="scalable"])
@@ -255,19 +257,19 @@ AS_CASE([$enable_ofi_mr],
         [AC_MSG_ERROR([Invalid OFI memory registration mode: $enable_ofi_mr])])
 
 AC_ARG_ENABLE([mr-endpoint],
-    [AC_HELP_STRING([--enable-mr-endpoint],
+    [AS_HELP_STRING([--enable-mr-endpoint],
                     [Use FI_MR_ENDPOINT to enable cxi provider. (default: disabled)])])
 AS_IF([test "$enable_mr_endpoint" = "yes"],
       [AC_DEFINE([ENABLE_MR_ENDPOINT], [1], [If defined, the OFI transport will use FI_MR_ENDPOINT])])
 
 AC_ARG_ENABLE([ofi-manual-progress],
-    [AC_HELP_STRING([--enable-ofi-manual-progress],
+    [AS_HELP_STRING([--enable-ofi-manual-progress],
                     [Use FI_MANUAL_PROGRESS for data progress control mode. (default: disabled)])])
 AS_IF([test "$enable_ofi_manual_progress" = "yes"],
       [AC_DEFINE([ENABLE_FI_MANUAL_PROGRESS], [1], [If defined, the OFI will use FI_MANUAL_PROGRESS as data progress mode. This is currently required for cxi provider.])])
 
 AC_ARG_ENABLE([max-teams],
-    [AC_HELP_STRING([--enable-max-teams=NUMBER],
+    [AS_HELP_STRING([--enable-max-teams=NUMBER],
                     [Default value for the maximum number of teams allowed (default: 10)])])
 
 AS_IF([test -z "$enable_max_teams"],
@@ -275,65 +277,65 @@ AS_IF([test -z "$enable_max_teams"],
       [AC_DEFINE_UNQUOTED([DEFAULT_TEAMS_MAX], [$enable_max_teams], [Maximum number of teams (custom)])])
 
 AC_ARG_ENABLE([rpm-prefix],
-    [AC_HELP_STRING([--enable-rpm-prefix],
+    [AS_HELP_STRING([--enable-rpm-prefix],
                     [Generate RPM spec file that supports an alternate installation prefix (default:disabled)])])
 AS_IF([test "$enable_rpm_prefix" = "yes"], [SOS_RPM_PREFIXED=""], [SOS_RPM_PREFIXED="# DISABLED: "])
 AC_SUBST([SOS_RPM_PREFIXED])
 
 AC_ARG_ENABLE([av-map],
-    [AC_HELP_STRING([--enable-av-map],
+    [AS_HELP_STRING([--enable-av-map],
                     [enable av-map instead of av-table in the OFI transport. (default: disabled)])])
 AS_IF([test "$enable_av_map" = "yes"],
       [AC_DEFINE([USE_AV_MAP], [1], [If defined, the OFI transport will use FI_AV_MAP.  Otherwise, FI_AV_TABLE is used.])])
 
 AC_ARG_ENABLE([bounce-buffers],
-    [AC_HELP_STRING([--disable-bounce-buffers],
+    [AS_HELP_STRING([--disable-bounce-buffers],
                     [Disable bounce buffers by default (default: enabled)])])
 AS_IF([test "$enable_bounce_buffers" = "no"],
       [AC_DEFINE([DEFAULT_BOUNCE_SIZE], [0], [Default bounce buffer threshold])],
       [AC_DEFINE([DEFAULT_BOUNCE_SIZE], [2048], [Default bounce buffer threshold])])
 
 AC_ARG_ENABLE([ofi-inject],
-    [AC_HELP_STRING([--disable-ofi-inject],
+    [AS_HELP_STRING([--disable-ofi-inject],
                     [Disable OFI inject by default (default: enabled)])])
 AS_IF([test "$enable_ofi_inject" = "no"],
       [AC_DEFINE([DISABLE_OFI_INJECT], [1], [If defined, the OFI will not use fi_inject.])])
 
 AC_ARG_ENABLE([nonfetch-amo],
-    [AC_HELP_STRING([--disable-nonfetch-amo],
+    [AS_HELP_STRING([--disable-nonfetch-amo],
                     [Disable non-fetching AMO and replace them with fetching AMO (default: enabled)])])
 AS_IF([test "$enable_nonfetch_amo" = "no"],
       [AC_DEFINE([DISABLE_NONFETCH_AMO], [1], [If defined, SOS will fetch values for any AMO.])])
 
 AC_ARG_WITH([oshrun-launcher],
-    [AC_HELP_STRING([--with-oshrun-launcher],
+    [AS_HELP_STRING([--with-oshrun-launcher],
                     [Set launcher to be used by oshrun launcher wrapper. (default: auto)])])
 
 AC_ARG_ENABLE([memcpy],
-    [AC_HELP_STRING([--enable-memcpy],
+    [AS_HELP_STRING([--enable-memcpy],
                     [Use memcpy to perform local put/get operations (default:disabled)])])
 
 AC_ARG_ENABLE([ofi-fence],
-    [AC_HELP_STRING([--enable-ofi-fence],
+    [AS_HELP_STRING([--enable-ofi-fence],
                     [Use FI_FENCE feature to optimize put-with-signal operations. (default: disabled)])])
 AS_IF([test "$enable_ofi_fence" = "yes"],
       [AC_DEFINE([USE_FI_FENCE], [1], [If defined, the OFI transport will use FI_FENCE. Otherwise, transport layer fence is used.])])
 
 AC_ARG_ENABLE([shr-atomics],
-    [AC_HELP_STRING([--enable-shr-atomics],
+    [AS_HELP_STRING([--enable-shr-atomics],
                     [Enable shared memory atomic operations. (default: auto)])])
 AS_IF([test "$enable_shr_atomics" = "yes"],
       [AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])])
 
 AC_ARG_ENABLE([manpages],
-    [AC_HELP_STRING([--enable-manpages],
+    [AS_HELP_STRING([--enable-manpages],
                     [Include man pages in the installation (default:disabled)])])
 AM_CONDITIONAL([ENABLE_MANPAGES], [test "$enable_manpages" = "yes"])
 AS_IF([test "$enable_manpages" = "yes"], [SOS_RPM_MANPAGES=""], [SOS_RPM_MANPAGES="# DISABLED: "])
 AC_SUBST([SOS_RPM_MANPAGES])
 
 AC_ARG_ENABLE([ofi-hmem],
-    [AC_HELP_STRING([--enable-ofi-hmem],
+    [AS_HELP_STRING([--enable-ofi-hmem],
                     [Use FI_HMEM to support transfers to and from device memory. (default: disabled)])])
 AS_IF([test "$enable_ofi_hmem" = "yes"],
       [AC_DEFINE([USE_FI_HMEM], [1], [If defined, the OFI transport will enable FI_HMEM.])])
@@ -383,11 +385,14 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 AS_IF([test "$shmem_cv_c11_works" = "no"],
       [AC_MSG_RESULT([no])
       CFLAGS="$ORIG_CFLAGS"
-      AC_PROG_CC_C99
+      # AC_PROG_CC_C99 is obsolete after autoconf 2.70, because
+      # AC_PROG_CC should revert to C99 automatically if needed
+      m4_version_prereq([2.70], [AC_PROG_CC], [AC_PROG_CC_C99])
       ],
       [AC_MSG_RESULT([yes])
       CFLAGS="-std=gnu11 $ORIG_CFLAGS"]
       )
+
 AC_LANG_POP([C])
 AM_CONDITIONAL([HAVE_C11], [test "$shmem_cv_c11_works" = "yes" -a "$enable_c11_checks" != "no"])
 # end gnu11/gnu99 check
@@ -436,7 +441,9 @@ OPAL_CHECK_PORTALS4([portals4],
     [transport_portals4="yes"],
     [transport_portals4="no"])
 
-OPAL_CHECK_OFI
+OPAL_CHECK_OFI([ofi],
+    [transport_ofi="yes"],
+    [transport_ofi="no"])
 
 AS_IF([test "$opal_ofi_happy" = "yes"],
     [transport_ofi="yes"],
@@ -544,9 +551,9 @@ if test "$enable_shr_atomics" != "no" -a "$transport_xpmem" = "yes" -a "$transpo
     AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])
 fi
 
-AC_ARG_ENABLE([pmi-simple], [AC_HELP_STRING([--enable-pmi-simple],
+AC_ARG_ENABLE([pmi-simple], [AS_HELP_STRING([--enable-pmi-simple],
               [Use MPICH simple PMI-1 library for process management])])
-AC_ARG_ENABLE([pmi-mpi], [AC_HELP_STRING([--enable-pmi-mpi],
+AC_ARG_ENABLE([pmi-mpi], [AS_HELP_STRING([--enable-pmi-mpi],
               [Use MPI for process management])])
 
 AS_IF([test "$enable_pmi_simple" = "yes" -o "$enable_pmi_mpi" = "yes"],
@@ -616,9 +623,9 @@ AS_IF([test "$enable_pmi_simple" = "yes"],
 dnl check for types
 
 AC_LANG_PUSH([C])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ _Complex v; ]] )],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ ]], [[ float _Complex v; ]] )],
                   [],
-                  [AC_ERROR([C Compiler does not support _Complex])])
+                  [AC_MSG_ERROR(C Compiler does not support _Complex)])
 AC_LANG_POP([C])
 
 SHMEM_FIND_INT_TYPE([char], [$transport])
@@ -687,18 +694,16 @@ AC_MSG_CHECKING([size of SHMEM_REDUCE_MIN_WRKDATA_SIZE])
 AC_MSG_RESULT([$C_REDUCE_MIN_WRKDATA_SIZE])
 
 AC_MSG_CHECKING([if long can hold lock_t])
-AC_TRY_RUN([struct lock_s { int a; int b; }; int main(void) { if (sizeof(long) == sizeof(struct lock_s)) return 0; else return 1; }],
-               [AC_MSG_RESULT([yes])], [
+AC_RUN_IFELSE([AC_LANG_SOURCE([[struct lock_s { int a; int b; }; int main(void) { if (sizeof(long) == sizeof(struct lock_s)) return 0; else return 1; }]])],[AC_MSG_RESULT([yes])],[
                 AC_MSG_RESULT([no])
-                AC_MSG_ERROR([Lock API requires long can hold 'struct { int a; int b; }']) ])
+                AC_MSG_ERROR([Lock API requires long can hold 'struct { int a; int b; }']) ],[])
 
 if test "$FC" != "" ; then
   AC_DEFINE([ENABLE_FORTRAN],[1],[Fortran support enabled])
   AC_MSG_CHECKING([if complex sizes are appropriate])
-  AC_TRY_RUN([float _Complex x; double _Complex y; int main(void) { if (sizeof(x)==8 && sizeof(y)==16) return 0; else return 1; }],
-                 [AC_MSG_RESULT([yes])], [
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[float _Complex x; double _Complex y; int main(void) { if (sizeof(x)==8 && sizeof(y)==16) return 0; else return 1; }]])],[AC_MSG_RESULT([yes])],[
                   AC_MSG_RESULT([no])
-                  AC_MSG_ERROR([float _Complex and double _Complex must be 4 and 8 bytes, respectively]) ])
+                  AC_MSG_ERROR([float _Complex and double _Complex must be 4 and 8 bytes, respectively]) ],[])
   # make sure Fortran supports ISO_C_BINDING (Fortran 2003)
   AC_CACHE_CHECK([if Fortran compiler supports ISO_C_BINDING],
     [shmem_cv_fortran_iso_c_binding],
@@ -824,7 +829,7 @@ AC_SUBST(aslr_LDFLAGS)
 dnl check for library functions
 
 AC_MSG_CHECKING([for data segment pointer])
-AC_TRY_RUN([
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #ifdef __APPLE__
 #include <mach-o/getsect.h>
 #else
@@ -854,11 +859,9 @@ int main(void) {
 #endif
     if (!(base != (void*)0 && length > 0)) return 2;
     return 0;
-}],
-    AC_MSG_RESULT([found]),
-    [ AC_MSG_RESULT([not found])
+}]])],[AC_MSG_RESULT(found)],[ AC_MSG_RESULT([not found])
       AC_MSG_ERROR([Could not locate data segment])
-    ])
+    ],[])
 
 dnl final output
 
@@ -912,11 +915,11 @@ if test "$transport_portals4" = "yes" ; then
 fi
 
 if test "$transport_ofi" = "yes" ; then
-    CPPFLAGS="$CPPFLAGS $opal_ofi_CPPFLAGS"
-    LDFLAGS="$LDFLAGS $opal_ofi_LDFLAGS"
-    LIBS="$LIBS $opal_ofi_LIBS"
-    WRAPPER_COMPILER_EXTRA_LDFLAGS="$opal_ofi_LDFLAGS"
-    WRAPPER_COMPILER_EXTRA_LIBS="$opal_ofi_LIBS"
+    CPPFLAGS="$CPPFLAGS $ofi_CPPFLAGS"
+    LDFLAGS="$LDFLAGS $ofi_LDFLAGS"
+    LIBS="$LIBS $ofi_LIBS"
+    WRAPPER_COMPILER_EXTRA_LDFLAGS="$ofi_LDFLAGS"
+    WRAPPER_COMPILER_EXTRA_LIBS="$ofi_LIBS"
 fi
 
 if test "$transport_ucx" = "yes" ; then


### PR DESCRIPTION
This PR aligns SOS's configury with OMPI's main branch ref [cebad71e](https://github.com/open-mpi/ompi/commit/cebad71e4f50d49e486ccd54668cf58698556a7c)

It removes several configure-time warnings about obsolete autotools features and adds relevant updates for OFI (esp. for HMEM), UCX, and Portals4.

All changes from `OMPI/config/*` are verbatim, and `SOS/configure.ac` was run through `autoupdate`.