### PR TITLE
ofi: merge the default ctx and target endpoints

### DIFF
--- a/README
+++ b/README
@@ -263,6 +263,15 @@ options.
         Disable multirail functionality. Enabling this will restrict all
         communications to occur over a single NIC per system.
 
+    SHMEM_OFI_DISABLE_SINGLE_EP (default: off)
+        Disable the single endpoint resource optimization. Setting this (to any
+        value) will enable at least 2 separate endpoints per PE, one for
+        transmission on the default context and one as the target of
+        communication. If unset, the default context and the target endpoint
+        are merged to conserve context resources.  Regardless of this
+        parameter, each PE consumes another endpoint for each OpenSHMEM user
+        context that is created.
+
   Team Environment variables:
 
     SHMEM_TEAMS_MAX (default: 10)

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -109,6 +109,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_STX_DISABLE_PRIVATE, bool, false, SHMEM_INTERNAL_ENV_
                        "Disallow private contexts from having exclusive STX access")
 SHMEM_INTERNAL_ENV_DEF(OFI_DISABLE_MULTIRAIL, bool, false, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Disable usage of multirail functionality")
+SHMEM_INTERNAL_ENV_DEF(OFI_DISABLE_SINGLE_EP, bool, false, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Disable single endpoint resource optimization (enable separate Tx and Rx EPs)")
 #endif
 
 #ifdef USE_UCX


### PR DESCRIPTION
SOS currently opens 2 libfabric endpoints (EPs) per process, which can lead to Rx/TX resource exhaustion in scale-up scenarios (like with 1 process per core, when there are more cores on the CPU than there are contexts on the NIC - see https://github.com/Sandia-OpenSHMEM/SOS/issues/1127).  This PR merges those 2 endpoints, which benefits scaling (i.e., it  improves the maximum PPN by 2x in typical cases), and seems to improve overall performance due to better runtime progress.

In this PR I propose we make single-EP the default behavior for SOS over OFI transport.  The optimization can be disabled by setting the new env var `SHMEM_OFI_DISABLE_SINGLE_EP`.

This also has the benefit of enabling `FI_MANUAL_PROGRESS` for a few providers, like OPX, TCP, and sockets - when SOS is configured with `--enable-ofi-manual-progress` _and_ `--enable-manual-progress`.