### PR TITLE
configury: Fixed disable-rpath

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -948,6 +948,8 @@ LIBS="$LIBS $pmi_LIBS"
 WRAPPER_COMPILER_EXTRA_LDFLAGS="$WRAPPER_COMPILER_EXTRA_LDFLAGS $pmi_LDFLAGS $aslr_LDFLAGS"
 WRAPPER_COMPILER_EXTRA_LIBS="$WRAPPER_COMPILER_LIBS $pmi_LIBS"
 
+AS_IF([test "$enable_rpath" = "no"], [hardcode_into_libs="no"], [])
+
 # Need the libtool binary before setting up rpath
 LT_OUTPUT
 


### PR DESCRIPTION
Issue #1162

The build system relies on libtool to build libraries. libtool will insert an rpath into libraries unless you set hardcode_into_libs = no. Modified configury to set hardcode_into_libs if disable-rpath is set.