### PR TITLE
configury: add -lpmi_simple to AM_LDFLAGS

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,6 +130,7 @@ endif
 
 if USE_PMI_SIMPLE
 AM_CPPFLAGS += -I$(top_srcdir)/pmi-simple
+AM_LDFLAGS = -L$(top_builddir)/pmi-simple -lpmi_simple
 libsma_la_SOURCES += \
 	runtime-pmi.c
 else


### PR DESCRIPTION
This comes from a perfectly reasonable request from @abrooks98 to link in `pmi-simple` as a direct dependency of `libsma`, when `pmi-simple` is enabled.