### PR TITLE
src: Bug fix in shmem_internal_copy_self

### DIFF
--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -376,7 +376,10 @@ static inline
 void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
 {
 #ifdef USE_FI_HMEM
-    long completion = 0;
+    // "completion" set to 1 to wait for completion of put operation initiated
+    // by shmem_internal_put_nb, even if "completion" not incremented in call 
+    // to shmem_internal_put_nb.
+    long completion = 1;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion);
     shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);


### PR DESCRIPTION
This PR makes it such that **shmem_internal_copy_self** will always wait until any pending put operations are complete before returning.

For example, when using OFI with bounce buffers enabled it is possible that **shmem_internal_put_nb** will not increment the **completion** value. If **completion** is zero, the call to **shmem_internal_put_wait** will not wait for completion of pending/ongoing put transactions before returning, even though the intent of **shmem_internal_copy_self** is to be blocking.