### PR TITLE
Option to disable non-fetch AMO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
           - config_name: Without OFI inject
             sos_config: --disable-ofi-inject --enable-pmi-simple
             libfabric_version: v1.13.x
+          - config_name: Without Non-fetch AMO
+            sos_config: --disable-nonfetch-amo --enable-pmi-simple
+            libfabric_version: v1.13.x
                      
     name: OFI ${{ matrix.libfabric_version }} (${{ matrix.config_name }})
 

--- a/configure.ac
+++ b/configure.ac
@@ -297,7 +297,13 @@ AC_ARG_ENABLE([ofi-inject],
     [AC_HELP_STRING([--disable-ofi-inject],
                     [Disable OFI inject by default (default: enabled)])])
 AS_IF([test "$enable_ofi_inject" = "no"],
-      [AC_DEFINE([DISABLE_OFI_INJECT], [0], [If defined, the OFI will not use fi_inject.])])
+      [AC_DEFINE([DISABLE_OFI_INJECT], [1], [If defined, the OFI will not use fi_inject.])])
+
+AC_ARG_ENABLE([nonfetch-amo],
+    [AC_HELP_STRING([--disable-nonfetch-amo],
+                    [Disable non-fetching AMO and replace them with fetching AMO (default: enabled)])])
+AS_IF([test "$enable_nonfetch_amo" = "no"],
+      [AC_DEFINE([DISABLE_NONFETCH_AMO], [1], [If defined, SOS will fetch values for any AMO.])])
 
 AC_ARG_WITH([oshrun-launcher],
     [AC_HELP_STRING([--with-oshrun-launcher],

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -244,8 +244,13 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_atomic(ctx, target, source, len, pe, op, datatype);
     } else {
+#ifdef DISABLE_NONFETCH_AMO
+        shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
+                                     source, target, len, pe, op, datatype);
+#else
         shmem_transport_atomic((shmem_transport_ctx_t *)ctx, target, source,
                                len, pe, op, datatype);
+#endif
     }
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -245,8 +245,10 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
         shmem_shr_transport_atomic(ctx, target, source, len, pe, op, datatype);
     } else {
 #ifdef DISABLE_NONFETCH_AMO
+        unsigned long long tmp_fetch = 0;
         shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
-                                     source, target, len, pe, op, datatype);
+                                     source, &tmp_fetch, len, pe, op, datatype);
+        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
 #else
         shmem_transport_atomic((shmem_transport_ctx_t *)ctx, target, source,
                                len, pe, op, datatype);
@@ -281,8 +283,15 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_atomic_set(ctx, target, source, len, pe, datatype);
     } else {
+#ifdef DISABLE_NONFETCH_AMO
+        unsigned long long tmp_fetch = 0;
+        shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
+                                     source, &tmp_fetch, len, pe, FI_ATOMIC_WRITE, datatype);
+        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
+#else
         shmem_transport_atomic_set((shmem_transport_ctx_t *)ctx, target,
                                    source, len, pe, datatype);
+#endif
     }
 }
 


### PR DESCRIPTION
This PR adds support to optionally disable non-fetch AMO and instead fetch AMO. This is due to a bug with non-fetch AMO on CXI provider that gets stuck after a certain number of operations when optimized MR mode is not used. This is a temporary work-around and may be removed as the original bug is resolved. 