### PR TITLE
Teams: move warning to debug message for config_mask==0 and config == null

### DIFF
--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -337,8 +337,8 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
 
         if (config_mask == 0) {
             if (config != NULL) {
-                RAISE_WARN_MSG("%s %s\n", "team_split_strided operation encountered an unexpected",
-                               "non-NULL config structure passed with a config_mask of 0.");
+                DEBUG_MSG("%s %s\n", "team_split_strided operation encountered an unexpected",
+                          "non-NULL config structure passed with a config_mask of 0.");
             }
             shmem_team_config_t defaults;
             myteam->config_mask   = 0;


### PR DESCRIPTION
As discussed in #1122, this warning may not be necessary, especially with some upcoming proposed changes to the specification to clarify this special case.

For now this PR changes this to a debug message, so at least users will not see any message unless the env var `SHMEM_DEBUG=1` is set.

I could likely be convinced to remove this message entirely, but given the state of the OpenSHMEM v1.5 spec, which is unclear as to whether a null `config` argument is acceptable, a debug message might be a better "compromise".

@dalcinl @stewartl318 @mrogowski - I invited you as collaborators to review, you'll need to accept it in email.