### PR TITLE
src: Add fix to query_for_fabric

### DIFF
--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1556,7 +1556,7 @@ int query_for_fabric(struct fabric_info *info)
                 }
             }
         }
-        fabrics_list_tail->next = NULL;
+        if (fabrics_list_tail) fabrics_list_tail->next = NULL;
     }
     else {
         fabrics_list_head = info->fabrics;


### PR DESCRIPTION
This PR adds a fix to an issue detected by Coverity where **fabrics_list_tail** could - in certain scenarios - be dereferenced when it is NULL