### PR TITLE
fix pedantic compiler warnings

### DIFF
--- a/mpp/shmemx_c_func.h4
+++ b/mpp/shmemx_c_func.h4
@@ -92,6 +92,6 @@ SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_ctx_signal_set(shmem_ctx_t ctx, uin
 
 /* Separate initializers */
 SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_heap_create(void *base, size_t size, int device_type, int device_index);
-SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_heap_preinit();
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_heap_preinit(void);
 SHMEM_FUNCTION_ATTRIBUTES int SHPRE()shmemx_heap_preinit_thread(int requested, int *provided);
-SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_heap_postinit();
+SHMEM_FUNCTION_ATTRIBUTES void SHPRE()shmemx_heap_postinit(void);

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -412,7 +412,7 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
 
     shmem_internal_team_release_psyncs(parent_team, SYNC);
 
-    /* This OR reduction assures all PEs return the same value.  */
+    /* This MAX reduction assures all PEs return the same value.  */
     psync = shmem_internal_team_choose_psync(parent_team, REDUCE);
 
     shmem_internal_op_to_all(team_ret_val_reduced, team_ret_val, 1, sizeof(int),

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1348,6 +1348,7 @@ int allocate_fabric_resources(struct fabric_info *info)
 }
 
 #ifdef USE_HWLOC
+static inline
 struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **provs, size_t num_nics) {
     int ret = 0;
     hwloc_bitmap_t bindset = hwloc_bitmap_alloc();
@@ -1420,6 +1421,7 @@ static int compare_nic_names(const void *f1, const void *f2)
     return strcmp((*fabric1)->nic->device_attr->name, (*fabric2)->nic->device_attr->name);
 }
 
+static inline
 bool nic_already_used(struct fid_nic *nic, struct fi_info *fabrics, int num_nics)
 {
     struct fi_info *cur_fabric = fabrics;


### PR DESCRIPTION
These are small fixes for compiler warnings found with `--enable-pedantic`.