### PR TITLE
Teams: remove debug msg if mask==0 & config!=null

### DIFF
--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -336,10 +336,6 @@ int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE
         myteam->size        = PE_size;
 
         if (config_mask == 0) {
-            if (config != NULL) {
-                DEBUG_MSG("%s %s\n", "team_split_strided operation encountered an unexpected",
-                          "non-NULL config structure passed with a config_mask of 0.");
-            }
             shmem_team_config_t defaults;
             myteam->config_mask   = 0;
             myteam->contexts_len  = 0;


### PR DESCRIPTION
This relates to PRs #1138 and #1122.  It removes the debug message in the case that `config_mask == 0` and `config == null`.