### PR TITLE
Improving OFI Transport Counter Polling Implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,11 +69,13 @@ jobs:
             xpmem_version: master
             sos_config: --with-xpmem=${XPMEM_INSTALL_DIR} --enable-error-checking
                         --enable-remote-virtual-addressing --enable-pmi-simple
+                        --enable-hard-polling
             libfabric_version: v2.1.x
           - config_name: XPMEM shared atomics
             xpmem_version: master
             sos_config: --with-xpmem=${XPMEM_INSTALL_DIR} --enable-shr-atomics
                         --enable-error-checking --enable-pmi-simple
+                        --enable-hard-polling
             libfabric_version: v2.1.x
           - config_name: RVA, thread completion
             sos_config: --enable-error-checking --enable-remote-virtual-addressing
@@ -517,7 +519,7 @@ jobs:
         sos_config: [--enable-pmi-simple --disable-fortran,
                      --with-cma --enable-error-checking --enable-profiling
                      --enable-pmi-simple --disable-fortran --with-hwloc=no,
-                     --with-xpmem --enable-error-checking --enable-pmi-simple --with-hwloc=no]
+                     --with-xpmem --enable-error-checking --enable-pmi-simple --with-hwloc=no --enable-hard-polling]
     steps:
       - name: Checking OS version
         run: |
@@ -620,7 +622,7 @@ jobs:
       matrix:
         include:
           - config_name: XPMEM with Shared Atomics
-            sos_config: --with-xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple
+            sos_config: --with-xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple --enable-hard-polling
             portals4_version: master
             xpmem_version: master
 
@@ -736,7 +738,7 @@ jobs:
         include:
           - config_name: transport_none
             xpmem_version: master
-        sos_config: [--with-xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple]
+        sos_config: [--with-xpmem --enable-shr-atomics --enable-error-checking --enable-pmi-simple --enable-hard-polling]
 
     steps:
       - name: Checking OS version

--- a/configure.ac
+++ b/configure.ac
@@ -537,7 +537,6 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
-       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1731,6 +1731,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     cntr_put_attr.events   = FI_CNTR_EVENTS_COMP;
     cntr_get_attr.events   = FI_CNTR_EVENTS_COMP;
 
+#if 0
     /* Set FI_WAIT based on the put and get polling limits defined above */
     if (shmem_transport_ofi_put_poll_limit < 0) {
         cntr_put_attr.wait_obj = FI_WAIT_NONE;
@@ -1742,6 +1743,9 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     } else {
         cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
     }
+#endif
+        cntr_put_attr.wait_obj = FI_WAIT_UNSPEC;
+        cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
 
     /* Allow provider to choose CQ size, since we are using FI_RM_ENABLED.
      * Context format is used to return bounce buffer pointers in the event


### PR DESCRIPTION
The current libfabric counter polling implementation requires a series of separate lock acquisitions fi_cntr(), fi_cntr_err(), and fi_cq_read(), that can be simplified if we only use fi_cnt_wait(). We see improvements in put latency benchmarks when the shmem_transport_ofi_put_quiet() polling code is removed and no change in functionality.

Addresses Issue #1217 
For evaluation purposes only.