### PR TITLE
Fixed SHMEM_SYMMETRIC_SIZE

### DIFF
--- a/src/shmem_env.c
+++ b/src/shmem_env.c
@@ -38,9 +38,12 @@ atol_scaled(char *str, shmem_internal_env_size *out)
     double p = -1.0;
     char f;
 
-    n = sscanf(str, "%lf%c", &p, &f);
+    if (2 == sscanf(str, "%lf%c%n", &p, &f, &n)) {
+        if (str[n] != '\0') {
+            fprintf(stderr, "Invalid size in environment variable\n");
+            return 1;
+        }
 
-    if (n == 2) {
         switch (f) {
             case 'k':
             case 'K':


### PR DESCRIPTION
i inspired by [OpenMPI](https://github.com/open-mpi/ompi/blob/6ec63e2b69d4ef5b0e085d38abfab35d24008318/oshmem/info/info.c#L240C10-L240C30)

#1185 