### PR TITLE
CI: Ignore failures during UCX testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,7 @@ jobs:
           make -j
           make install
       - name: Test SOS (${{ matrix.sos_config }})
+        continue-on-error: true
         run: |
           cd build
           make check TESTS= -j


### PR DESCRIPTION
There two issues with UCX in CI #1148 and #1048 that are under debug. Temporarily disable the test until these tickets are root caused and resolved inorder to reduce noise in CI results.