### PR TITLE
ofi: Add per-operation NIC Tx load balancing (round-robin and random)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -340,6 +340,12 @@ AC_ARG_ENABLE([ofi-hmem],
 AS_IF([test "$enable_ofi_hmem" = "yes"],
       [AC_DEFINE([USE_FI_HMEM], [1], [If defined, the OFI transport will enable FI_HMEM.])])
 
+AC_ARG_ENABLE([ofi-tx-load-balancing],
+    [AS_HELP_STRING([--enable-ofi-tx-load-balancing],
+                    [Enable OFI transmit load balancing across available NICs. (default: disabled)])])
+AS_IF([test "$enable_ofi_tx_load_balancing" = "yes"],
+      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will randomly select among available NICs for transmit operations.])])
+
 PKG_INSTALLDIR()
 
 dnl check for programs

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,7 @@ AS_IF([test "$with_hwloc" != "no"], [
         OPAL_3RDPARTY_WITH([hwloc], [hwloc], [package_hwloc])
         _OPAL_CONFIG_HWLOC_EXTERNAL(
             [external_hwloc_happy=1
+             shmem_hwloc_found=yes
              opal_hwloc_mode="external"
              AC_DEFINE([USE_HWLOC], [1], [Enable hwloc. Default behavior is to automatically enable hwloc if installation can be found])],
             [AS_IF([test -n "$with_hwloc"],
@@ -340,17 +341,25 @@ AC_ARG_ENABLE([ofi-hmem],
 AS_IF([test "$enable_ofi_hmem" = "yes"],
       [AC_DEFINE([USE_FI_HMEM], [1], [If defined, the OFI transport will enable FI_HMEM.])])
 
-AC_ARG_ENABLE([ofi-tx-load-balancing],
-    [AS_HELP_STRING([--enable-ofi-tx-load-balancing],
-                    [Enable OFI transmit load balancing across available NICs using round-robin selection. (default: disabled)])])
-AS_IF([test "$enable_ofi_tx_load_balancing" = "yes"],
-      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will use round-robin selection among available NICs for transmit operations.])])
+AC_ARG_ENABLE([ofi-tx-load-balancing-round-robin],
+    [AS_HELP_STRING([--enable-ofi-tx-load-balancing-round-robin],
+                    [Enable OFI transmit load balancing across available NICs using round-robin selection. Requires --with-hwloc. Mutually exclusive with --enable-ofi-tx-load-balancing-random. (default: disabled)])])
 
 AC_ARG_ENABLE([ofi-tx-load-balancing-random],
     [AS_HELP_STRING([--enable-ofi-tx-load-balancing-random],
-                    [Enable OFI transmit load balancing across available NICs using random selection. Implies --enable-ofi-tx-load-balancing. (default: disabled)])])
+                    [Enable OFI transmit load balancing across available NICs using random selection. Requires --with-hwloc. Mutually exclusive with --enable-ofi-tx-load-balancing-round-robin. (default: disabled)])])
+
+AS_IF([test "$enable_ofi_tx_load_balancing_round_robin" = "yes" -a "$enable_ofi_tx_load_balancing_random" = "yes"],
+      [AC_MSG_ERROR([--enable-ofi-tx-load-balancing-round-robin and --enable-ofi-tx-load-balancing-random are mutually exclusive])])
+
+AS_IF([test "$enable_ofi_tx_load_balancing_round_robin" = "yes"],
+      [AS_IF([test "$shmem_hwloc_found" != "yes"],
+             [AC_MSG_ERROR([--enable-ofi-tx-load-balancing-round-robin requires hwloc; ensure hwloc is installed and --with-hwloc is not disabled])])
+       AC_DEFINE([USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN], [1], [If defined, the OFI transport will use round-robin selection among available NICs for transmit operations.])])
+
 AS_IF([test "$enable_ofi_tx_load_balancing_random" = "yes"],
-      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will select among available NICs for transmit operations.])
+      [AS_IF([test "$shmem_hwloc_found" != "yes"],
+             [AC_MSG_ERROR([--enable-ofi-tx-load-balancing-random requires hwloc; ensure hwloc is installed and --with-hwloc is not disabled])])
        AC_DEFINE([USE_OFI_TX_LOAD_BALANCING_RANDOM], [1], [If defined, the OFI transport will use random selection among available NICs for transmit operations.])])
 
 PKG_INSTALLDIR()

--- a/configure.ac
+++ b/configure.ac
@@ -342,9 +342,16 @@ AS_IF([test "$enable_ofi_hmem" = "yes"],
 
 AC_ARG_ENABLE([ofi-tx-load-balancing],
     [AS_HELP_STRING([--enable-ofi-tx-load-balancing],
-                    [Enable OFI transmit load balancing across available NICs. (default: disabled)])])
+                    [Enable OFI transmit load balancing across available NICs using round-robin selection. (default: disabled)])])
 AS_IF([test "$enable_ofi_tx_load_balancing" = "yes"],
-      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will randomly select among available NICs for transmit operations.])])
+      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will use round-robin selection among available NICs for transmit operations.])])
+
+AC_ARG_ENABLE([ofi-tx-load-balancing-random],
+    [AS_HELP_STRING([--enable-ofi-tx-load-balancing-random],
+                    [Enable OFI transmit load balancing across available NICs using random selection. Implies --enable-ofi-tx-load-balancing. (default: disabled)])])
+AS_IF([test "$enable_ofi_tx_load_balancing_random" = "yes"],
+      [AC_DEFINE([USE_OFI_TX_LOAD_BALANCING], [1], [If defined, the OFI transport will select among available NICs for transmit operations.])
+       AC_DEFINE([USE_OFI_TX_LOAD_BALANCING_RANDOM], [1], [If defined, the OFI transport will use random selection among available NICs for transmit operations.])])
 
 PKG_INSTALLDIR()
 

--- a/src/atomic_c.c4
+++ b/src/atomic_c.c4
@@ -310,8 +310,11 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic(ctx, target, &tmp, sizeof(TYPE),          \
-                              pe, SHM_INTERNAL_SUM, ITYPE);             \
+                              pe, SHM_INTERNAL_SUM, ITYPE, nic_idx);    \
     }
 
 
@@ -361,8 +364,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic(ctx, target, &value, sizeof(TYPE),        \
-                              pe, SHM_INTERNAL_SUM, ITYPE);             \
+                              pe, SHM_INTERNAL_SUM, ITYPE, nic_idx);    \
     }
 
 
@@ -432,8 +437,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(dest, sizeof(TYPE));                  \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic_set(ctx, (void *) dest, &value,           \
-                                  sizeof(TYPE), pe, ITYPE);             \
+                                  sizeof(TYPE), pe, ITYPE, nic_idx);    \
     }
 
 
@@ -445,8 +452,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic(ctx, target, &value, sizeof(TYPE),        \
-                              pe, SHM_INTERNAL_BXOR, ITYPE);            \
+                              pe, SHM_INTERNAL_BXOR, ITYPE, nic_idx);   \
     }
 
 
@@ -458,8 +467,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic(ctx, target, &value, sizeof(TYPE),        \
-                              pe, SHM_INTERNAL_BAND, ITYPE);            \
+                              pe, SHM_INTERNAL_BAND, ITYPE, nic_idx);   \
     }
 
 
@@ -471,8 +482,10 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic(ctx, target, &value, sizeof(TYPE),        \
-                              pe, SHM_INTERNAL_BOR, ITYPE);             \
+                              pe, SHM_INTERNAL_BOR, ITYPE, nic_idx);    \
     }
 
 

--- a/src/atomic_c.c4
+++ b/src/atomic_c.c4
@@ -232,9 +232,12 @@ SHMEM_DEFINE_FOR_EXTENDED_AMO(`SHMEM_PROF_DEF_CTX_ATOMIC_SET')
         SHMEM_ERR_CHECK_PE(pe);                                 \
         SHMEM_ERR_CHECK_CTX(ctx);                               \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));        \
+                                                                \
+        size_t nic_idx = 0;                                     \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                     \
         shmem_internal_swap(ctx, target, &value, &newval,       \
-                            sizeof(TYPE), pe, ITYPE);           \
-        shmem_internal_get_wait(ctx);                           \
+                            sizeof(TYPE), pe, ITYPE, nic_idx);  \
+        shmem_internal_get_wait(ctx, nic_idx);                  \
         return newval;                                          \
     }
 
@@ -251,8 +254,11 @@ shmem_swap(long *target, long value, int pe)
     SHMEM_ERR_CHECK_PE(pe);
     SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(long));
 
-    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, target, &value, &newval, sizeof(long), pe, SHM_INTERNAL_LONG, nic_idx);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx);
     return newval;
 }
 #endif
@@ -267,9 +273,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_cswap(ctx, target, &value, &newval, &cond,       \
-                             sizeof(TYPE), pe, ITYPE);                  \
-        shmem_internal_get_wait(ctx);                                   \
+                             sizeof(TYPE), pe, ITYPE, nic_idx);         \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return newval;                                                  \
     }
 
@@ -283,9 +292,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_cswap(ctx, target, &value, &newval, &cond,       \
-                             sizeof(TYPE), pe, ITYPE);                  \
-        shmem_internal_get_wait(ctx);                                   \
+                             sizeof(TYPE), pe, ITYPE, nic_idx);         \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return newval;                                                  \
     }
 
@@ -311,10 +323,13 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic(ctx, target, &tmp, &oldval,         \
                                     sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
-                                    ITYPE);                             \
-        shmem_internal_get_wait(ctx);                                   \
+                                    ITYPE, nic_idx);                    \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return oldval;                                                  \
     }
 
@@ -327,10 +342,13 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic(ctx, target, &tmp, &oldval,         \
                                     sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
-                                    ITYPE);                             \
-        shmem_internal_get_wait(ctx);                                   \
+                                    ITYPE, nic_idx);                    \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return oldval;                                                  \
     }
 
@@ -358,10 +376,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic(ctx, target, &value, &oldval,       \
                                     sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
-                                    ITYPE);                             \
-        shmem_internal_get_wait(ctx);                                   \
+                                    ITYPE, nic_idx);                    \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return oldval;                                                  \
     }
 
@@ -375,10 +395,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic(ctx, target, &value, &oldval,       \
                                     sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
-                                    ITYPE);                             \
-        shmem_internal_get_wait(ctx);                                   \
+                                    ITYPE, nic_idx);                    \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return oldval;                                                  \
     }
 
@@ -393,9 +415,11 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE));                \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic_fetch(ctx, &val, (void *) source,         \
-                                    sizeof(TYPE), pe, ITYPE);           \
-        shmem_internal_get_wait(ctx);                                   \
+                                    sizeof(TYPE), pe, ITYPE, nic_idx);  \
+        shmem_internal_get_wait(ctx, nic_idx);                          \
         return val;                                                     \
     }
 
@@ -454,7 +478,7 @@ shmem_swap(long *target, long value, int pe)
 
 #define SHMEM_DEF_FETCH_XOR(STYPE,TYPE,ITYPE)                                \
     TYPE SHMEM_FUNCTION_ATTRIBUTES                                           \
-    SHMEM_FUNC_PROTOTYPE(STYPE, fetch_xor, TYPE *target, TYPE value,  \
+    SHMEM_FUNC_PROTOTYPE(STYPE, fetch_xor, TYPE *target, TYPE value,         \
                          int  pe)                                            \
         TYPE oldval;                                                         \
         SHMEM_ERR_CHECK_INITIALIZED();                                       \
@@ -462,10 +486,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                            \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
+        size_t nic_idx = 0;                                                  \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                 \
         shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BXOR,     \
-                                    ITYPE);                                  \
-        shmem_internal_get_wait(ctx);                                        \
+                                    ITYPE, nic_idx);                         \
+        shmem_internal_get_wait(ctx, nic_idx);                               \
         return oldval;                                                       \
     }
 
@@ -479,10 +505,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                            \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
+        size_t nic_idx = 0;                                                  \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                 \
         shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BAND,     \
-                                    ITYPE);                                  \
-        shmem_internal_get_wait(ctx);                                        \
+                                    ITYPE, nic_idx);                         \
+        shmem_internal_get_wait(ctx, nic_idx);                               \
         return oldval;                                                       \
     }
 
@@ -496,10 +524,12 @@ shmem_swap(long *target, long value, int pe)
         SHMEM_ERR_CHECK_CTX(ctx);                                            \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                     \
                                                                              \
+        size_t nic_idx = 0;                                                  \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                 \
         shmem_internal_fetch_atomic(ctx, target, &value, &oldval,            \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BOR,      \
-                                    ITYPE);                                  \
-        shmem_internal_get_wait(ctx);                                        \
+                                    ITYPE, nic_idx);                         \
+        shmem_internal_get_wait(ctx, nic_idx);                               \
         return oldval;                                                       \
     }
 

--- a/src/atomic_f.c
+++ b/src/atomic_f.c
@@ -41,8 +41,8 @@ FC_SHMEM_SWAP(fortran_integer_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, SIZEOF_FORTRAN_INTEGER);
 
     shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, SIZEOF_FORTRAN_INTEGER,
-                        *pe, SHM_INTERNAL_FORTRAN_INTEGER);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                        *pe, SHM_INTERNAL_FORTRAN_INTEGER, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -64,8 +64,8 @@ FC_SHMEM_INT4_SWAP(int32_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
     shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 4,
-                        *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                        *pe, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -87,8 +87,8 @@ FC_SHMEM_INT8_SWAP(int64_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
     shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 8,
-                        *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                        *pe, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -112,8 +112,8 @@ FC_SHMEM_REAL4_SWAP(float *target,
     shmem_internal_assert(sizeof(float) == 4);
 
     shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 4,
-                        *pe, SHM_INTERNAL_FLOAT);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                        *pe, SHM_INTERNAL_FLOAT, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -137,8 +137,8 @@ FC_SHMEM_REAL8_SWAP(double *target,
     shmem_internal_assert(sizeof(double) == 8);
 
     shmem_internal_swap(SHMEM_CTX_DEFAULT, target, value, &newval, 8,
-                        *pe, SHM_INTERNAL_DOUBLE);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                        *pe, SHM_INTERNAL_DOUBLE, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -163,8 +163,8 @@ FC_SHMEM_INT4_CSWAP(int32_t *target,
 
     shmem_internal_cswap(SHMEM_CTX_DEFAULT, target, value, &newval, cond,
                          4,
-                         *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                         *pe, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -189,8 +189,8 @@ FC_SHMEM_INT8_CSWAP(int64_t *target,
 
     shmem_internal_cswap(SHMEM_CTX_DEFAULT, target, value, &newval, cond,
                          8,
-                         *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                         *pe, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return newval;
 }
 
@@ -212,8 +212,8 @@ FC_SHMEM_INT4_FADD(int32_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
     shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, value, &oldval, 4,
-                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return oldval;
 }
 
@@ -235,8 +235,8 @@ FC_SHMEM_INT8_FADD(int64_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
     shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, value, &oldval, 8,
-                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return oldval;
 }
 
@@ -256,8 +256,8 @@ FC_SHMEM_INT4_FINC(int32_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 4);
 
     shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, &tmp, &oldval, 4,
-                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return oldval;
 }
 
@@ -277,8 +277,8 @@ FC_SHMEM_INT8_FINC(int64_t *target,
     SHMEM_ERR_CHECK_SYMMETRIC(target, 8);
 
     shmem_internal_fetch_atomic(SHMEM_CTX_DEFAULT, target, &tmp, &oldval, 8,
-                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                                *pe, SHM_INTERNAL_SUM, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
     return oldval;
 }
 
@@ -373,8 +373,8 @@ FC_SHMEM_INT4_FETCH(int32_t *source,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(source, 4);
 
-    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
 
     return val;
 }
@@ -394,8 +394,8 @@ FC_SHMEM_INT8_FETCH(int64_t *source,
     SHMEM_ERR_CHECK_PE(*pe);
     SHMEM_ERR_CHECK_SYMMETRIC(source, 8);
 
-    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
 
     return val;
 }
@@ -417,8 +417,8 @@ FC_SHMEM_REAL4_FETCH(float *source,
 
     shmem_internal_assert(sizeof(float) == 4);
 
-    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 4, *pe, SHM_INTERNAL_INT32, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
 
     return val;
 }
@@ -440,8 +440,8 @@ FC_SHMEM_REAL8_FETCH(double *source,
 
     shmem_internal_assert(sizeof(double) == 8);
 
-    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) source, 8, *pe, SHM_INTERNAL_INT64, 0);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);
 
     return val;
 }

--- a/src/atomic_nbi_c.c4
+++ b/src/atomic_nbi_c.c4
@@ -124,8 +124,12 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                 \
         SHMEM_ERR_CHECK_CTX(ctx);                               \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));        \
+                                                                \
+        size_t nic_idx = 0;                                     \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                    \
         shmem_internal_swap_nbi(ctx, target, &value, fetch,     \
-                                sizeof(TYPE), pe, ITYPE);       \
+                                sizeof(TYPE), pe, ITYPE,        \
+                                nic_idx);                       \
     }
 
 
@@ -151,9 +155,12 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic_nbi(ctx, target, &tmp, fetch,       \
                                     sizeof(TYPE), pe, SHM_INTERNAL_SUM, \
-                                    ITYPE);                             \
+                                    ITYPE, nic_idx);                    \
     }
 
 
@@ -165,9 +172,13 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic_nbi(ctx, target, &value, fetch,     \
                                         sizeof(TYPE), pe,               \
-                                        SHM_INTERNAL_SUM, ITYPE);       \
+                                        SHM_INTERNAL_SUM, ITYPE,        \
+                                        nic_idx);                       \
     }
 
 
@@ -195,9 +206,12 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic_nbi(ctx, target, &value, fetch,     \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BXOR,\
-                                    ITYPE);                             \
+                                    ITYPE, nic_idx);                    \
     }
 
 
@@ -209,9 +223,12 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic_nbi(ctx, target, &value, fetch,     \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BAND,\
-                                    ITYPE);                             \
+                                    ITYPE, nic_idx);                    \
     }
 
 
@@ -223,9 +240,12 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_fetch_atomic_nbi(ctx, target, &value, fetch,     \
                                     sizeof(TYPE), pe, SHM_INTERNAL_BOR, \
-                                    ITYPE);                             \
+                                    ITYPE, nic_idx);                    \
     }
 
 /* Function prototype for v1.4 routines with the default context: */

--- a/src/atomic_nbi_c.c4
+++ b/src/atomic_nbi_c.c4
@@ -179,8 +179,11 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(source, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_atomic_fetch(ctx, fetch, (void *) source,        \
-                                    sizeof(TYPE), pe, ITYPE);           \
+                                    sizeof(TYPE), pe, ITYPE, nic_idx);  \
     }
 
 

--- a/src/atomic_nbi_c.c4
+++ b/src/atomic_nbi_c.c4
@@ -141,8 +141,11 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
         SHMEM_ERR_CHECK_PE(pe);                                         \
         SHMEM_ERR_CHECK_CTX(ctx);                                       \
         SHMEM_ERR_CHECK_SYMMETRIC(target, sizeof(TYPE));                \
+                                                                        \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_cswap_nbi(ctx, target, &value, fetch, &cond,     \
-                             sizeof(TYPE), pe, ITYPE);                  \
+                             sizeof(TYPE), pe, ITYPE, nic_idx);         \
     }
 
 

--- a/src/atomic_nbi_c.c4
+++ b/src/atomic_nbi_c.c4
@@ -196,7 +196,7 @@ SHMEM_DEFINE_FOR_BITWISE_AMO(`SHMEM_PROF_DEF_CTX_FETCH_XOR_NBI')
                                                                         \
         size_t nic_idx = 0;                                             \
         SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
-        shmem_internal_atomic_fetch(ctx, fetch, (void *) source,        \
+        shmem_internal_atomic_fetch_nbi(ctx, fetch, (void *) source,    \
                                     sizeof(TYPE), pe, ITYPE, nic_idx);  \
     }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -437,7 +437,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             if (pe == shmem_internal_my_pe) continue;
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, len, pe, &completion, nic_idx);
         }
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
@@ -522,7 +522,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, send_buf, len, children[i],
                                   &completion, nic_idx);
         }
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
@@ -591,7 +591,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, size_t count, 
            exist. */
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
         /* let everyone know that it's safe to send to us */
@@ -619,7 +619,7 @@ shmem_internal_op_to_all_linear(void *target, const void *source, size_t count, 
         /* send data, ack, and wait for completion */
         shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                                PE_start, op, datatype, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
@@ -798,7 +798,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
            exist. */
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
                               shmem_internal_my_pe, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
         /* let everyone know that it's safe to send to us */
@@ -827,7 +827,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
                                (num_children == 0) ? source : target,
                                count * type_size, parent,
                                op, datatype, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
@@ -904,7 +904,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, size_t coun
 
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size, peer,
                               &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready, sizeof(long), peer, nic_idx);
@@ -934,7 +934,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, size_t coun
 
                 shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion, nic_idx);
-                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
                 shmem_internal_fence(SHMEM_CTX_DEFAULT);
                 shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer, nic_idx);
@@ -944,7 +944,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, size_t coun
 
                 shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target,
                                       wrk_size, peer, &completion, nic_idx);
-                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+                shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
                 shmem_internal_fence(SHMEM_CTX_DEFAULT);
                 shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, step_psync, &ps_data_ready,
                                          sizeof(long), peer, nic_idx);
@@ -962,7 +962,7 @@ shmem_internal_op_to_all_recdbl_sw(void *target, const void *source, size_t coun
 
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, current_target, wrk_size,
                                   peer, &completion, nic_idx);
-            shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+            shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence(SHMEM_CTX_DEFAULT);
             shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync_extra_peer, &ps_data_ready,
                                      sizeof(long), peer, nic_idx);
@@ -1084,7 +1084,7 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
         size_t offset = ((shmem_internal_my_pe - PE_start) / PE_stride) * len;
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + offset, source, len, PE_start,
                               &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 
         /* ensure ordering */
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
@@ -1136,7 +1136,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
         /* send data to me + 1 */
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + iter_offset, (char*) target + iter_offset,
                              len, next_proc, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* send completion for this round to next proc.  Note that we
@@ -1199,7 +1199,7 @@ shmem_internal_fcollect_recdbl(void *target, const void *source, size_t len,
         /* send data to peer */
         shmem_internal_put_nb(SHMEM_CTX_DEFAULT, (char*) target + curr_offset, (char*) target + curr_offset,
                               distance * len, real_peer, &completion, nic_idx);
-        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+        shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
         shmem_internal_fence(SHMEM_CTX_DEFAULT);
 
         /* mark completion for this round */

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -1006,6 +1006,8 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
     long zero = 0, one = 1;
     long completion = 0;
     int free_source = 0;
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
 
 
     if (count == 0) return;
@@ -1020,11 +1022,11 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         if (NULL == tmp)
             RAISE_ERROR_MSG("Unable to allocate %zub temporary buffer\n", count*type_size);
 
-        shmem_internal_copy_self(tmp, target, count * type_size);
+        shmem_internal_copy_self(tmp, target, count * type_size, nic_idx);
         free_source = 1;
         source = tmp;
 
-        shmem_internal_sync(PE_start, PE_stride, PE_size, pSync + 2);
+        shmem_internal_sync(PE_start, PE_stride, PE_size, pSync + 2, nic_idx);
     }
 
     if (PE_start == shmem_internal_my_pe) {
@@ -1038,7 +1040,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
             //Create an array of size (count * type_size) of zeroes
             uint8_t *zeroes = (uint8_t *) calloc(count, type_size);
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, zeroes, count * type_size,
-                              shmem_internal_my_pe, &completion);
+                              shmem_internal_my_pe, &completion, nic_idx);
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_quiet(SHMEM_CTX_DEFAULT);
             free(zeroes);
@@ -1050,7 +1052,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
              i++, pe += PE_stride) {
                  
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
-                               pe, &completion);           
+                               pe, &completion, nic_idx);           
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence(SHMEM_CTX_DEFAULT);
             
@@ -1059,14 +1061,14 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         for (pe = PE_start + PE_stride, i = 1 ;
              i < PE_size ;
              i++, pe += PE_stride) {
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe);
+            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe, nic_idx);
         }
                 
         /* Wait for others to acknowledge initialization */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
         
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe, nic_idx);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
         
         
@@ -1074,7 +1076,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         for (pe = PE_start + PE_stride, i = 1 ;
              i < PE_size ;
              i++, pe += PE_stride) {
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe);
+            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), pe, nic_idx);
         }
     } else {
             
@@ -1082,7 +1084,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe, nic_idx);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
         /* Send contribution to all pes larger than itself */
@@ -1090,20 +1092,20 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
              i < PE_size;
              i++, pe += PE_stride) {
 
-            shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count, type_size,
-                               pe, op, datatype, &completion);
+            shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count * type_size,
+                               pe, op, datatype, &completion, nic_idx);
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence(SHMEM_CTX_DEFAULT);
             
         }
         
         shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
-                              PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+                              PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG, nic_idx);
                               
         SHMEM_WAIT(pSync, 0);
         
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe, nic_idx);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
         
     }
@@ -1124,6 +1126,8 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
     long zero = 0, one = 1;
     long completion = 0;
     int free_source = 0;
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     
     /* In-place scan: copy source data to a temporary buffer so we can use
      * the symmetric buffer to accumulate scan data. */
@@ -1133,11 +1137,11 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
         if (NULL == tmp)
             RAISE_ERROR_MSG("Unable to allocate %zub temporary buffer\n", count*type_size);
 
-        shmem_internal_copy_self(tmp, target, count * type_size);
+        shmem_internal_copy_self(tmp, target, count * type_size, nic_idx);
         free_source = 1;
         source = tmp;
 
-        shmem_internal_sync(PE_start, PE_stride, PE_size, pSync + 2);
+        shmem_internal_sync(PE_start, PE_stride, PE_size, pSync + 2, nic_idx);
     }
 
 
@@ -1155,7 +1159,7 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
             //Create an array of size (count * type_size) of zeroes
             uint8_t *zeroes = (uint8_t *) calloc(count, type_size);
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, zeroes, count * type_size,
-                              shmem_internal_my_pe, &completion);
+                              shmem_internal_my_pe, &completion, nic_idx);
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_quiet(SHMEM_CTX_DEFAULT);
             free(zeroes);
@@ -1167,20 +1171,20 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
              i++, pe += PE_stride) {
                  
             shmem_internal_put_nb(SHMEM_CTX_DEFAULT, target, source, count * type_size,
-                               pe, &completion);           
+                               pe, &completion, nic_idx);           
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence(SHMEM_CTX_DEFAULT);
         }
         
         /* Let next pe know that it's safe to send to us */
         if(shmem_internal_my_pe + PE_stride < PE_size)
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), shmem_internal_my_pe + PE_stride);
+            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), shmem_internal_my_pe + PE_stride, nic_idx);
 
         /* Wait for others to acknowledge sending data */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe, nic_idx);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
     } else {
@@ -1188,7 +1192,7 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe, nic_idx);
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
 
         /* Send contribution to all pes larger than itself */
@@ -1196,18 +1200,18 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
              i < PE_size;
              i++, pe += PE_stride) {
 
-            shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count, type_size,
-                               pe, op, datatype, &completion);
+            shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count * type_size,
+                               pe, op, datatype, &completion, nic_idx);
             shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
             shmem_internal_fence(SHMEM_CTX_DEFAULT);    
         }
         
         /* Let next pe know that it's safe to send to us */
         if (shmem_internal_my_pe + PE_stride < PE_size)
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), shmem_internal_my_pe + PE_stride);
+            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one), shmem_internal_my_pe + PE_stride, nic_idx);
         
         shmem_internal_atomic(SHMEM_CTX_DEFAULT, pSync, &one, sizeof(one),
-                              PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
+                              PE_start, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG, nic_idx);
     }
     
     if (free_source)

--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -158,7 +158,9 @@ shmem_barrier_all(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 }
 
 
@@ -169,7 +171,9 @@ shmem_barrier(int PE_start, int logPE_stride, int PE_size, long *pSync)
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, 1 << logPE_stride, PE_size);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BARRIER_SYNC_SIZE);
 
-    shmem_internal_barrier(PE_start, 1 << logPE_stride, PE_size, pSync);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier(PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 
@@ -178,7 +182,9 @@ shmem_sync_all(void)
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
-    shmem_internal_sync_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_sync_all(nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -188,7 +194,9 @@ shmem_sync(int PE_start, int logPE_stride, int PE_size, long *pSync)
     SHMEM_ERR_CHECK_ACTIVE_SET(PE_start, 1 << logPE_stride, PE_size);
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BARRIER_SYNC_SIZE);
 
-    shmem_internal_sync(PE_start, 1 << logPE_stride, PE_size, pSync);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_sync(PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 /* Team-based Collective Routines */
@@ -199,9 +207,11 @@ shmem_team_sync(shmem_team_t team)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_TEAM_VALID(team);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, SYNC);
-    shmem_internal_sync(myteam->start, myteam->stride, myteam->size, psync);
+    long *psync = shmem_internal_team_choose_psync(myteam, SYNC, nic_idx);
+    shmem_internal_sync(myteam->start, myteam->stride, myteam->size, psync, nic_idx);
     shmem_internal_team_release_psyncs(myteam, SYNC);
     return 0;
 }
@@ -228,9 +238,11 @@ shmem_team_sync(shmem_team_t team)
         SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE)*nreduce,   \
                                 sizeof(TYPE)*nreduce, 1, 1);            \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_op_to_all(target, source, nreduce, sizeof(TYPE), \
                                  PE_start, 1 << logPE_stride, PE_size,  \
-                                 pWrk, pSync, IOP, ITYPE);              \
+                                 pWrk, pSync, IOP, ITYPE, nic_idx);     \
     }
 
 #define SHMEM_DEF_REDUCE(STYPE,TYPE,ITYPE,SOP,IOP)                      \
@@ -247,11 +259,14 @@ shmem_team_sync(shmem_team_t team)
                                 sizeof(TYPE)*nreduce, 1, 1);            \
         TYPE *pWrk = NULL;                                              \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam, REDUCE); \
+        long *psync = shmem_internal_team_choose_psync(myteam, REDUCE,  \
+                                                       nic_idx);        \
         shmem_internal_op_to_all(dest, source, nreduce, sizeof(TYPE),   \
                    myteam->start, myteam->stride, myteam->size, pWrk,   \
-                   psync, IOP, ITYPE);                                  \
+                   psync, IOP, ITYPE, nic_idx);                         \
         shmem_internal_team_release_psyncs(myteam, REDUCE);             \
         return 0;                                                       \
     }
@@ -292,9 +307,11 @@ shmem_broadcast32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_bcast(target, source, nlong * 4,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
-                         pSync, 1);
+                         pSync, 1, nic_idx);
 }
 
 
@@ -311,9 +328,11 @@ shmem_broadcast64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long)*SHMEM_BCAST_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_bcast(target, source, nlong * 8,
                          PE_root, PE_start, 1 << logPE_stride, PE_size,
-                         pSync, 1);
+                         pSync, 1, nic_idx);
 }
 
 int SHMEM_FUNCTION_ATTRIBUTES
@@ -327,15 +346,17 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, BCAST);
+    long *psync = shmem_internal_team_choose_psync(myteam, BCAST, nic_idx);
     shmem_internal_bcast(dest, source, nelems, PE_root, myteam->start,
                          myteam->stride, myteam->size,
-                         psync, 1);
+                         psync, 1, nic_idx);
     shmem_internal_team_release_psyncs(myteam, BCAST);
     int team_root = myteam->start + PE_root * myteam->stride;
     if (shmem_internal_my_pe == team_root && dest != source)
-        shmem_internal_copy_self(dest, source, nelems);
+        shmem_internal_copy_self(dest, source, nelems, nic_idx);
     return 0;
 }
 
@@ -353,16 +374,19 @@ shmem_broadcastmem(shmem_team_t team, void *dest, const void *source,
         SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),    \
                                 nelems * sizeof(TYPE), 1, 1);           \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam, BCAST);  \
+        long *psync = shmem_internal_team_choose_psync(myteam, BCAST,   \
+                                                       nic_idx);        \
         shmem_internal_bcast(dest, source, nelems * sizeof(TYPE),       \
                              PE_root, myteam->start, myteam->stride,    \
-                             myteam->size, psync, 1);                   \
+                             myteam->size, psync, 1, nic_idx);          \
         shmem_internal_team_release_psyncs(myteam, BCAST);              \
         int team_root = myteam->start + PE_root * myteam->stride;       \
         if (shmem_internal_my_pe == team_root && dest != source) {      \
             shmem_internal_copy_self(dest, source,                      \
-                                     nelems * sizeof(TYPE));            \
+                                     nelems * sizeof(TYPE), nic_idx);   \
         }                                                               \
         return 0;                                                       \
     }
@@ -380,8 +404,10 @@ shmem_collect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_collect(target, source, nlong * 4,
-                      PE_start, 1 << logPE_stride, PE_size, pSync);
+                      PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 
@@ -396,8 +422,10 @@ shmem_collect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_collect(target, source, nlong * 8,
-                      PE_start, 1 << logPE_stride, PE_size, pSync);
+                      PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 #define SHMEM_DEF_COLLECT(STYPE,TYPE)                                  \
@@ -412,12 +440,15 @@ shmem_collect64(void *target, const void *source, size_t nlong,
         SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),   \
                                 nelems * sizeof(TYPE), 1, 1);          \
                                                                        \
+        size_t nic_idx = 0;                                            \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                           \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
         long *psync = shmem_internal_team_choose_psync(myteam,         \
-                                                        COLLECT);      \
+                                                        COLLECT,       \
+                                                        nic_idx);      \
         shmem_internal_collect(dest, source, nelems * sizeof(TYPE),    \
                                myteam->start, myteam->stride,          \
-                               myteam->size, psync);                   \
+                               myteam->size, psync, nic_idx);          \
         shmem_internal_team_release_psyncs(myteam, COLLECT);           \
         return 0;                                                      \
     }
@@ -434,10 +465,12 @@ shmem_collectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
+    long *psync = shmem_internal_team_choose_psync(myteam, COLLECT, nic_idx);
     shmem_internal_collect(dest, source, nelems, myteam->start,
-                           myteam->stride, myteam->size, psync);
+                           myteam->stride, myteam->size, psync, nic_idx);
     shmem_internal_team_release_psyncs(myteam, COLLECT);
     return 0;
 }
@@ -453,8 +486,10 @@ shmem_fcollect32(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 4, nlong * 4, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_fcollect(target, source, nlong * 4,
-                       PE_start, 1 << logPE_stride, PE_size, pSync);
+                       PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 
@@ -469,8 +504,10 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_COLLECT_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(target, source, nlong * 8, nlong * 8, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_fcollect(target, source, nlong * 8,
-                       PE_start, 1 << logPE_stride, PE_size, pSync);
+                       PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 #define SHMEM_DEF_FCOLLECT(STYPE,TYPE)                                  \
@@ -485,12 +522,15 @@ shmem_fcollect64(void *target, const void *source, size_t nlong,
         SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),    \
                                 nelems * sizeof(TYPE), 1, 1);           \
                                                                         \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
         long *psync = shmem_internal_team_choose_psync(myteam,          \
-                                                        COLLECT);       \
+                                                        COLLECT,        \
+                                                        nic_idx);       \
         shmem_internal_fcollect(dest, source, nelems * sizeof(TYPE),    \
                                 myteam->start, myteam->stride,          \
-                                myteam->size, psync);                   \
+                                myteam->size, psync, nic_idx);          \
         shmem_internal_team_release_psyncs(myteam, COLLECT);            \
         return 0;                                                       \
     }
@@ -507,10 +547,12 @@ shmem_fcollectmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, COLLECT);
+    long *psync = shmem_internal_team_choose_psync(myteam, COLLECT, nic_idx);
     shmem_internal_fcollect(dest, source, nelems, myteam->start,
-                            myteam->stride, myteam->size, psync);
+                            myteam->stride, myteam->size, psync, nic_idx);
     shmem_internal_team_release_psyncs(myteam, COLLECT);
     return 0;
 }
@@ -526,8 +568,10 @@ shmem_alltoall32(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 4, nelems * 4, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_alltoall(dest, source, nelems * 4,
-                            PE_start, 1 << logPE_stride, PE_size, pSync);
+                            PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 
@@ -542,8 +586,10 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * 8, nelems * 8, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_alltoall(dest, source, nelems * 8,
-                            PE_start, 1 << logPE_stride, PE_size, pSync);
+                            PE_start, 1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 #define SHMEM_DEF_ALLTOALL(STYPE,TYPE)                                 \
@@ -558,12 +604,15 @@ shmem_alltoall64(void *dest, const void *source, size_t nelems, int PE_start,
         SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems * sizeof(TYPE),   \
                                 nelems * sizeof(TYPE), 1, 1);          \
                                                                        \
+        size_t nic_idx = 0;                                            \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                           \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team; \
         long *psync = shmem_internal_team_choose_psync(myteam,         \
-                                                        ALLTOALL);     \
+                                                        ALLTOALL,      \
+                                                        nic_idx);      \
         shmem_internal_alltoall(dest, source, nelems * sizeof(TYPE),   \
                                myteam->start, myteam->stride,          \
-                               myteam->size, psync);                   \
+                               myteam->size, psync, nic_idx);          \
         shmem_internal_team_release_psyncs(myteam, ALLTOALL);          \
         return 0;                                                      \
     }
@@ -580,10 +629,12 @@ shmem_alltoallmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_OVERLAP(dest, source, nelems, nelems, 1, 1);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL);
+    long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL, nic_idx);
     shmem_internal_alltoall(dest, source, nelems, myteam->start,
-                            myteam->stride, myteam->size, psync);
+                            myteam->stride, myteam->size, psync, nic_idx);
     shmem_internal_team_release_psyncs(myteam, ALLTOALL);
     return 0;
 }
@@ -602,8 +653,10 @@ shmem_alltoalls32(void *dest, const void *source, ptrdiff_t dst, ptrdiff_t sst,
     SHMEM_ERR_CHECK_SYMMETRIC(source, 4 * ((nelems-1) * sst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_alltoalls(dest, source, dst, sst, 4, nelems, PE_start,
-                             1 << logPE_stride, PE_size, pSync);
+                             1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 
@@ -620,8 +673,10 @@ shmem_alltoalls64(void *dest, const void *source, ptrdiff_t dst, ptrdiff_t sst,
     SHMEM_ERR_CHECK_SYMMETRIC(source, 8 * ((nelems-1) * sst + 1));
     SHMEM_ERR_CHECK_SYMMETRIC(pSync, sizeof(long) * SHMEM_ALLTOALL_SYNC_SIZE);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_alltoalls(dest, source, dst, sst, 8, nelems, PE_start,
-                             1 << logPE_stride, PE_size, pSync);
+                             1 << logPE_stride, PE_size, pSync, nic_idx);
 }
 
 #define SHMEM_DEF_ALLTOALLS(STYPE,TYPE)                                      \
@@ -635,11 +690,14 @@ shmem_alltoalls64(void *dest, const void *source, ptrdiff_t dst, ptrdiff_t sst,
         SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems * sizeof(TYPE));              \
         SHMEM_ERR_CHECK_SYMMETRIC(source, nelems * sizeof(TYPE));            \
                                                                              \
+        size_t nic_idx = 0;                                                  \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                 \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;       \
-        long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL);    \
+        long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL,     \
+                                                       nic_idx);             \
         shmem_internal_alltoalls(dest, source, dst, sst, sizeof(TYPE),       \
                                  nelems, myteam->start, myteam->stride,      \
-                                 myteam->size, psync);                       \
+                                 myteam->size, psync, nic_idx);              \
         shmem_internal_team_release_psyncs(myteam, ALLTOALL);                \
         return 0;                                                            \
     }
@@ -655,11 +713,13 @@ shmem_alltoallsmem(shmem_team_t team, void *dest, const void *source,
     SHMEM_ERR_CHECK_SYMMETRIC(dest, nelems);
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;
-    long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL);
+    long *psync = shmem_internal_team_choose_psync(myteam, ALLTOALL, nic_idx);
     shmem_internal_alltoalls(dest, source, dst, sst, 1, nelems,
                              myteam->start, myteam->stride, myteam->size,
-                             psync);
+                             psync, nic_idx);
     shmem_internal_team_release_psyncs(myteam, ALLTOALL);
     return 0;
 }

--- a/src/collectives_c.c4
+++ b/src/collectives_c.c4
@@ -321,7 +321,9 @@ SHMEM_BIND_C_COLL_MIN_MAX(`SHMEM_DEF_REDUCE', `max', `SHM_INTERNAL_MAX')
         TYPE *pWrk = NULL;                                              \
                                                                         \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam, SCAN); \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
+        long *psync = shmem_internal_team_choose_psync(myteam, SCAN, nic_idx); \
         shmem_internal_exscan(dest, source, nelems, sizeof(TYPE),   \
                    myteam->start, myteam->stride, myteam->size, pWrk,   \
                    psync, IOP, ITYPE);                                  \
@@ -345,7 +347,9 @@ SHMEM_BIND_C_COLL_SUM_PROD(`SHMEM_DEF_EXSCAN', `sum', `SHM_INTERNAL_SUM')
         TYPE *pWrk = NULL;                                              \
                                                                         \
         shmem_internal_team_t *myteam = (shmem_internal_team_t *)team;  \
-        long *psync = shmem_internal_team_choose_psync(myteam, SCAN); \
+        size_t nic_idx = 0;                                             \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                            \
+        long *psync = shmem_internal_team_choose_psync(myteam, SCAN, nic_idx); \
         shmem_internal_inscan(dest, source, nelems, sizeof(TYPE),   \
                    myteam->start, myteam->stride, myteam->size, pWrk,   \
                    psync, IOP, ITYPE);                                  \

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -318,9 +318,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                          \
     SHMEM_ERR_CHECK_CTX(ctx);                        \
     SHMEM_ERR_CHECK_SYMMETRIC(addr, sizeof(TYPE));   \
+                                                     \
+    size_t nic_idx = 0;                              \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);             \
     shmem_internal_get(ctx, &tmp, addr, sizeof(TYPE),\
-                       pe);                          \
-    shmem_internal_get_wait(ctx);                    \
+                       pe, nic_idx);                 \
+    shmem_internal_get_wait(ctx, nic_idx);           \
     return tmp;                                      \
   }
 
@@ -413,9 +416,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *    \
                             nelems, sizeof(TYPE) * nelems, 0, \
                             (shmem_internal_my_pe == pe));    \
+                                                              \
+    size_t nic_idx = 0;                                       \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                      \
     shmem_internal_get(ctx, target, source,                   \
-                       sizeof(TYPE) * nelems, pe);            \
-    shmem_internal_get_wait(ctx);                             \
+                       sizeof(TYPE) * nelems, pe, nic_idx);   \
+    shmem_internal_get_wait(ctx, nic_idx);                    \
   }
 
 
@@ -432,9 +438,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE)*nelems, \
                            (SIZE) * nelems, 0,             \
                            (shmem_internal_my_pe == pe));  \
+                                                           \
+    size_t nic_idx = 0;                                    \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                   \
     shmem_internal_get(ctx, target, source, (SIZE)*nelems, \
-                       pe);                                \
-    shmem_internal_get_wait(ctx);                          \
+                       pe, nic_idx);                       \
+    shmem_internal_get_wait(ctx, nic_idx);                 \
   }
 
 
@@ -451,8 +460,10 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
                             nelems, sizeof(TYPE) * nelems, 0,    \
                             (shmem_internal_my_pe == pe));       \
+    size_t nic_idx = 0;                                          \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                         \
     shmem_internal_get(ctx, target, source, sizeof(TYPE)*nelems, \
-                       pe);                                      \
+                       pe, nic_idx);                             \
   }
 
 
@@ -469,7 +480,10 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
                             (SIZE) * nelems, 0,                \
                             (shmem_internal_my_pe == pe));     \
-    shmem_internal_get(ctx, target, source, (SIZE)*nelems, pe);\
+    size_t nic_idx = 0;                                        \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                       \
+    shmem_internal_get(ctx, target, source, (SIZE)*nelems,     \
+                       pe, nic_idx);                           \
   }
 
 #define SHMEM_DEF_IPUT(STYPE,TYPE)                            \
@@ -593,13 +607,16 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                    sizeof(TYPE) * ((nelems-1) * tst + 1),     \
                    sizeof(TYPE) * ((nelems-1) * sst + 1), 0,  \
                    (shmem_internal_my_pe == pe));             \
+                                                              \
+    size_t nic_idx = 0;                                       \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                      \
     for ( ; nelems > 0 ; --nelems) {                          \
       shmem_internal_get(ctx, target, source, sizeof(TYPE),   \
-                         pe);                                 \
+                         pe, nic_idx);                        \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
-    shmem_internal_get_wait(ctx);                             \
+    shmem_internal_get_wait(ctx, nic_idx);                    \
   }
 
 #define SHMEM_DEF_IBGET(STYPE,TYPE)                           \
@@ -619,13 +636,16 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                    sizeof(TYPE) * ((nblocks-1) * tst + bsize), \
                    sizeof(TYPE) * ((nblocks-1) * sst + bsize), \
                    0, (shmem_internal_my_pe == pe));          \
+                                                              \
+    size_t nic_idx = 0;                                       \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                      \
     for ( ; nblocks > 0 ; --nblocks) {                        \
       shmem_internal_get(ctx, target, source,                 \
-                         bsize * sizeof(TYPE), pe);           \
+                         bsize * sizeof(TYPE), pe, nic_idx);  \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
-    shmem_internal_get_wait(ctx);                             \
+    shmem_internal_get_wait(ctx, nic_idx);                    \
   }
 
 #define SHMEM_DEF_IGET_N(NAME,SIZE)                       \
@@ -646,12 +666,16 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                      (SIZE) * ((nelems-1) * tst + 1),     \
                      (SIZE) * ((nelems-1) * sst + 1), 0,  \
                      (shmem_internal_my_pe == pe));       \
+                                                          \
+    size_t nic_idx = 0;                                   \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                  \
     for ( ; nelems > 0 ; --nelems) {                      \
-      shmem_internal_get(ctx, target, source, (SIZE), pe);\
+      shmem_internal_get(ctx, target, source, (SIZE),     \
+                         pe, nic_idx);                    \
       target = (uint8_t *) target + tst * (SIZE);         \
       source = (uint8_t *) source + sst * (SIZE);         \
     }                                                     \
-    shmem_internal_get_wait(ctx);                         \
+    shmem_internal_get_wait(ctx, nic_idx);                \
   }
 
 #define SHMEM_DEF_IBGET_N(NAME,SIZE)                      \
@@ -672,13 +696,16 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                      (SIZE) * ((nblocks-1) * tst + bsize), \
                      (SIZE) * ((nblocks-1) * sst + bsize), \
                      0, (shmem_internal_my_pe == pe));    \
+                                                          \
+    size_t nic_idx = 0;                                   \
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);              \
     for ( ; nblocks > 0 ; --nblocks) {                    \
       shmem_internal_get(ctx, target, source,             \
-                         bsize * (SIZE), pe);             \
+                         bsize * (SIZE), pe, nic_idx);    \
       target = (uint8_t *) target + tst * (SIZE);         \
       source = (uint8_t *) source + sst * (SIZE);         \
     }                                                     \
-    shmem_internal_get_wait(ctx);                         \
+    shmem_internal_get_wait(ctx, nic_idx);                \
   }
 
 #define SHMEM_DEF_PUT_SIGNAL(STYPE,TYPE)                                \
@@ -871,10 +898,12 @@ shmem_signal_fetch(const uint64_t* sig_addr)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &val, (void *) sig_addr, 
                                 sizeof(uint64_t), shmem_internal_my_pe,
-                                SHM_INTERNAL_UINT64);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+                                SHM_INTERNAL_UINT64, nic_idx);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx);
     return val;
 }
 
@@ -932,8 +961,10 @@ shmemx_getmem_ct(shmemx_ct_t ct, void *target, const void *source, size_t nelems
     SHMEM_ERR_CHECK_SYMMETRIC(source, nelems);
     SHMEM_ERR_CHECK_NULL(target, nelems);
 
-    shmem_internal_get_ct(ct, target, source, nelems, pe);
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_get_ct(ct, target, source, nelems, pe, nic_idx);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES shmemx_putmem_ct(shmemx_ct_t ct, void *target, const void *source,

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -349,7 +349,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     shmem_internal_put_nb(ctx, target, source,                   \
                           sizeof(TYPE) * nelems, pe,             \
                           &completion, nic_idx);                 \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);          \
+    shmem_internal_put_wait(ctx, &completion);                   \
   }
 
 
@@ -372,7 +372,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                       \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,\
                           pe, &completion, nic_idx);           \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);        \
+    shmem_internal_put_wait(ctx, &completion);                 \
   }
 
 
@@ -555,7 +555,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);       \
+    shmem_internal_put_wait(ctx, &completion);                \
   }
 
 #define SHMEM_DEF_IPUT_N(NAME,SIZE)                          \
@@ -614,7 +614,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
       target = (uint8_t *) target + tst * (SIZE);            \
       source = (uint8_t *) source + sst * (SIZE);            \
     }                                                        \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);      \
+    shmem_internal_put_wait(ctx, &completion);               \
   }
 
 #define SHMEM_DEF_IGET(STYPE,TYPE)                            \
@@ -757,7 +757,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     shmem_internal_put_nb(ctx, target, source,                          \
                           sizeof(TYPE) * nelems, pe,                    \
                           &completion, nic_idx);                        \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);                 \
+    shmem_internal_put_wait(ctx, &completion);                          \
     shmem_internal_fence(ctx);                                          \
     if (sig_op == SHMEM_SIGNAL_ADD)                                     \
         shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), \
@@ -791,7 +791,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,         \
                           pe, &completion, nic_idx);                    \
-    shmem_internal_put_wait(ctx, &completion, nic_idx);                 \
+    shmem_internal_put_wait(ctx, &completion);                          \
     shmem_internal_fence(ctx);                                          \
     if (sig_op == SHMEM_SIGNAL_ADD)                                     \
         shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), \
@@ -1029,7 +1029,7 @@ void SHMEM_FUNCTION_ATTRIBUTES shmemx_putmem_ct(shmemx_ct_t ct, void *target, co
     size_t nic_idx = 0;
     SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_put_ct_nb(ct, target, source, nelems, pe, &completion, nic_idx);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 }
 
 

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -305,8 +305,11 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_PE(pe);                                    \
     SHMEM_ERR_CHECK_CTX(ctx);                                  \
     SHMEM_ERR_CHECK_SYMMETRIC(addr, sizeof(TYPE));             \
+                                                               \
+    size_t nic_idx = 0;                                        \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                       \
     shmem_internal_put_scalar(ctx, addr, &value, sizeof(TYPE), \
-                             pe);                              \
+                             pe, nic_idx);                     \
   }
 
 #define SHMEM_DEF_G(STYPE,TYPE)                      \
@@ -340,10 +343,13 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
                             nelems, sizeof(TYPE) * nelems, 0,    \
                             (shmem_internal_my_pe == pe));       \
+                                                                 \
+    size_t nic_idx = 0;                                          \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                         \
     shmem_internal_put_nb(ctx, target, source,                   \
                           sizeof(TYPE) * nelems, pe,             \
-                          &completion);                          \
-    shmem_internal_put_wait(ctx, &completion);                   \
+                          &completion, nic_idx);                 \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);          \
   }
 
 
@@ -361,9 +367,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
                             (SIZE) * nelems, 0,                \
                             (shmem_internal_my_pe == pe));     \
+                                                               \
+    size_t nic_idx = 0;                                        \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                       \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,\
-                          pe, &completion);                    \
-    shmem_internal_put_wait(ctx, &completion);                 \
+                          pe, &completion, nic_idx);           \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);        \
   }
 
 
@@ -379,9 +388,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, sizeof(TYPE) *       \
                             nelems, sizeof(TYPE) * nelems, 0,    \
                             (shmem_internal_my_pe == pe));       \
+                                                                 \
+    size_t nic_idx = 0;                                          \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                         \
     shmem_internal_put_nbi(ctx, target, source,                  \
                            sizeof(TYPE)*nelems,                  \
-        pe);                                                     \
+                           pe, nic_idx);                         \
   }
 
 
@@ -398,8 +410,11 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, source, (SIZE) * nelems,   \
                             (SIZE) * nelems, 0,                \
                             (shmem_internal_my_pe == pe));     \
+                                                               \
+    size_t nic_idx = 0;                                        \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                       \
     shmem_internal_put_nbi(ctx, target, source, (SIZE)*nelems, \
-                           pe);                                \
+                           pe, nic_idx);                       \
   }
 
 
@@ -502,9 +517,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                    sizeof(TYPE) * ((nelems-1) * tst + 1),     \
                    sizeof(TYPE) * ((nelems-1) * sst + 1), 0,  \
                    (shmem_internal_my_pe == pe));             \
+                                                              \
+    size_t nic_idx = 0;                                       \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                      \
     for ( ; nelems > 0 ; --nelems) {                          \
       shmem_internal_put_scalar(ctx, target, source,          \
-                               sizeof(TYPE), pe);             \
+                               sizeof(TYPE), pe, nic_idx);    \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
@@ -527,14 +545,17 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                    sizeof(TYPE) * ((nblocks-1) * tst + bsize), \
                    sizeof(TYPE) * ((nblocks-1) * sst + bsize), \
                    0, (shmem_internal_my_pe == pe));          \
+                                                              \
+    size_t nic_idx = 0;                                       \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                      \
     for ( ; nblocks > 0 ; --nblocks) {                        \
       shmem_internal_put_nb(ctx, target, source,              \
                                 bsize * sizeof(TYPE), pe,     \
-                                &completion);                 \
+                                &completion, nic_idx);        \
       target += tst;                                          \
       source += sst;                                          \
     }                                                         \
-    shmem_internal_put_wait(ctx, &completion);                \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);       \
   }
 
 #define SHMEM_DEF_IPUT_N(NAME,SIZE)                          \
@@ -554,9 +575,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                         (SIZE) * ((nelems-1) * tst + 1),     \
                         (SIZE) * ((nelems-1) * sst + 1), 0,  \
                         (shmem_internal_my_pe == pe));       \
+                                                             \
+    size_t nic_idx = 0;                                      \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                     \
     for ( ; nelems > 0 ; --nelems) {                         \
       shmem_internal_put_scalar(ctx, target, source, (SIZE), \
-                               pe);                          \
+                               pe, nic_idx);                 \
       target = (uint8_t *) target + tst * (SIZE);            \
       source = (uint8_t *) source + sst * (SIZE);            \
     }                                                        \
@@ -580,14 +604,17 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                         (SIZE) * ((nblocks-1) * tst + bsize), \
                         (SIZE) * ((nblocks-1) * sst + bsize), \
                         0, (shmem_internal_my_pe == pe));    \
+                                                             \
+    size_t nic_idx = 0;                                      \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                     \
     for ( ; nblocks > 0 ; --nblocks) {                       \
       shmem_internal_put_nb(ctx, target, source,             \
                             bsize * (SIZE), pe,              \
-                            &completion);                    \
+                            &completion, nic_idx);           \
       target = (uint8_t *) target + tst * (SIZE);            \
       source = (uint8_t *) source + sst * (SIZE);            \
     }                                                        \
-    shmem_internal_put_wait(ctx, &completion);               \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);      \
   }
 
 #define SHMEM_DEF_IGET(STYPE,TYPE)                            \
@@ -698,7 +725,7 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                      0, (shmem_internal_my_pe == pe));    \
                                                           \
     size_t nic_idx = 0;                                   \
-        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);              \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                  \
     for ( ; nblocks > 0 ; --nblocks) {                    \
       shmem_internal_get(ctx, target, source,             \
                          bsize * (SIZE), pe, nic_idx);    \
@@ -724,19 +751,22 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                             sizeof(uint64_t), 0,                        \
                             (shmem_internal_my_pe == pe));              \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
+                                                                        \
+    size_t nic_idx = 0;                                                 \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                \
     shmem_internal_put_nb(ctx, target, source,                          \
                           sizeof(TYPE) * nelems, pe,                    \
-                          &completion);                                 \
-    shmem_internal_put_wait(ctx, &completion);                          \
+                          &completion, nic_idx);                        \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);                 \
     shmem_internal_fence(ctx);                                          \
     if (sig_op == SHMEM_SIGNAL_ADD)                                     \
         shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), \
                               pe, SHM_INTERNAL_SUM,                     \
-                              SHM_INTERNAL_UINT64);                     \
+                              SHM_INTERNAL_UINT64, nic_idx);            \
     else                                                                \
         shmem_internal_atomic_set(ctx, sig_addr, &signal,               \
                                   sizeof(uint64_t), pe,                 \
-                                  SHM_INTERNAL_UINT64);                 \
+                                  SHM_INTERNAL_UINT64, nic_idx);        \
   }
 
 
@@ -756,18 +786,21 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                             sizeof(uint64_t), 0,                        \
                             (shmem_internal_my_pe == pe));              \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
+                                                                        \
+    size_t nic_idx = 0;                                                 \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                \
     shmem_internal_put_nb(ctx, target, source, (SIZE) * nelems,         \
-                          pe, &completion);                             \
-    shmem_internal_put_wait(ctx, &completion);                          \
+                          pe, &completion, nic_idx);                    \
+    shmem_internal_put_wait(ctx, &completion, nic_idx);                 \
     shmem_internal_fence(ctx);                                          \
     if (sig_op == SHMEM_SIGNAL_ADD)                                     \
         shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), \
                               pe, SHM_INTERNAL_SUM,                     \
-                              SHM_INTERNAL_UINT64);                     \
+                              SHM_INTERNAL_UINT64, nic_idx);            \
     else                                                                \
         shmem_internal_atomic_set(ctx, sig_addr, &signal,               \
                                   sizeof(uint64_t), pe,                 \
-                                  SHM_INTERNAL_UINT64);                 \
+                                  SHM_INTERNAL_UINT64, nic_idx);        \
   }
 
 #define SHMEM_DEF_PUT_SIGNAL_NBI(STYPE,TYPE)                            \
@@ -784,10 +817,14 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
     SHMEM_ERR_CHECK_OVERLAP(target, sig_addr, sizeof(TYPE) * nelems,    \
                             sizeof(uint64_t), 0,                        \
                             (shmem_internal_my_pe == pe));              \
+                                                                        \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
+                                                                        \
+    size_t nic_idx = 0;                                                 \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                \
     shmem_internal_put_signal_nbi(ctx, target, source,                  \
                                   sizeof(TYPE) * nelems, sig_addr,      \
-                                  signal, sig_op, pe);                  \
+                                  signal, sig_op, pe, nic_idx);         \
   }
 
 
@@ -806,8 +843,12 @@ SHMEM_PROF_DEF_CTX_PUT_N_SIGNAL_NBI(`mem')
                             sizeof(uint64_t), 0,                        \
                             (shmem_internal_my_pe == pe));              \
     SHMEM_ERR_CHECK_SIG_OP(sig_op);                                     \
+                                                                        \
+    size_t nic_idx = 0;                                                 \
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);                                \
     shmem_internal_put_signal_nbi(ctx, target, source, (SIZE) * nelems, \
-                                  sig_addr, signal, sig_op, pe);        \
+                                  sig_addr, signal, sig_op,             \
+                                  pe, nic_idx);                         \
   }
 
 
@@ -914,8 +955,10 @@ shmemx_signal_add(uint64_t *sig_addr, uint64_t signal, int pe)
     SHMEM_ERR_CHECK_PE(pe);
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_atomic(SHMEM_CTX_DEFAULT, sig_addr, &signal, sizeof(uint64_t),
-                          pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                          pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -926,8 +969,10 @@ shmemx_ctx_signal_add(shmem_ctx_t ctx, uint64_t *sig_addr, uint64_t signal, int 
     SHMEM_ERR_CHECK_CTX(ctx);
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
-                          pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                          pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -937,8 +982,10 @@ shmemx_signal_set(uint64_t *sig_addr, uint64_t signal, int pe)
     SHMEM_ERR_CHECK_PE(pe);
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, (void *) sig_addr, &signal,
-                              sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+                              sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -949,8 +996,10 @@ shmemx_ctx_signal_set(shmem_ctx_t ctx, uint64_t *sig_addr, uint64_t signal, int 
     SHMEM_ERR_CHECK_CTX(ctx);
     SHMEM_ERR_CHECK_SYMMETRIC(sig_addr, sizeof(uint64_t));
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     shmem_internal_atomic_set(ctx, (void *) sig_addr, &signal,
-                              sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+                              sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 }
 
 void SHMEM_FUNCTION_ATTRIBUTES
@@ -977,8 +1026,10 @@ void SHMEM_FUNCTION_ATTRIBUTES shmemx_putmem_ct(shmemx_ct_t ct, void *target, co
     SHMEM_ERR_CHECK_SYMMETRIC(target, nelems);
     SHMEM_ERR_CHECK_NULL(source, nelems);
 
-    shmem_internal_put_ct_nb(ct, target, source, nelems, pe, &completion);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_put_ct_nb(ct, target, source, nelems, pe, &completion, nic_idx);
+    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
 }
 
 

--- a/src/data_c.c4
+++ b/src/data_c.c4
@@ -972,6 +972,7 @@ shmemx_ctx_signal_add(shmem_ctx_t ctx, uint64_t *sig_addr, uint64_t signal, int 
     pe = shmem_internal_team_pe(((shmem_transport_ctx_t *) ctx)->team, pe);
     size_t nic_idx = 0;
     SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
                           pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
 }
 
@@ -999,6 +1000,7 @@ shmemx_ctx_signal_set(shmem_ctx_t ctx, uint64_t *sig_addr, uint64_t signal, int 
     pe = shmem_internal_team_pe(((shmem_transport_ctx_t *) ctx)->team, pe);
     size_t nic_idx = 0;
     SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_atomic_set(ctx, (void *) sig_addr, &signal,
                               sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 }
 

--- a/src/data_f.c4
+++ b/src/data_f.c4
@@ -136,8 +136,8 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_IPUT_SIZE')
         SHMEM_ERR_CHECK_NULL(target, *len);                             \
                                                                         \
         shmem_internal_get(SHMEM_CTX_DEFAULT, target, source,           \
-                           SIZE * *len, *pe);                           \
-        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);                     \
+                           SIZE * *len, *pe, 0);                        \
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);                  \
     }
 
 define(`SHMEM_WRAP_FC_GET',
@@ -161,7 +161,7 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_GET_SIZE')
         SHMEM_ERR_CHECK_NULL(target, *nelems);                          \
                                                                         \
         shmem_internal_get(SHMEM_CTX_DEFAULT, target, source,           \
-                           SIZE * *nelems, *pe);                        \
+                           SIZE * *nelems, *pe, 0);                     \
     }
 
 define(`SHMEM_WRAP_FC_GET_NBI',
@@ -195,11 +195,11 @@ SHMEM_BIND_F_SIZES(`SHMEM_WRAP_FC_GET_NBI_SIZE')
                                                                         \
         for ( ; len > 0 ; --len ) {                                     \
             shmem_internal_get(SHMEM_CTX_DEFAULT, target, source, SIZE, \
-                               *pe);                                    \
+                               *pe, 0);                                 \
             target += (*tst * SIZE);                                    \
             source += (*sst * SIZE);                                    \
         }                                                               \
-        shmem_internal_get_wait(SHMEM_CTX_DEFAULT);                     \
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0);                  \
     }
 
 define(`SHMEM_WRAP_FC_IGET',

--- a/src/init.c
+++ b/src/init.c
@@ -143,7 +143,9 @@ shmem_internal_shutdown(void)
         return;
     }
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     shmem_internal_finalized = 1;
 

--- a/src/init.c
+++ b/src/init.c
@@ -116,7 +116,11 @@ static void
 shmem_internal_randr_init(void)
 {
     shmem_internal_rand_seed = shmem_internal_my_pe;
+    /* Only reset nic_rr_idx when TX LB is not active; otherwise
+     * shmem_transport_startup() has already set the staggered start. */
+#if !defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) && !defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
     shmem_internal_nic_rr_idx = 0;
+#endif
 
 #ifdef ENABLE_THREADS
     SHMEM_MUTEX_INIT(shmem_internal_mutex_rand_r);

--- a/src/init.c
+++ b/src/init.c
@@ -97,6 +97,7 @@ int shmem_internal_global_exit_called = 0;
 int shmem_internal_thread_level;
 
 unsigned int shmem_internal_rand_seed;
+size_t shmem_internal_nic_rr_idx;
 
 #ifdef USE_HWLOC
 #include <hwloc.h>
@@ -115,6 +116,7 @@ static void
 shmem_internal_randr_init(void)
 {
     shmem_internal_rand_seed = shmem_internal_my_pe;
+    shmem_internal_nic_rr_idx = 0;
 
 #ifdef ENABLE_THREADS
     SHMEM_MUTEX_INIT(shmem_internal_mutex_rand_r);

--- a/src/lock_c.c
+++ b/src/lock_c.c
@@ -44,7 +44,9 @@ shmem_clear_lock(long *lockp)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(lockp, sizeof(long));
 
-    shmem_internal_clear_lock(lockp);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_clear_lock(lockp, nic_idx);
 }
 
 
@@ -54,7 +56,9 @@ shmem_set_lock(long *lockp)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(lockp, sizeof(long));
 
-    shmem_internal_set_lock(lockp);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_set_lock(lockp, nic_idx);
 }
 
 
@@ -64,5 +68,7 @@ shmem_test_lock(long *lockp)
     SHMEM_ERR_CHECK_INITIALIZED();
     SHMEM_ERR_CHECK_SYMMETRIC(lockp, sizeof(long));
 
-    return shmem_internal_test_lock(lockp);
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    return shmem_internal_test_lock(lockp, nic_idx);
 }

--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -28,7 +28,7 @@
 
 /* Note: Increase MAX_KV_COUNT if more key/values are needed.  MAX_KV_COUNT is
  * 2 * the number of key/value pairs. */
-#define MAX_KV_COUNT 20
+#define MAX_KV_COUNT 40
 #define MAX_KV_LENGTH 512
 
 static int rank = -1;

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -251,11 +251,12 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
            the CXI provider */
         unsigned long long tmp_fetch = 0;
         shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
-                                     source, &tmp_fetch, len, pe, op, datatype);
-        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
+                                     source, &tmp_fetch, len, pe, op, datatype, nic_idx);
+        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx, nic_idx);
 #else
         shmem_transport_atomic((shmem_transport_ctx_t *)ctx, target, source,
                                len, pe, op, datatype, nic_idx);
+#endif
     }
 }
 
@@ -291,11 +292,12 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
            the CXI provider */
         unsigned long long tmp_fetch = 0;
         shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
-                                     source, &tmp_fetch, len, pe, FI_ATOMIC_WRITE, datatype);
-        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
+                                     source, &tmp_fetch, len, pe, FI_ATOMIC_WRITE, datatype, nic_idx);
+        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx, nic_idx);
 #else
         shmem_transport_atomic_set((shmem_transport_ctx_t *)ctx, target,
                                    source, len, pe, datatype, nic_idx);
+#endif
     }
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -33,7 +33,7 @@
 static inline
 void
 shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe,
-                      long *completion)
+                      long *completion, size_t nic_idx)
 {
     if (len == 0)
         return;
@@ -41,23 +41,23 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
     if (shmem_shr_transport_use_write(ctx, target, source, len, pe)) {
         shmem_shr_transport_put(ctx, target, source, len, pe);
     } else {
-        shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, completion);
+        shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, completion, nic_idx);
     }
 }
 
 
 static inline
 void
-shmem_internal_put_wait(shmem_ctx_t ctx, long *completion)
+shmem_internal_put_wait(shmem_ctx_t ctx, long *completion, size_t nic_idx)
 {
-    shmem_transport_put_wait((shmem_transport_ctx_t *)ctx, completion);
+    shmem_transport_put_wait((shmem_transport_ctx_t *)ctx, completion, nic_idx);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
 
 static inline
 void
-shmem_internal_put_scalar(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_internal_put_scalar(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -65,11 +65,11 @@ shmem_internal_put_scalar(shmem_ctx_t ctx, void *target, const void *source, siz
         shmem_shr_transport_put_scalar(ctx, target, source, len, pe);
     } else {
 #ifndef DISABLE_OFI_INJECT
-        shmem_transport_put_scalar((shmem_transport_ctx_t *)ctx, target, source, len, pe);
+        shmem_transport_put_scalar((shmem_transport_ctx_t *)ctx, target, source, len, pe, nic_idx);
 #else
         long completion = 0;
-        shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, &completion);
-	shmem_internal_put_wait(ctx, &completion);
+        shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, &completion, nic_idx);
+	    shmem_internal_put_wait(ctx, &completion, nic_idx);
 #endif
     }
 }
@@ -77,35 +77,35 @@ shmem_internal_put_scalar(shmem_ctx_t ctx, void *target, const void *source, siz
 static inline
 void
 shmem_internal_put_signal_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len,
-                              uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
+                              uint64_t *sig_addr, uint64_t signal, int sig_op, int pe, size_t nic_idx)
 {
     if (len == 0) {
         if (sig_op == SHMEM_SIGNAL_ADD)
             shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal, sizeof(uint64_t),
-                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
         else
             shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
-                                      sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+                                      sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
         return;
     }
 
     if (shmem_shr_transport_use_write(ctx, target, source, len, pe)) {
-        shmem_shr_transport_put_signal(ctx, target, source, len, sig_addr, signal, sig_op, pe);
+        shmem_shr_transport_put_signal(ctx, target, source, len, sig_addr, signal, sig_op, pe, nic_idx);
     } else {
-        shmem_transport_put_signal_nbi((shmem_transport_ctx_t *) ctx, target, source, len, sig_addr, signal, sig_op, pe);
+        shmem_transport_put_signal_nbi((shmem_transport_ctx_t *) ctx, target, source, len, sig_addr, signal, sig_op, pe, nic_idx);
     }
 }
 
 static inline
 void
-shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     if (len == 0) return;
 
     if (shmem_shr_transport_use_write(ctx, target, source, len, pe)) {
         shmem_shr_transport_put(ctx, target, source, len, pe);
     } else {
-        shmem_transport_put_nbi((shmem_transport_ctx_t *)ctx, target, source, len, pe);
+        shmem_transport_put_nbi((shmem_transport_ctx_t *)ctx, target, source, len, pe, nic_idx);
     }
 }
 
@@ -113,11 +113,11 @@ shmem_internal_put_nbi(shmem_ctx_t ctx, void *target, const void *source, size_t
 static inline
 void
 shmem_internal_put_ct_nb(shmemx_ct_t ct, void *target, const void *source, size_t len, int pe,
-                      long *completion)
+                      long *completion, size_t nic_idx)
 {
     /* TODO: add shortcut for on-node-comms */
     shmem_transport_put_ct_nb((shmem_transport_ct_t *)
-                              ct, target, source, len, pe, completion);
+                              ct, target, source, len, pe, completion, nic_idx);
 }
 
 
@@ -130,7 +130,7 @@ shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len
     if (shmem_shr_transport_use_read(ctx, target, source, len, pe)) {
         shmem_shr_transport_get(ctx, target, source, len, pe);
     } else {
-        shmem_transport_get((shmem_transport_ctx_t *)ctx, target, source, len, pe);
+        shmem_transport_get((shmem_transport_ctx_t *)ctx, target, source, len, pe, nic_idx);
     }
 }
 
@@ -142,7 +142,7 @@ shmem_internal_get_ct(shmemx_ct_t ct, void *target, const void *source, size_t l
 {
     /* TODO: add shortcut for on-node-comms */
     shmem_transport_get_ct((shmem_transport_ct_t *) ct,
-                           target, source, len, pe);
+                           target, source, len, pe, nic_idx);
 }
 
 
@@ -164,7 +164,7 @@ shmem_internal_swap(shmem_ctx_t ctx, void *target, void *source, void *dest, siz
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_swap(ctx, target, source, dest, len, pe, datatype);
     } else {
-        shmem_transport_swap((shmem_transport_ctx_t *)ctx, target, source, dest, len, pe, datatype);
+        shmem_transport_swap((shmem_transport_ctx_t *)ctx, target, source, dest, len, pe, datatype, nic_idx);
     }
 }
 
@@ -173,7 +173,7 @@ static inline
 void
 shmem_internal_swap_nbi(shmem_ctx_t ctx, void *target, void *source,
                         void *dest, size_t len, int pe,
-                        shm_internal_datatype_t datatype)
+                        shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -181,7 +181,7 @@ shmem_internal_swap_nbi(shmem_ctx_t ctx, void *target, void *source,
         shmem_shr_transport_swap(ctx, target, source, dest, len, pe, datatype);
     } else {
         shmem_transport_swap_nbi((shmem_transport_ctx_t *)ctx, target, source,
-                                 dest, len, pe, datatype);
+                                 dest, len, pe, datatype, nic_idx);
     }
 }
 
@@ -197,7 +197,7 @@ shmem_internal_cswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
         shmem_shr_transport_cswap(ctx, target, source, dest, operand, len, pe, datatype);
     } else {
         shmem_transport_cswap((shmem_transport_ctx_t *)ctx, target, source,
-                              dest, operand, len, pe, datatype);
+                              dest, operand, len, pe, datatype, nic_idx);
     }
 }
 
@@ -230,7 +230,7 @@ shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
         shmem_shr_transport_mswap(ctx, target, source, dest, mask, len, pe, datatype);
     } else {
         shmem_transport_mswap((shmem_transport_ctx_t *)ctx, target, source,
-                              dest, mask, len, pe, datatype);
+                              dest, mask, len, pe, datatype, nic_idx);
     }
 }
 
@@ -238,7 +238,8 @@ shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, vo
 static inline
 void
 shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t len,
-                      int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                      int pe, shm_internal_op_t op, shm_internal_datatype_t datatype,
+                      size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -254,8 +255,7 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
         shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
 #else
         shmem_transport_atomic((shmem_transport_ctx_t *)ctx, target, source,
-                               len, pe, op, datatype);
-#endif
+                               len, pe, op, datatype, nic_idx);
     }
 }
 
@@ -271,7 +271,7 @@ shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, s
         shmem_shr_transport_atomic_fetch(ctx, target, source, len, pe, datatype);
     } else {
         shmem_transport_atomic_fetch((shmem_transport_ctx_t *)ctx, target,
-                                     source, len, pe, datatype);
+                                     source, len, pe, datatype, nic_idx);
     }
 }
 
@@ -279,7 +279,7 @@ shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, s
 static inline
 void
 shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, size_t len,
-                          int pe, shm_internal_datatype_t datatype)
+                          int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -295,8 +295,7 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
         shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
 #else
         shmem_transport_atomic_set((shmem_transport_ctx_t *)ctx, target,
-                                   source, len, pe, datatype);
-#endif
+                                   source, len, pe, datatype, nic_idx);
     }
 }
 
@@ -314,7 +313,7 @@ shmem_internal_fetch_atomic(shmem_ctx_t ctx, void *target, void *source, void *d
                                          op, datatype);
     } else {
         shmem_transport_fetch_atomic((shmem_transport_ctx_t *)ctx, target,
-                                     source, dest, len, pe, op, datatype);
+                                     source, dest, len, pe, op, datatype, nic_idx);
     }
 }
 
@@ -323,7 +322,7 @@ static inline
 void
 shmem_internal_atomicv(shmem_ctx_t ctx, void *target, const void *source,
                        size_t len, int pe, shm_internal_op_t op,
-                       shm_internal_datatype_t datatype, long *completion)
+                       shm_internal_datatype_t datatype, long *completion, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -336,14 +335,14 @@ shmem_internal_atomicv(shmem_ctx_t ctx, void *target, const void *source,
     for (size_t i = 0; i < count; i++) {
         shmem_internal_fetch_atomic(ctx, ((uint8_t *) target) + (i * type_size),
                                     ((uint8_t *) source) + (i * type_size), &tmp_fetch, type_size,
-                                    pe, op, datatype);
+                                    pe, op, datatype, nic_idx);
     }
 #else
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_atomicv(ctx, target, source, len, pe, op, datatype);
     } else {
         shmem_transport_atomicv((shmem_transport_ctx_t *)ctx, target, source, len,
-                                pe, op, datatype, completion);
+                                pe, op, datatype, completion, nic_idx);
     }
 #endif
 }
@@ -353,7 +352,7 @@ static inline
 void
 shmem_internal_fetch_atomic_nbi(shmem_ctx_t ctx, void *target, void *source,
                                 void *dest, size_t len, int pe,
-                                shm_internal_op_t op, shm_internal_datatype_t datatype)
+                                shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -362,7 +361,7 @@ shmem_internal_fetch_atomic_nbi(shmem_ctx_t ctx, void *target, void *source,
                                          op, datatype);
     } else {
         shmem_transport_fetch_atomic_nbi((shmem_transport_ctx_t *)ctx, target,
-                                         source, dest, len, pe, op, datatype);
+                                         source, dest, len, pe, op, datatype, nic_idx);
     }
 }
 
@@ -404,7 +403,7 @@ void shmem_internal_ct_wait(shmemx_ct_t ct, long wait_for)
 
 /* Uses internal put for external heap config; otherwise memcpy */
 static inline
-void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
+void shmem_internal_copy_self(void *dest, const void *source, size_t nelems, size_t nic_idx)
 {
 #ifdef USE_FI_HMEM
     // "completion" set to 1 to wait for completion of put operation initiated
@@ -412,8 +411,8 @@ void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
     // to shmem_internal_put_nb.
     long completion = 1;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
-                          shmem_internal_my_pe, &completion);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+                          shmem_internal_my_pe, &completion, nic_idx);
+    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
 #else
     memcpy(dest, source, nelems);
 #endif

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -48,9 +48,9 @@ shmem_internal_put_nb(shmem_ctx_t ctx, void *target, const void *source, size_t 
 
 static inline
 void
-shmem_internal_put_wait(shmem_ctx_t ctx, long *completion, size_t nic_idx)
+shmem_internal_put_wait(shmem_ctx_t ctx, long *completion)
 {
-    shmem_transport_put_wait((shmem_transport_ctx_t *)ctx, completion, nic_idx);
+    shmem_transport_put_wait((shmem_transport_ctx_t *)ctx, completion);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
@@ -69,7 +69,7 @@ shmem_internal_put_scalar(shmem_ctx_t ctx, void *target, const void *source, siz
 #else
         long completion = 0;
         shmem_transport_put_nb((shmem_transport_ctx_t *)ctx, target, source, len, pe, &completion, nic_idx);
-	    shmem_internal_put_wait(ctx, &completion, nic_idx);
+	    shmem_internal_put_wait(ctx, &completion);
 #endif
     }
 }
@@ -414,7 +414,7 @@ void shmem_internal_copy_self(void *dest, const void *source, size_t nelems, siz
     long completion = 1;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion, nic_idx);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion, nic_idx);
+    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
 #else
     memcpy(dest, source, nelems);
 #endif

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -123,7 +123,7 @@ shmem_internal_put_ct_nb(shmemx_ct_t ct, void *target, const void *source, size_
 
 static inline
 void
-shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe)
+shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     if (len == 0) return;
 
@@ -137,7 +137,8 @@ shmem_internal_get(shmem_ctx_t ctx, void *target, const void *source, size_t len
 
 static inline
 void
-shmem_internal_get_ct(shmemx_ct_t ct, void *target, const void *source, size_t len, int pe)
+shmem_internal_get_ct(shmemx_ct_t ct, void *target, const void *source, size_t len,
+                      int pe, size_t nic_idx)
 {
     /* TODO: add shortcut for on-node-comms */
     shmem_transport_get_ct((shmem_transport_ct_t *) ct,
@@ -147,16 +148,16 @@ shmem_internal_get_ct(shmemx_ct_t ct, void *target, const void *source, size_t l
 
 static inline
 void
-shmem_internal_get_wait(shmem_ctx_t ctx)
+shmem_internal_get_wait(shmem_ctx_t ctx, size_t idx)
 {
-    shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
+    shmem_transport_get_wait((shmem_transport_ctx_t *)ctx, idx);
     /* on-node is always blocking, so this is a no-op for them */
 }
 
 static inline
 void
 shmem_internal_swap(shmem_ctx_t ctx, void *target, void *source, void *dest, size_t len,
-                    int pe, shm_internal_datatype_t datatype)
+                    int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -188,7 +189,7 @@ shmem_internal_swap_nbi(shmem_ctx_t ctx, void *target, void *source,
 static inline
 void
 shmem_internal_cswap(shmem_ctx_t ctx, void *target, void *source, void *dest, void *operand, size_t len,
-                    int pe, shm_internal_datatype_t datatype)
+                    int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -221,7 +222,7 @@ shmem_internal_cswap_nbi(shmem_ctx_t ctx, void *target, void *source,
 static inline
 void
 shmem_internal_mswap(shmem_ctx_t ctx, void *target, void *source, void *dest, void *mask, size_t len,
-                    int pe, shm_internal_datatype_t datatype)
+                    int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -262,7 +263,7 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
 static inline
 void
 shmem_internal_atomic_fetch(shmem_ctx_t ctx, void *target, const void *source, size_t len,
-                            int pe, shm_internal_datatype_t datatype)
+                            int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -304,7 +305,7 @@ static inline
 void
 shmem_internal_fetch_atomic(shmem_ctx_t ctx, void *target, void *source, void *dest, size_t len,
                             int pe, shm_internal_op_t op,
-                            shm_internal_datatype_t datatype)
+                            shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -206,7 +206,7 @@ static inline
 void
 shmem_internal_cswap_nbi(shmem_ctx_t ctx, void *target, void *source,
                          void *dest, void *operand, size_t len, int pe,
-                         shm_internal_datatype_t datatype)
+                         shm_internal_datatype_t datatype, size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -214,7 +214,7 @@ shmem_internal_cswap_nbi(shmem_ctx_t ctx, void *target, void *source,
         shmem_shr_transport_cswap(ctx, target, source, dest, operand, len, pe, datatype);
     } else {
         shmem_transport_cswap_nbi((shmem_transport_ctx_t *)ctx, target, source,
-                                  dest, operand, len, pe, datatype);
+                                  dest, operand, len, pe, datatype, nic_idx);
     }
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -337,7 +337,7 @@ shmem_internal_atomicv(shmem_ctx_t ctx, void *target, const void *source,
         shmem_internal_fetch_atomic(ctx, ((uint8_t *) target) + (i * type_size),
                                     ((uint8_t *) source) + (i * type_size), &tmp_fetch, type_size,
                                     pe, op, datatype, nic_idx);
-        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx);
+        shmem_transport_get_wait((shmem_transport_ctx_t *)ctx, nic_idx);
     }
     *completion += 1;
 #else

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -375,7 +375,8 @@ shmem_internal_fetch_atomic_nbi(shmem_ctx_t ctx, void *target, void *source,
 static inline
 void
 shmem_internal_atomic_fetch_nbi(shmem_ctx_t ctx, void *target, const void *source,
-                                size_t len, int pe, shm_internal_datatype_t datatype)
+                                size_t len, int pe, shm_internal_datatype_t datatype,
+                                size_t nic_idx)
 {
     shmem_internal_assert(len > 0);
 
@@ -383,7 +384,7 @@ shmem_internal_atomic_fetch_nbi(shmem_ctx_t ctx, void *target, const void *sourc
         shmem_shr_transport_atomic_fetch(ctx, target, source, len, pe, datatype);
     } else {
         shmem_transport_atomic_fetch_nbi((shmem_transport_ctx_t *)ctx, target,
-                                         source, len, pe, datatype);
+                                         source, len, pe, datatype, nic_idx);
     }
 }
 

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -186,6 +186,22 @@ extern hwloc_topology_t shmem_internal_topology;
         }                                                                \
     } while(0)
 
+/* TODO: Add definition if not using OFI or if multiplexing disabled.
+ * Would just return 0, or just do nothing since nic_idx will already
+ * be initialized to 0.
+ */
+#ifdef USE_OFI
+#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
+    do {                                                                 \
+        int rand_int = rand_r(&shmem_internal_rand_seed);                \
+        double normalized = (double)rand_int / (double)RAND_MAX;         \
+        int range = shmem_transport_ofi_num_nics - 1;                    \
+        idx = (int)(normalized * range);                                 \
+    } while (0)
+#else
+#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)
+#endif
+
 #ifdef ENABLE_ERROR_CHECKING
 #define SHMEM_ERR_CHECK_INITIALIZED()                                    \
     do {                                                                 \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -195,8 +195,7 @@ extern hwloc_topology_t shmem_internal_topology;
     do {                                                                 \
         int rand_int = rand_r(&shmem_internal_rand_seed);                \
         double normalized = (double)rand_int / (double)RAND_MAX;         \
-        int range = shmem_transport_ofi_num_nics - 1;                    \
-        idx = (int)(normalized * range);                                 \
+        idx = (int)(normalized * shmem_transport_ofi_num_nics);          \
     } while (0)
 #else
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -186,10 +186,6 @@ extern hwloc_topology_t shmem_internal_topology;
         }                                                                \
     } while(0)
 
-/* TODO: Add definition if not using OFI or if multiplexing disabled.
- * Would just return 0, or just do nothing since nic_idx will already
- * be initialized to 0.
- */
 #ifdef USE_OFI
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -186,7 +186,7 @@ extern hwloc_topology_t shmem_internal_topology;
         }                                                                \
     } while(0)
 
-#ifdef USE_OFI
+#ifdef USE_OFI_TX_LOAD_BALANCING
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \
         int rand_int = rand_r(&shmem_internal_rand_seed);                \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -187,21 +187,14 @@ extern hwloc_topology_t shmem_internal_topology;
         }                                                                \
     } while(0)
 
-#ifdef USE_OFI_TX_LOAD_BALANCING
-#ifdef USE_OFI_TX_LOAD_BALANCING_RANDOM
-/* Random NIC selection via rand_r.
- * Use modulo to avoid the float-multiply edge case where rand_int==RAND_MAX
- * produces normalized==1.0 and an out-of-bounds index. */
-#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
-    do {                                                                 \
-        int rand_int = rand_r(&shmem_internal_rand_seed);                \
-        idx = (int)((unsigned)rand_int %                                 \
-                    (unsigned)shmem_transport_ofi_num_nics);             \
-    } while (0)
-#else
-/* Round-robin NIC selection: uniform distribution, no PRNG overhead.
- * Use atomic fetch-add only for SHMEM_THREAD_MULTIPLE to avoid races. */
-#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
+
+// For Tx load balancing schemes
+
+#ifdef USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN
+
+  /* Round-robin NIC selection: uniform distribution, no PRNG overhead.
+   * Use atomic fetch-add only for SHMEM_THREAD_MULTIPLE to avoid races. */
+  #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \
         size_t rr;                                                       \
         if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE) {      \
@@ -211,11 +204,24 @@ extern hwloc_topology_t shmem_internal_topology;
             rr = shmem_internal_nic_rr_idx++;                            \
         }                                                                \
         idx = rr % shmem_transport_ofi_num_nics;                         \
-    } while (0)
-#endif
+      } while (0)
+
+#elif defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
+
+  /* Random NIC selection via rand_r.
+   * Use modulo to avoid the float-multiply edge case where rand_int==RAND_MAX
+   * produces normalized==1.0 and an out-of-bounds index. */
+  #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
+    do {                                                                 \
+        int rand_int = rand_r(&shmem_internal_rand_seed);                \
+        idx = (int)((unsigned)rand_int %                                 \
+                    (unsigned)shmem_transport_ofi_num_nics);             \
+      } while (0)
 #else
-#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)
+ /* No TX load balancing: nic_idx remains 0 (one NIC per PE). */
+ #define SHMEM_GET_TRANSMIT_NIC_IDX(idx) do { } while (0)
 #endif
+
 
 #ifdef ENABLE_ERROR_CHECKING
 #define SHMEM_ERR_CHECK_INITIALIZED()                                    \

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -50,6 +50,7 @@ extern int shmem_external_heap_device_type;
 extern int shmem_external_heap_device;
 
 extern unsigned int shmem_internal_rand_seed;
+extern size_t shmem_internal_nic_rr_idx;
 
 #ifdef USE_HWLOC
 #include <hwloc.h>
@@ -187,12 +188,23 @@ extern hwloc_topology_t shmem_internal_topology;
     } while(0)
 
 #ifdef USE_OFI_TX_LOAD_BALANCING
+#ifdef USE_OFI_TX_LOAD_BALANCING_RANDOM
+/* Random NIC selection via rand_r. */
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \
         int rand_int = rand_r(&shmem_internal_rand_seed);                \
         double normalized = (double)rand_int / (double)RAND_MAX;         \
         idx = (int)(normalized * shmem_transport_ofi_num_nics);          \
     } while (0)
+#else
+/* Round-robin NIC selection: uniform distribution, no PRNG overhead. */
+#define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
+    do {                                                                 \
+        idx = shmem_internal_nic_rr_idx;                                 \
+        if (++shmem_internal_nic_rr_idx >= shmem_transport_ofi_num_nics) \
+            shmem_internal_nic_rr_idx = 0;                              \
+    } while (0)
+#endif
 #else
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)
 #endif

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -189,20 +189,28 @@ extern hwloc_topology_t shmem_internal_topology;
 
 #ifdef USE_OFI_TX_LOAD_BALANCING
 #ifdef USE_OFI_TX_LOAD_BALANCING_RANDOM
-/* Random NIC selection via rand_r. */
+/* Random NIC selection via rand_r.
+ * Use modulo to avoid the float-multiply edge case where rand_int==RAND_MAX
+ * produces normalized==1.0 and an out-of-bounds index. */
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \
         int rand_int = rand_r(&shmem_internal_rand_seed);                \
-        double normalized = (double)rand_int / (double)RAND_MAX;         \
-        idx = (int)(normalized * shmem_transport_ofi_num_nics);          \
+        idx = (int)((unsigned)rand_int %                                 \
+                    (unsigned)shmem_transport_ofi_num_nics);             \
     } while (0)
 #else
-/* Round-robin NIC selection: uniform distribution, no PRNG overhead. */
+/* Round-robin NIC selection: uniform distribution, no PRNG overhead.
+ * Use atomic fetch-add only for SHMEM_THREAD_MULTIPLE to avoid races. */
 #define SHMEM_GET_TRANSMIT_NIC_IDX(idx)                                  \
     do {                                                                 \
-        idx = shmem_internal_nic_rr_idx;                                 \
-        if (++shmem_internal_nic_rr_idx >= shmem_transport_ofi_num_nics) \
-            shmem_internal_nic_rr_idx = 0;                              \
+        size_t rr;                                                       \
+        if (shmem_internal_thread_level == SHMEM_THREAD_MULTIPLE) {      \
+            rr = __atomic_fetch_add(&shmem_internal_nic_rr_idx, 1,       \
+                                    __ATOMIC_RELAXED);                   \
+        } else {                                                         \
+            rr = shmem_internal_nic_rr_idx++;                            \
+        }                                                                \
+        idx = rr % shmem_transport_ofi_num_nics;                         \
     } while (0)
 #endif
 #else

--- a/src/shmem_lock.h
+++ b/src/shmem_lock.h
@@ -46,9 +46,8 @@ shmem_internal_clear_lock(long *lockp, size_t nic_idx)
 
     /* release the lock if I'm the last to try to obtain it */
     cond = shmem_internal_my_pe + 1;
-    shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &zero, &curr, &cond,
-                         sizeof(int), 0, SHM_INTERNAL_INT, nic_idx); // Multiplex across NICs?
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
+    shmem_internal_cswap(SHMEM_CTX_DEFAULT, &(lock->last), &zero, &curr, &cond, sizeof(int), 0, SHM_INTERNAL_INT, nic_idx);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx);
 
     /* if local PE was not the last to hold the lock, look for the next in line */
     if (curr != shmem_internal_my_pe + 1) {
@@ -56,10 +55,8 @@ shmem_internal_clear_lock(long *lockp, size_t nic_idx)
 
         /* wait for next part of the data block to be non-zero */
         for (;;) {
-            shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &cur_data, &(lock->data),
-                                        sizeof(int), shmem_internal_my_pe,
-                                        SHM_INTERNAL_INT, nic_idx); // Multiplex across NICs?
-            shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
+            shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &cur_data, &(lock->data), sizeof(int), shmem_internal_my_pe, SHM_INTERNAL_INT, nic_idx);
+            shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx);
 
             if (NEXT(cur_data) != 0)
                 break;
@@ -68,9 +65,8 @@ shmem_internal_clear_lock(long *lockp, size_t nic_idx)
         }
 
         /* set the signal bit on new lock holder */
-        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &sig, &curr,
-                             &sig, sizeof(int), NEXT(cur_data) - 1, SHM_INTERNAL_INT, nic_idx);// Multiplex across NICs?
-        shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
+        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &sig, &curr, &sig, sizeof(int), NEXT(cur_data) - 1, SHM_INTERNAL_INT, nic_idx);
+        shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); 
     }
 }
 
@@ -82,29 +78,25 @@ shmem_internal_set_lock(long *lockp, size_t nic_idx)
     int curr, zero = 0, me = shmem_internal_my_pe + 1;
 
     /* initialize my elements to zero */
-    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, &(lock->data), &zero,
-                              sizeof(zero), shmem_internal_my_pe, SHM_INTERNAL_INT, nic_idx);
+    shmem_internal_atomic_set(SHMEM_CTX_DEFAULT, &(lock->data), &zero, sizeof(zero), shmem_internal_my_pe, SHM_INTERNAL_INT, nic_idx);
     shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 
     /* update last with my value to add me to the queue */
-    shmem_internal_swap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr,
-                        sizeof(int), 0, SHM_INTERNAL_INT, 0); // Multiplex across NICs?
-    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, 0); // Multiplex across NICs?
+    shmem_internal_swap(SHMEM_CTX_DEFAULT, &(lock->last), &me, &curr, sizeof(int), 0, SHM_INTERNAL_INT, nic_idx);
+    shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
 
     /* If I wasn't the first, need to add myself to the previous last's next */
     if (0 != curr) {
         int next_mask = NEXT_MASK;
 
-        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &me, &curr,
-                             &next_mask, sizeof(int), curr - 1, SHM_INTERNAL_INT, nic_idx); // Multiplex across NICs?
+        shmem_internal_mswap(SHMEM_CTX_DEFAULT, &(lock->data), &me, &curr, &next_mask, sizeof(int), curr - 1, SHM_INTERNAL_INT, nic_idx);
         shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
 
         /* now wait for the signal part of data to be non-zero */
         for (;;) {
             int cur_data;
 
-            shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &cur_data, &(lock->data),
-                                        sizeof(int), shmem_internal_my_pe, SHM_INTERNAL_INT, nic_idx); // Multiplex across NICs?
+            shmem_internal_atomic_fetch(SHMEM_CTX_DEFAULT, &cur_data, &(lock->data), sizeof(int), shmem_internal_my_pe, SHM_INTERNAL_INT, nic_idx);
             shmem_internal_get_wait(SHMEM_CTX_DEFAULT, nic_idx); // Multiplex across NICs?
 
             if (SIGNAL(cur_data) != 0)

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -99,28 +99,24 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_TEST(type, a, b, ret) COMP(type, SYNC_LOAD(a), b, ret)
 
-#define SHMEM_WAIT_POLL(var, value)                                                        \
-    do {                                                                                   \
-        while (SYNC_LOAD(var) == value) {                                                  \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++)  { \
-                shmem_transport_probe(nic_idx);                                            \
-                SPINLOCK_BODY();                                                           \
-            }                                                                              \
-        }                                                                                  \
+#define SHMEM_WAIT_POLL(var, value)                                             \
+    do {                                                                        \
+        while (SYNC_LOAD(var) == value) {                                       \
+            shmem_transport_probe();                                            \
+            SPINLOCK_BODY();                                                    \
+        }                                                                       \
     } while(0)
 
-#define SHMEM_WAIT_UNTIL_POLL(var, cond, value)                                           \
-    do {                                                                                  \
-        int cmpret;                                                                       \
-                                                                                          \
-        COMP(cond, SYNC_LOAD(var), value, cmpret);                                        \
-        while (!cmpret) {                                                                 \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { \
-                shmem_transport_probe(nic_idx);                                           \
-                SPINLOCK_BODY();                                                          \
-            }                                                                             \
-            COMP(cond, SYNC_LOAD(var), value, cmpret);                                    \
-        }                                                                                 \
+#define SHMEM_WAIT_UNTIL_POLL(var, cond, value)                                \
+    do {                                                                       \
+        int cmpret;                                                            \
+                                                                               \
+        COMP(cond, SYNC_LOAD(var), value, cmpret);                             \
+        while (!cmpret) {                                                      \
+            shmem_transport_probe();                                           \
+            SPINLOCK_BODY();                                                   \
+            COMP(cond, SYNC_LOAD(var), value, cmpret);                         \
+        }                                                                      \
     } while(0)
 
 #define SHMEM_SIGNAL_WAIT_UNTIL_POLL(var, cond, value, sat_value)                         \
@@ -129,10 +125,8 @@ shmem_internal_fence(shmem_ctx_t ctx)
                                                                                           \
         COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);                      \
         while (!cmpret) {                                                                 \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { \
-                shmem_transport_probe(nic_idx);                                           \
-                SPINLOCK_BODY();                                                          \
-            }                                                                             \
+            shmem_transport_probe();                                                      \
+            SPINLOCK_BODY();                                                              \
             COMP_SIGNAL(cond, SYNC_LOAD(var), value, cmpret, sat_value);                  \
         }                                                                                 \
     } while(0)

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -108,9 +108,16 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_WAIT_UNTIL_POLL(var, cond, value)          \
     do {                                                 \
-        int cmpret;                                      \
+        /* Adding volatile attribute resolves
+        hanging behavior observed in put/get perf
+        tests, though put perf test will still hang
+        frequently, and specifically after 4096 byte msg
+        size test*/                                      \
+        volatile int cmpret;                             \
                                                          \
+        /*shmem_transport_probe();*/                     \
         COMP(cond, SYNC_LOAD(var), value, cmpret);       \
+        /*shmem_transport_probe();*/                     \
         while (!cmpret) {                                \
             shmem_transport_probe();                     \
             SPINLOCK_BODY();                             \

--- a/src/shmem_synchronization.h
+++ b/src/shmem_synchronization.h
@@ -108,16 +108,11 @@ shmem_internal_fence(shmem_ctx_t ctx)
 
 #define SHMEM_WAIT_UNTIL_POLL(var, cond, value)          \
     do {                                                 \
-        /* Adding volatile attribute resolves
-        hanging behavior observed in put/get perf
-        tests, though put perf test will still hang
-        frequently, and specifically after 4096 byte msg
-        size test*/                                      \
-        volatile int cmpret;                             \
+        int cmpret;                                      \
                                                          \
-        /*shmem_transport_probe();*/                     \
+        /*shmem_transport_probe();*/                         \
         COMP(cond, SYNC_LOAD(var), value, cmpret);       \
-        /*shmem_transport_probe();*/                     \
+        /*shmem_transport_probe();*/                         \
         while (!cmpret) {                                \
             shmem_transport_probe();                     \
             SPINLOCK_BODY();                             \

--- a/src/shmem_team.h
+++ b/src/shmem_team.h
@@ -58,11 +58,12 @@ int shmem_internal_team_translate_pe(shmem_internal_team_t *src_team, int src_pe
 
 int shmem_internal_team_split_strided(shmem_internal_team_t *parent_team, int PE_start, int PE_stride,
                                       int PE_size, const shmem_team_config_t *config, long config_mask,
-                                      shmem_internal_team_t **new_team);
+                                      shmem_internal_team_t **new_team, size_t nic_idx);
 
 int shmem_internal_team_split_2d(shmem_internal_team_t *parent_team, int xrange,
                                  const shmem_team_config_t *xaxis_config, long xaxis_mask, shmem_internal_team_t **xaxis_team,
-                                 const shmem_team_config_t *yaxis_config, long yaxis_mask, shmem_internal_team_t **yaxis_team);
+                                 const shmem_team_config_t *yaxis_config, long yaxis_mask, shmem_internal_team_t **yaxis_team,
+                                 size_t nic_idx);
 
 int shmem_internal_team_destroy(shmem_internal_team_t *team);
 
@@ -70,7 +71,7 @@ int shmem_internal_team_create_ctx(shmem_internal_team_t *team, long options, sh
 
 int shmem_internal_ctx_get_team(shmem_ctx_t ctx, shmem_internal_team_t **team);
 
-long * shmem_internal_team_choose_psync(shmem_internal_team_t *team, shmem_internal_team_op_t op);
+long * shmem_internal_team_choose_psync(shmem_internal_team_t *team, shmem_internal_team_op_t op, size_t nic_idx);
 
 void shmem_internal_team_release_psyncs(shmem_internal_team_t *team, shmem_internal_team_op_t op);
 

--- a/src/shr_transport.h4
+++ b/src/shr_transport.h4
@@ -566,7 +566,8 @@ SHMEM_DEFINE_FOR_AMO(SHMEM_DEF_SUM_OP)
 static inline void
 shmem_shr_transport_put_signal(shmem_ctx_t ctx, void *target,
                                const void *source, size_t len,
-                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
+                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe,
+                               size_t nic_idx)
 {
 #if USE_MEMCPY
     memcpy(target, source, len);
@@ -587,10 +588,10 @@ shmem_shr_transport_put_signal(shmem_ctx_t ctx, void *target,
 #else
     if (sig_op == SHMEM_SIGNAL_ADD)
         shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal, sizeof(uint64_t),
-                               pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                               pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
     else
         shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
-                                   sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+                                   sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 #endif
 #elif USE_CMA
     shmem_transport_cma_put(target, source, len, pe,
@@ -600,10 +601,10 @@ shmem_shr_transport_put_signal(shmem_ctx_t ctx, void *target,
     /* Using network atomics as CMA does not support atomic operations */
     if (sig_op == SHMEM_SIGNAL_ADD)
         shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal, sizeof(uint64_t),
-                               pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                               pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
     else
         shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
-                                   sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+                                   sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 #else
     RAISE_ERROR_STR("No path to peer");
 #endif

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -295,9 +295,9 @@ shmem_malloc(size_t size)
     ret = dlmalloc(size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -315,9 +315,9 @@ shmem_calloc(size_t count, size_t size)
     ret = dlcalloc(count, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -330,9 +330,9 @@ shmem_free(void *ptr)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     shmem_internal_free(ptr);
 }
@@ -350,9 +350,9 @@ shmem_realloc(void *ptr, size_t size)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     if (size == 0 && ptr != NULL) {
@@ -363,9 +363,8 @@ shmem_realloc(void *ptr, size_t size)
     }
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -386,9 +385,9 @@ shmem_align(size_t alignment, size_t size)
     ret = dlmemalign(alignment, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-        shmem_internal_barrier_all(nic_idx);
-    }
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -443,9 +442,9 @@ shmem_malloc_with_hints(size_t size, long hints)
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
     if (!(hints & SHMEMX_MALLOC_NO_BARRIER)) {
-        for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-            shmem_internal_barrier_all(nic_idx);
-        }
+        size_t nic_idx = 0;
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+        shmem_internal_barrier_all(nic_idx);
     }
     return ret;
 }

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -295,7 +295,9 @@ shmem_malloc(size_t size)
     ret = dlmalloc(size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -313,7 +315,9 @@ shmem_calloc(size_t count, size_t size)
     ret = dlcalloc(count, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -326,7 +330,9 @@ shmem_free(void *ptr)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     shmem_internal_free(ptr);
 }
@@ -344,7 +350,9 @@ shmem_realloc(void *ptr, size_t size)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     if (size == 0 && ptr != NULL) {
@@ -355,7 +363,7 @@ shmem_realloc(void *ptr, size_t size)
     }
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all();
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -376,7 +384,9 @@ shmem_align(size_t alignment, size_t size)
     ret = dlmemalign(alignment, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all();
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+    shmem_internal_barrier_all(nic_idx);
 
     return ret;
 }
@@ -430,9 +440,11 @@ shmem_malloc_with_hints(size_t size, long hints)
     ret = dlmalloc(size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    if (!(hints & SHMEMX_MALLOC_NO_BARRIER))
-        shmem_internal_barrier_all();
-
+    if (!(hints & SHMEMX_MALLOC_NO_BARRIER)) {
+        size_t nic_idx = 0;
+        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
+        shmem_internal_barrier_all(nic_idx);
+    }
     return ret;
 }
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -295,9 +295,9 @@ shmem_malloc(size_t size)
     ret = dlmalloc(size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    size_t nic_idx = 0;
-    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     return ret;
 }
@@ -315,9 +315,9 @@ shmem_calloc(size_t count, size_t size)
     ret = dlcalloc(count, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    size_t nic_idx = 0;
-    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     return ret;
 }
@@ -330,9 +330,9 @@ shmem_free(void *ptr)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    size_t nic_idx = 0;
-    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     shmem_internal_free(ptr);
 }
@@ -350,9 +350,9 @@ shmem_realloc(void *ptr, size_t size)
       SHMEM_ERR_CHECK_SYMMETRIC_HEAP(ptr);
     }
 
-    size_t nic_idx = 0;
-    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     SHMEM_MUTEX_LOCK(shmem_internal_mutex_alloc);
     if (size == 0 && ptr != NULL) {
@@ -363,7 +363,9 @@ shmem_realloc(void *ptr, size_t size)
     }
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     return ret;
 }
@@ -384,9 +386,9 @@ shmem_align(size_t alignment, size_t size)
     ret = dlmemalign(alignment, size);
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
-    size_t nic_idx = 0;
-    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-    shmem_internal_barrier_all(nic_idx);
+    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+        shmem_internal_barrier_all(nic_idx);
+    }
 
     return ret;
 }
@@ -441,9 +443,9 @@ shmem_malloc_with_hints(size_t size, long hints)
     SHMEM_MUTEX_UNLOCK(shmem_internal_mutex_alloc);
 
     if (!(hints & SHMEMX_MALLOC_NO_BARRIER)) {
-        size_t nic_idx = 0;
-        SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
-        shmem_internal_barrier_all(nic_idx);
+        for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+            shmem_internal_barrier_all(nic_idx);
+        }
     }
     return ret;
 }

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -232,7 +232,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
             return;                                                                               \
         }                                                                                         \
                                                                                                   \
@@ -268,7 +268,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
         }                                                                                         \
                                                                                                   \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); };                                                              \
             return;                                                                               \
         }                                                                                         \
                                                                                                   \
@@ -304,7 +304,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
             return SIZE_MAX;                                                                      \
         }                                                                                         \
                                                                                                   \
@@ -324,7 +324,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
                     }                                                                             \
                 }                                                                                 \
             }                                                                                     \
-            if (!cmpret) shmem_transport_probe();                                                 \
+            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                 \
         }                                                                                         \
                                                                                                   \
         shmem_internal_membar_acq_rel();                                                          \
@@ -354,7 +354,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
             return SIZE_MAX;                                                                      \
         }                                                                                         \
                                                                                                   \
@@ -374,7 +374,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
                     }                                                                             \
                 }                                                                                 \
             }                                                                                     \
-            if (!cmpret) shmem_transport_probe();                                                 \
+            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                 \
         }                                                                                         \
                                                                                                   \
         shmem_internal_membar_acq_rel();                                                          \
@@ -408,7 +408,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            shmem_transport_probe();                                                           \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -423,7 +423,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
                     }                                                                          \
                 }                                                                              \
             }                                                                                  \
-            if (!cmpret) shmem_transport_probe();                                              \
+            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                              \
         }                                                                                      \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
@@ -456,7 +456,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            shmem_transport_probe();                                                           \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -471,7 +471,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
                     }                                                                          \
                 }                                                                              \
             }                                                                                  \
-            if (!cmpret) shmem_transport_probe();                                              \
+            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                              \
         }                                                                                      \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
@@ -495,7 +495,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME_VECTOR')
             shmem_internal_membar_acq_rel();                                                   \
             shmem_transport_syncmem();                                                         \
         } else {                                                                               \
-            shmem_transport_probe();                                                           \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
         }                                                                                      \
         return cmpret;                                                                         \
     }
@@ -520,7 +520,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
                 int cmpret;                                                                       \
                 SHMEM_TEST(cond, &vars[i], value, cmpret);                                        \
                 if (!cmpret) {                                                                    \
-                    shmem_transport_probe();                                                      \
+                    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                      \
                     return 0;                                                                     \
                 }                                                                                 \
             }                                                                                     \
@@ -551,7 +551,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
                 int cmpret;                                                                       \
                 SHMEM_TEST(cond, &vars[i], values[i], cmpret);                                    \
                 if (!cmpret) {                                                                    \
-                    shmem_transport_probe();                                                      \
+                    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                      \
                     return 0;                                                                     \
                 }                                                                                 \
             }                                                                                     \
@@ -596,7 +596,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL_VECTOR')
             shmem_internal_membar_acq_rel();                                                      \
             shmem_transport_syncmem();                                                            \
         } else                                                                                    \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
                                                                                                   \
         return found_idx;                                                                         \
     }
@@ -635,7 +635,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
             shmem_internal_membar_acq_rel();                                                      \
             shmem_transport_syncmem();                                                            \
         } else                                                                                    \
-            shmem_transport_probe();                                                              \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
                                                                                                   \
         return found_idx;                                                                         \
     }
@@ -666,7 +666,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            shmem_transport_probe();                                                           \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -680,7 +680,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
                 }                                                                              \
             }                                                                                  \
         }                                                                                      \
-        if (!cmpret) shmem_transport_probe();                                                  \
+        if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                  \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
@@ -712,7 +712,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            shmem_transport_probe();                                                           \
+            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -726,7 +726,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
                 }                                                                              \
             }                                                                                  \
         }                                                                                      \
-        if (!cmpret) shmem_transport_probe();                                                  \
+        if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                  \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \

--- a/src/synchronization_c.c4
+++ b/src/synchronization_c.c4
@@ -232,7 +232,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
+            shmem_transport_probe();                                                              \
             return;                                                                               \
         }                                                                                         \
                                                                                                   \
@@ -268,7 +268,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL')
         }                                                                                         \
                                                                                                   \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); };                                                              \
+            shmem_transport_probe();                                                              \
             return;                                                                               \
         }                                                                                         \
                                                                                                   \
@@ -304,7 +304,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
+            shmem_transport_probe();                                                              \
             return SIZE_MAX;                                                                      \
         }                                                                                         \
                                                                                                   \
@@ -324,7 +324,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ALL_VECTOR')
                     }                                                                             \
                 }                                                                                 \
             }                                                                                     \
-            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                 \
+            if (!cmpret) shmem_transport_probe();                                                 \
         }                                                                                         \
                                                                                                   \
         shmem_internal_membar_acq_rel();                                                          \
@@ -354,7 +354,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
             }                                                                                     \
         }                                                                                         \
         if (nelems == 0 || num_ignored == nelems) {                                               \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
+            shmem_transport_probe();                                                              \
             return SIZE_MAX;                                                                      \
         }                                                                                         \
                                                                                                   \
@@ -374,7 +374,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY')
                     }                                                                             \
                 }                                                                                 \
             }                                                                                     \
-            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                 \
+            if (!cmpret) shmem_transport_probe();                                                 \
         }                                                                                         \
                                                                                                   \
         shmem_internal_membar_acq_rel();                                                          \
@@ -408,7 +408,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
+            shmem_transport_probe();                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -423,7 +423,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_ANY_VECTOR')
                     }                                                                          \
                 }                                                                              \
             }                                                                                  \
-            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                              \
+            if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
@@ -456,7 +456,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
+            shmem_transport_probe();                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -471,7 +471,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME')
                     }                                                                          \
                 }                                                                              \
             }                                                                                  \
-            if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                              \
+            if (!cmpret) shmem_transport_probe();                                              \
         }                                                                                      \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
@@ -495,7 +495,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_WAIT_UNTIL_SOME_VECTOR')
             shmem_internal_membar_acq_rel();                                                   \
             shmem_transport_syncmem();                                                         \
         } else {                                                                               \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
+            shmem_transport_probe();                                                           \
         }                                                                                      \
         return cmpret;                                                                         \
     }
@@ -520,7 +520,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST')
                 int cmpret;                                                                       \
                 SHMEM_TEST(cond, &vars[i], value, cmpret);                                        \
                 if (!cmpret) {                                                                    \
-                    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                      \
+                    shmem_transport_probe();                                                      \
                     return 0;                                                                     \
                 }                                                                                 \
             }                                                                                     \
@@ -551,7 +551,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL')
                 int cmpret;                                                                       \
                 SHMEM_TEST(cond, &vars[i], values[i], cmpret);                                    \
                 if (!cmpret) {                                                                    \
-                    for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                      \
+                    shmem_transport_probe();                                                      \
                     return 0;                                                                     \
                 }                                                                                 \
             }                                                                                     \
@@ -596,7 +596,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ALL_VECTOR')
             shmem_internal_membar_acq_rel();                                                      \
             shmem_transport_syncmem();                                                            \
         } else                                                                                    \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
+            shmem_transport_probe();                                                              \
                                                                                                   \
         return found_idx;                                                                         \
     }
@@ -635,7 +635,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY')
             shmem_internal_membar_acq_rel();                                                      \
             shmem_transport_syncmem();                                                            \
         } else                                                                                    \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                              \
+            shmem_transport_probe();                                                              \
                                                                                                   \
         return found_idx;                                                                         \
     }
@@ -666,7 +666,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
+            shmem_transport_probe();                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -680,7 +680,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_ANY_VECTOR')
                 }                                                                              \
             }                                                                                  \
         }                                                                                      \
-        if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                  \
+        if (!cmpret) shmem_transport_probe();                                                  \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \
@@ -712,7 +712,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
             }                                                                                  \
         }                                                                                      \
         if (nelems == 0 || num_ignored == nelems) {                                            \
-            for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                           \
+            shmem_transport_probe();                                                           \
             return 0;                                                                          \
         }                                                                                      \
                                                                                                \
@@ -726,7 +726,7 @@ SHMEM_BIND_C_SYNC(`SHMEM_DEF_TEST_SOME')
                 }                                                                              \
             }                                                                                  \
         }                                                                                      \
-        if (!cmpret) for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) { shmem_transport_probe( nic_idx ); }                                                  \
+        if (!cmpret) shmem_transport_probe();                                                  \
         shmem_internal_membar_acq_rel();                                                       \
         shmem_transport_syncmem();                                                             \
         return ncompleted;                                                                     \

--- a/src/teams_c.c4
+++ b/src/teams_c.c4
@@ -115,9 +115,12 @@ shmem_team_split_strided(shmem_team_t parent_team, int PE_start,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     return shmem_internal_team_split_strided((shmem_internal_team_t *)parent_team,
                                              PE_start, PE_stride, PE_size, config,
-                                             config_mask, (shmem_internal_team_t **)new_team);
+                                             config_mask, (shmem_internal_team_t **)new_team,
+                                             nic_idx);
 }
 
 int SHMEM_FUNCTION_ATTRIBUTES
@@ -128,11 +131,14 @@ shmem_team_split_2d(shmem_team_t parent_team, int xrange,
 {
     SHMEM_ERR_CHECK_INITIALIZED();
 
+    size_t nic_idx = 0;
+    SHMEM_GET_TRANSMIT_NIC_IDX(nic_idx);
     return shmem_internal_team_split_2d((shmem_internal_team_t *)parent_team,
                                         xrange, xaxis_config, xaxis_mask,
                                         (shmem_internal_team_t **)xaxis_team,
                                         yaxis_config, yaxis_mask,
-                                        (shmem_internal_team_t **)yaxis_team);
+                                        (shmem_internal_team_t **)yaxis_team,
+                                        nic_idx);
 }
 
 int SHMEM_FUNCTION_ATTRIBUTES

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -192,7 +192,7 @@ static inline
 void
 shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                           const void *operand, size_t len, int pe,
-                          shm_internal_datatype_t datatype)
+                          shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -59,7 +59,7 @@ shmem_transport_fini(void)
 
 static inline
 void
-shmem_transport_probe(size_t nic_idx)
+shmem_transport_probe(void)
 {
     return;
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -59,7 +59,7 @@ shmem_transport_fini(void)
 
 static inline
 void
-shmem_transport_probe(void)
+shmem_transport_probe(size_t nic_idx)
 {
     return;
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -157,7 +157,7 @@ shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source
 
 static inline
 void
-shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 {
     /* Nop */
 }

--- a/src/transport_none.h
+++ b/src/transport_none.h
@@ -112,7 +112,7 @@ shmem_transport_fence(shmem_transport_ctx_t* ctx)
 
 static inline
 void
-shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -128,14 +128,14 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
 static inline
 void
 shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
+                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion, size_t nic_idx)
 {
     /* No op */
 }
@@ -143,14 +143,14 @@ shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 static inline
 void
 shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                       int pe)
+                       int pe, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void
-shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -166,7 +166,7 @@ shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 static inline
 void
 shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
-                     size_t len, int pe, shm_internal_datatype_t datatype)
+                     size_t len, int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -174,7 +174,7 @@ shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *sourc
 static inline
 void
 shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
-                         size_t len, int pe, shm_internal_datatype_t datatype)
+                         size_t len, int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -183,7 +183,7 @@ static inline
 void
 shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
-                      shm_internal_datatype_t datatype)
+                      shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -201,7 +201,7 @@ static inline
 void
 shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
-                      shm_internal_datatype_t datatype)
+                      shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -209,7 +209,7 @@ shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
 static inline
 void
 shmem_transport_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                       int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                       int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -225,7 +225,7 @@ shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const void *so
 static inline
 void
 shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
-                             int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -233,7 +233,7 @@ shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const voi
 static inline
 void
 shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
-                                 int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                                 int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -241,7 +241,7 @@ shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const
 static inline
 void
 shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                             int pe, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -249,7 +249,7 @@ shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const voi
 static inline
 void
 shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                             int pe, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
@@ -294,14 +294,15 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
 static inline
 void
 shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void
-                          *source, size_t len, int pe, long *completion)
+                          *source, size_t len, int pe, long *completion, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void shmem_transport_get_ct(shmem_transport_ct_t *ct, void
-                            *target, const void *source, size_t len, int pe)
+                            *target, const void *source, size_t len, int pe,
+                            size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -52,6 +52,9 @@
 #include "runtime.h"
 #include "uthash.h"
 
+struct fi_info **provider_list = NULL;
+size_t shmem_transport_ofi_num_nics = 0;
+
 struct fabric_info {
     struct fi_info *fabrics;
     struct fi_info *p_info;
@@ -386,7 +389,7 @@ struct shmem_transport_ofi_stx_t {
     int               is_private;
 };
 typedef struct shmem_transport_ofi_stx_t shmem_transport_ofi_stx_t;
-static shmem_transport_ofi_stx_t* shmem_transport_ofi_stx_pool = NULL;
+static shmem_transport_ofi_stx_t** shmem_transport_ofi_stx_pool = NULL;
 
 struct shmem_transport_ofi_stx_kvs_t {
     int                         stx_idx;
@@ -397,7 +400,7 @@ typedef struct shmem_transport_ofi_stx_kvs_t shmem_transport_ofi_stx_kvs_t;
 static shmem_transport_ofi_stx_kvs_t* shmem_transport_ofi_stx_kvs = NULL;
 
 static inline
-void shmem_transport_ofi_dump_stx(void) {
+void shmem_transport_ofi_dump_stx(size_t idx) {
     char stx_str[256];
     int i, offset;
 
@@ -407,8 +410,8 @@ void shmem_transport_ofi_dump_stx(void) {
     for (i = offset = 0; i < shmem_transport_ofi_stx_max; i++)
         offset += snprintf(stx_str+offset, 256-offset,
                            (i == shmem_transport_ofi_stx_max-1) ? "%ld%s" : "%ld%s ",
-                           shmem_transport_ofi_stx_pool[i].ref_cnt,
-                           shmem_transport_ofi_stx_pool[i].is_private ? "P" : "S");
+                           shmem_transport_ofi_stx_pool[idx][i].ref_cnt,
+                           shmem_transport_ofi_stx_pool[idx][i].is_private ? "P" : "S");
 
     DEBUG_MSG("STX[%ld] = [ %s ]\n", shmem_transport_ofi_stx_max, stx_str);
 }
@@ -432,13 +435,13 @@ void shmem_transport_ofi_stx_rand_init(void) {
 }
 
 static inline
-int shmem_transport_ofi_stx_search_unused(void)
+int shmem_transport_ofi_stx_search_unused(size_t idx)
 {
     int stx_idx = -1, i;
 
     for (i = 0; i < shmem_transport_ofi_stx_max; i++) {
-        if (shmem_transport_ofi_stx_pool[i].ref_cnt == 0) {
-            shmem_internal_assert(!shmem_transport_ofi_stx_pool[i].is_private);
+        if (shmem_transport_ofi_stx_pool[idx][i].ref_cnt == 0) {
+            shmem_internal_assert(!shmem_transport_ofi_stx_pool[idx][i].is_private);
             stx_idx = i;
             break;
         }
@@ -449,7 +452,7 @@ int shmem_transport_ofi_stx_search_unused(void)
 
 
 static inline
-int shmem_transport_ofi_stx_search_shared(long threshold)
+int shmem_transport_ofi_stx_search_shared(long threshold, size_t idx)
 {
     static int rr_start_idx = 0;
     int stx_idx = -1, i, count;
@@ -458,9 +461,9 @@ int shmem_transport_ofi_stx_search_shared(long threshold)
         case ROUNDROBIN:
             i = rr_start_idx;
             for (count = 0; count < shmem_transport_ofi_stx_max; count++) {
-                if (shmem_transport_ofi_stx_pool[i].ref_cnt > 0 &&
-                    (shmem_transport_ofi_stx_pool[i].ref_cnt <= threshold || threshold == -1) &&
-                    !shmem_transport_ofi_stx_pool[i].is_private) {
+                if (shmem_transport_ofi_stx_pool[idx][i].ref_cnt > 0 &&
+                    (shmem_transport_ofi_stx_pool[idx][i].ref_cnt <= threshold || threshold == -1) &&
+                    !shmem_transport_ofi_stx_pool[idx][i].is_private) {
                     stx_idx = i;
                     rr_start_idx = (i + 1) % shmem_transport_ofi_stx_max;
                     break;
@@ -473,9 +476,9 @@ int shmem_transport_ofi_stx_search_shared(long threshold)
 
         case RANDOM:
             for (i = count = 0; i < shmem_transport_ofi_stx_max; i++) {
-                if (shmem_transport_ofi_stx_pool[i].ref_cnt > 0 &&
-                    (shmem_transport_ofi_stx_pool[i].ref_cnt <= threshold || threshold == -1) &&
-                    !shmem_transport_ofi_stx_pool[i].is_private)
+                if (shmem_transport_ofi_stx_pool[idx][i].ref_cnt > 0 &&
+                    (shmem_transport_ofi_stx_pool[idx][i].ref_cnt <= threshold || threshold == -1) &&
+                    !shmem_transport_ofi_stx_pool[idx][i].is_private)
                 {
                     ++count;
                     break;
@@ -489,9 +492,9 @@ int shmem_transport_ofi_stx_search_shared(long threshold)
             else {
                 do {
                     stx_idx = (int) (rand_r(&rand_pool_seed) / (RAND_MAX + 1.0) * shmem_transport_ofi_stx_max);
-                } while (!(shmem_transport_ofi_stx_pool[stx_idx].ref_cnt > 0 &&
-                           (shmem_transport_ofi_stx_pool[stx_idx].ref_cnt <= threshold || threshold == -1) &&
-                           !shmem_transport_ofi_stx_pool[stx_idx].is_private));
+                } while (!(shmem_transport_ofi_stx_pool[idx][stx_idx].ref_cnt > 0 &&
+                           (shmem_transport_ofi_stx_pool[idx][stx_idx].ref_cnt <= threshold || threshold == -1) &&
+                           !shmem_transport_ofi_stx_pool[idx][stx_idx].is_private));
             }
 
             break;
@@ -506,21 +509,23 @@ int shmem_transport_ofi_stx_search_shared(long threshold)
 
 
 static inline
-void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
+void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx, size_t idx)
 {
     if (shmem_transport_ofi_stx_max == 0) {
-        ctx->stx_idx = -1;
+        ctx->stx_idx[idx] = -1;
     } else if (shmem_transport_ofi_is_private(ctx->options)) {
         /* SHMEM contexts that are private to the same thread (i.e. have
          * SHMEM_CTX_PRIVATE option set) share the same STX.  */
 
+        // TODO: Should f be an array of shmem_transport_ofi_stx_kvs_t pointers, or single pointer and
+        // stx_idx field is an array?
         shmem_transport_ofi_stx_kvs_t *f;
         HASH_FIND(hh, shmem_transport_ofi_stx_kvs,
                   &ctx->tid, sizeof(struct shmem_internal_tid), f);
 
         if (f) {
-            shmem_transport_ofi_stx_pool[f->stx_idx].ref_cnt++;
-            ctx->stx_idx = f->stx_idx;
+            shmem_transport_ofi_stx_pool[idx][f->stx_idx].ref_cnt++;
+            ctx->stx_idx[idx] = f->stx_idx;
 
         } else {
             /* No STX allocated to the given TID, attempt to allocate one */
@@ -528,21 +533,21 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
             int stx_idx;
             shmem_transport_ofi_stx_t *stx = NULL;
 
-            stx_idx = shmem_transport_ofi_stx_search_unused();
+            stx_idx = shmem_transport_ofi_stx_search_unused(idx);
 
             /* Couldn't get new STX, assign a shared one */
             /* Note: When stx_max > 0, shared STX allocation is always successful */
             if (stx_idx < 0) {
                 DEBUG_STR("private STX unavailable, falling back to STX sharing");
                 is_unused = 0;
-                stx_idx = shmem_transport_ofi_stx_search_shared(shmem_transport_ofi_stx_threshold);
+                stx_idx = shmem_transport_ofi_stx_search_shared(shmem_transport_ofi_stx_threshold, idx);
                 if (stx_idx < 0)
-                    stx_idx = shmem_transport_ofi_stx_search_shared(-1);
+                    stx_idx = shmem_transport_ofi_stx_search_shared(-1, idx);
             }
 
             shmem_internal_assert(stx_idx >= 0);
-            stx = &shmem_transport_ofi_stx_pool[stx_idx];
-            ctx->stx_idx = stx_idx;
+            stx = &shmem_transport_ofi_stx_pool[idx][stx_idx];
+            ctx->stx_idx[idx] = stx_idx;
             stx->ref_cnt++;
 
             if (is_unused) {
@@ -552,7 +557,7 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
                     RAISE_ERROR_STR("out of memory when allocating STX KVS entry");
                 }
                 e->tid     = ctx->tid;
-                e->stx_idx = ctx->stx_idx;
+                e->stx_idx = ctx->stx_idx[idx]; /* FIX? */
                 HASH_ADD(hh, shmem_transport_ofi_stx_kvs, tid,
                          sizeof(struct shmem_internal_tid), e);
             } else {
@@ -561,20 +566,20 @@ void shmem_transport_ofi_stx_allocate(shmem_transport_ctx_t *ctx)
         }
     /* TODO: Optimize this case? else if (ctx->options & SHMEM_CTX_SERIALIZED) */
     } else {
-        int stx_idx = shmem_transport_ofi_stx_search_shared(shmem_transport_ofi_stx_threshold);
+        int stx_idx = shmem_transport_ofi_stx_search_shared(shmem_transport_ofi_stx_threshold, idx);
 
         if (stx_idx < 0)
-            stx_idx = shmem_transport_ofi_stx_search_unused();
+            stx_idx = shmem_transport_ofi_stx_search_unused(idx);
 
         if (stx_idx < 0)
-            stx_idx = shmem_transport_ofi_stx_search_shared(-1);
+            stx_idx = shmem_transport_ofi_stx_search_shared(-1, idx);
 
         shmem_internal_assert(stx_idx >= 0);
-        ctx->stx_idx = stx_idx;
-        shmem_transport_ofi_stx_pool[ctx->stx_idx].ref_cnt++;
+        ctx->stx_idx[idx] = stx_idx;
+        shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]].ref_cnt++;
     }
 
-    shmem_transport_ofi_dump_stx();
+    shmem_transport_ofi_dump_stx(idx);
 
     return;
 }
@@ -592,24 +597,24 @@ void init_bounce_buffer(shmem_free_list_item_t *item)
 
 
 static inline
-int bind_enable_ep_resources(shmem_transport_ctx_t *ctx)
+int bind_enable_ep_resources(shmem_transport_ctx_t *ctx, size_t idx)
 {
     int ret = 0;
 
     /* If using SOS-managed STXs, bind the STX */
-    if (ctx->stx_idx >= 0) {
-        ret = fi_ep_bind(ctx->ep, &shmem_transport_ofi_stx_pool[ctx->stx_idx].stx->fid, 0);
+    if (ctx->stx_idx[idx] >= 0) {
+        ret = fi_ep_bind(ctx->ep[idx], &shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]].stx->fid, 0);
         OFI_CHECK_RETURN_STR(ret, "fi_ep_bind STX to endpoint failed");
     }
 
     /* Put counter captures completions for non-fetching operations (put,
      * atomic, etc.) */
-    ret = fi_ep_bind(ctx->ep, &ctx->put_cntr->fid, FI_WRITE);
+    ret = fi_ep_bind(ctx->ep[idx], &ctx->put_cntr[idx]->fid, FI_WRITE);
     OFI_CHECK_RETURN_STR(ret, "fi_ep_bind put CNTR to endpoint failed");
 
     /* Get counter captures completions for fetching operations (get,
      * fetch-atomic, etc.) */
-    ret = fi_ep_bind(ctx->ep, &ctx->get_cntr->fid, FI_READ);
+    ret = fi_ep_bind(ctx->ep[idx], &ctx->get_cntr[idx]->fid, FI_READ);
     OFI_CHECK_RETURN_STR(ret, "fi_ep_bind get CNTR to endpoint failed");
 
     /* In addition to incrementing the put counter, bounce buffered puts and
@@ -622,14 +627,14 @@ int bind_enable_ep_resources(shmem_transport_ctx_t *ctx)
      * removed below.  However, there aren't currently any cases where removing
      * FI_RECV significantly improves performance or resource usage.  */
 
-    ret = fi_ep_bind(ctx->ep, &ctx->cq->fid,
+    ret = fi_ep_bind(ctx->ep[idx], &ctx->cq[idx]->fid,
                      FI_SELECTIVE_COMPLETION | FI_TRANSMIT | FI_RECV);
     OFI_CHECK_RETURN_STR(ret, "fi_ep_bind CQ to endpoint failed");
 
-    ret = fi_ep_bind(ctx->ep, &shmem_transport_ofi_avfd->fid, 0);
+    ret = fi_ep_bind(ctx->ep[idx], &shmem_transport_ofi_avfd->fid, 0);
     OFI_CHECK_RETURN_STR(ret, "fi_ep_bind AV to endpoint failed");
 
-    ret = fi_enable(ctx->ep);
+    ret = fi_enable(ctx->ep[idx]);
     OFI_CHECK_RETURN_STR(ret, "fi_enable on endpoint failed");
 
     return ret;
@@ -872,14 +877,14 @@ int publish_external_mr_info(void)
 #endif
 
 static
-int publish_mr_info(void)
+int publish_mr_info(struct fi_info *info)
 {
 #ifndef ENABLE_MR_SCALABLE
     {
         int err;
         uint64_t heap_key, data_key;
 
-        if (shmem_transport_ofi_info.p_info->domain_attr->mr_mode & FI_MR_PROV_KEY) {
+        if (info->domain_attr->mr_mode & FI_MR_PROV_KEY) {
             heap_key = fi_mr_key(shmem_transport_ofi_target_heap_mrfd);
             data_key = fi_mr_key(shmem_transport_ofi_target_data_mrfd);
         } else {
@@ -901,7 +906,7 @@ int publish_mr_info(void)
     }
 
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    if (shmem_transport_ofi_info.p_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
+    if (info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
         shmem_transport_ofi_use_absolute_address = 1;
     else
         shmem_transport_ofi_use_absolute_address = 0;
@@ -910,7 +915,7 @@ int publish_mr_info(void)
         int err;
         void *heap_base, *data_base;
 
-        if (shmem_transport_ofi_info.p_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
+        if (info->domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
             heap_base = shmem_internal_heap_base;
             data_base = shmem_internal_data_base;
         } else {
@@ -1098,7 +1103,7 @@ int atomicvalid_rtncheck(int ret, int atomic_size,
 
 static inline
 int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
-                      atomic_support_lv atomic_sup)
+                      atomic_support_lv atomic_sup, size_t idx)
 {
     int i, j;
     size_t atomic_size;
@@ -1106,7 +1111,7 @@ int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
     for (i = 0; i < DT_MAX; i++) {
         for (j = 0; j < OPS_MAX; j++) {
             int dt = SHMEM_TRANSPORT_DTYPE(DT[i]);
-            int ret = fi_atomicvalid(shmem_transport_ctx_default.ep,
+            int ret = fi_atomicvalid(shmem_transport_ctx_default.ep[idx],
                                      dt, OPS[j], &atomic_size);
             if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
@@ -1120,7 +1125,7 @@ int atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
 
 static inline
 int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT,
-                              int *OPS, atomic_support_lv atomic_sup)
+                              int *OPS, atomic_support_lv atomic_sup, size_t idx)
 {
     int i, j;
     size_t atomic_size;
@@ -1128,7 +1133,7 @@ int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT,
     for (i = 0; i < DT_MAX; i++) {
         for (j = 0; j < OPS_MAX; j++) {
             int dt = SHMEM_TRANSPORT_DTYPE(DT[i]);
-            int ret = fi_compare_atomicvalid(shmem_transport_ctx_default.ep,
+            int ret = fi_compare_atomicvalid(shmem_transport_ctx_default.ep[idx],
                                              dt, OPS[j], &atomic_size);
             if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
@@ -1142,7 +1147,7 @@ int compare_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT,
 
 static inline
 int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
-                            atomic_support_lv atomic_sup)
+                            atomic_support_lv atomic_sup, size_t idx)
 {
     int i, j;
     size_t atomic_size;
@@ -1150,7 +1155,7 @@ int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
     for (i = 0; i < DT_MAX; i++) {
         for (j = 0; j < OPS_MAX; j++) {
             int dt = SHMEM_TRANSPORT_DTYPE(DT[i]);
-            int ret = fi_fetch_atomicvalid(shmem_transport_ctx_default.ep,
+            int ret = fi_fetch_atomicvalid(shmem_transport_ctx_default.ep[idx],
                                            dt, OPS[j], &atomic_size);
             if (atomicvalid_rtncheck(ret, atomic_size, atomic_sup,
                                      SHMEM_OpName[OPS[j]],
@@ -1163,7 +1168,7 @@ int fetch_atomicvalid_DTxOP(int DT_MAX, int OPS_MAX, int *DT, int *OPS,
 }
 
 static inline
-int atomic_limitations_check(void)
+int atomic_limitations_check(size_t idx)
 {
     /* Retrieve messaging limitations from OFI
      *
@@ -1182,54 +1187,54 @@ int atomic_limitations_check(void)
 
     /* Standard OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_OPS, DT_AMO_STANDARD,
-                            AMO_STANDARD_OPS, general_atomic_sup);
+                            AMO_STANDARD_OPS, general_atomic_sup, idx);
     if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_FOPS,
                                   DT_AMO_STANDARD, FETCH_AMO_STANDARD_OPS,
-                                  general_atomic_sup);
+                                  general_atomic_sup, idx);
     if (ret)
         return ret;
 
     ret = compare_atomicvalid_DTxOP(SIZEOF_AMO_DT, SIZEOF_AMO_COPS,
                                     DT_AMO_STANDARD, COMPARE_AMO_STANDARD_OPS,
-                                    general_atomic_sup);
+                                    general_atomic_sup, idx);
     if (ret)
         return ret;
 
     /* Extended OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_OPS, DT_AMO_EXTENDED,
-                            AMO_EXTENDED_OPS, general_atomic_sup);
+                            AMO_EXTENDED_OPS, general_atomic_sup, idx);
     if (ret)
         return ret;
 
     ret = fetch_atomicvalid_DTxOP(SIZEOF_AMO_EX_DT, SIZEOF_AMO_EX_FOPS,
                                   DT_AMO_EXTENDED, FETCH_AMO_EXTENDED_OPS,
-                                  general_atomic_sup);
+                                  general_atomic_sup, idx);
     if (ret)
         return ret;
 
     /* Reduction OPS check */
     ret = atomicvalid_DTxOP(SIZEOF_RED_DT, SIZEOF_RED_OPS, DT_REDUCE_BITWISE,
-                            REDUCE_BITWISE_OPS, reduction_sup);
+                            REDUCE_BITWISE_OPS, reduction_sup, idx);
     if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDC_DT, SIZEOF_REDC_OPS, DT_REDUCE_COMPARE,
-                            REDUCE_COMPARE_OPS, reduction_sup);
+                            REDUCE_COMPARE_OPS, reduction_sup, idx);
     if (ret)
         return ret;
 
     ret = atomicvalid_DTxOP(SIZEOF_REDA_DT, SIZEOF_REDA_OPS, DT_REDUCE_ARITH,
-                            REDUCE_ARITH_OPS, reduction_sup);
+                            REDUCE_ARITH_OPS, reduction_sup, idx);
     if (ret)
         return ret;
 
     /* Internal atomic requirement */
     ret = compare_atomicvalid_DTxOP(SIZEOF_INTERNAL_REQ_DT, SIZEOF_INTERNAL_REQ_OPS,
                                     DT_INTERNAL_REQ, INTERNAL_REQ_OPS,
-                                    general_atomic_sup);
+                                    general_atomic_sup, idx);
     if (ret)
         return ret;
 
@@ -1356,6 +1361,11 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     ret = hwloc_get_proc_last_cpu_location(shmem_internal_topology, getpid(), bindset, HWLOC_CPUBIND_PROCESS);
     if (ret < 0) {
         RAISE_WARN_MSG("hwloc_get_proc_last_cpu_location failed (%s)\n", strerror(errno));
+        provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+        for (size_t idx = 0; idx < num_nics; idx++) {
+            provider_list[idx] = provs[idx];
+        }
+        shmem_transport_ofi_num_nics = num_nics;
         return provs[shmem_internal_my_pe % num_nics];
     }
 
@@ -1371,11 +1381,21 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         hwloc_obj_t io_device = hwloc_get_pcidev_by_busid(shmem_internal_topology, pci.domain_id, pci.bus_id, pci.device_id, pci.function_id);
         if (!io_device) {
             RAISE_WARN_MSG("hwloc_get_pcidev_by_busid failed\n");
+            provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            for (size_t idx = 0; idx < num_nics; idx++) {
+                provider_list[idx] = provs[idx];
+            }
+            shmem_transport_ofi_num_nics = num_nics;
             return provs[shmem_internal_my_pe % num_nics];
         };
         hwloc_obj_t first_non_io = hwloc_get_non_io_ancestor_obj(shmem_internal_topology, io_device);
         if (!first_non_io) {
             RAISE_WARN_MSG("hwloc_get_non_io_ancestor_obj failed\n");
+            provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            for (size_t idx = 0; idx < num_nics; idx++) {
+                provider_list[idx] = provs[idx];
+            }
+            shmem_transport_ofi_num_nics = num_nics;
             return provs[shmem_internal_my_pe % num_nics];
         }
 
@@ -1392,7 +1412,11 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
 
     if (!close_provs) {
         RAISE_WARN_MSG("Could not detect any NICs with affinity to the process\n");
-
+        provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+        for (size_t idx = 0; idx < num_nics; idx++) {
+            provider_list[idx] = provs[idx];
+        }
+        shmem_transport_ofi_num_nics = num_nics;
         /* If no 'close' NICs, select from list of all NICs using round-robin assignment */
         return provs[shmem_internal_my_pe % num_nics];
     }
@@ -1400,16 +1424,17 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     last_added->next = NULL;
 
     int idx = 0;
-    struct fi_info **prov_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
+    provider_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
     for (struct fi_info *cur_fabric = close_provs; cur_fabric; cur_fabric = cur_fabric->next) {
-        prov_list[idx++] = cur_fabric;
+        provider_list[idx++] = cur_fabric;
     }
 
     hwloc_bitmap_free(bindset);
 
-    struct fi_info *provider = prov_list[shmem_internal_my_pe % num_close_nics];
-    free(prov_list);
+    struct fi_info *provider = provider_list[shmem_internal_my_pe % num_close_nics];
+    //free(prov_list);
 
+    shmem_transport_ofi_num_nics = num_close_nics;
     return provider;
 }
 #endif
@@ -1565,7 +1590,10 @@ int query_for_fabric(struct fabric_info *info)
     info->p_info = NULL;
 
     if (shmem_internal_params.OFI_DISABLE_MULTIRAIL) {
+        provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+        provider_list[0] = fabrics_list_head;
         info->p_info = fabrics_list_head;
+        shmem_transport_ofi_num_nics = 1;
     }
     else {
         /* Generate a linked list of all fabrics with a non-null nic value */
@@ -1581,26 +1609,34 @@ int query_for_fabric(struct fabric_info *info)
         if (multirail_fabric_list_tail) multirail_fabric_list_tail->next = NULL;
 
         if (num_nics == 0) {
+            provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            provider_list[0] = fallback;
             info->p_info = fallback;
+            shmem_transport_ofi_num_nics = 1;
         }
         else {
             int idx = 0;
-            struct fi_info **prov_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            struct fi_info **sorted_prov_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             for (struct fi_info *cur_fabric = multirail_fabric_list_head; cur_fabric; cur_fabric = cur_fabric->next) {
-                prov_list[idx++] = cur_fabric;
+                sorted_prov_list[idx++] = cur_fabric;
             }
-            qsort(prov_list, num_nics, sizeof(struct fi_info *), compare_nic_names);
+            qsort(sorted_prov_list, num_nics, sizeof(struct fi_info *), compare_nic_names);
 #ifdef USE_HWLOC
-            info->p_info = assign_nic_with_hwloc(info->p_info, prov_list, num_nics);
+            info->p_info = assign_nic_with_hwloc(info->p_info, sorted_prov_list, num_nics);
 #else
             /* Round-robin assignment of NICs to PEs
              * FIXME: A more suitable indexing value would be
              * shmem_team_my_pe(SHMEM_TEAM_NODE) % num_nics, but it is too early in initialization to
              * do that here. We would also want to replace the similar occurrences in the
              * assign_nic_with_hwloc function. */
-            info->p_info = prov_list[shmem_internal_my_pe % num_nics];
+            provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            for (size_t idx = 0; idx < num_nics; idx++) {
+                provider_list[idx] = sorted_prov_list[idx];
+            }
+            info->p_info = provider_list[shmem_internal_my_pe % num_nics];
+            shmem_transport_ofi_num_nics = num_nics;
 #endif
-            free(prov_list);
+            //free(prov_list); //Add free(provider_list) to cleanup
         }
     }
     if (NULL == info->p_info) {
@@ -1734,37 +1770,67 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     struct fabric_info* info = &shmem_transport_ofi_info;
 
-    info->p_info->ep_attr->tx_ctx_cnt = shmem_transport_ofi_stx_max > 0 ? FI_SHARED_CONTEXT : 0;
-    info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_RECV;
-    info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
-    info->p_info->mode = 0;
-    info->p_info->tx_attr->mode = 0;
-    info->p_info->rx_attr->mode = 0;
-    info->p_info->tx_attr->caps = info->p_info->caps;
-    info->p_info->rx_attr->caps = FI_RECV; /* to drive progress on the CQ */;
+    // Need to do these steps for all providers in provider_list?
+    //info->p_info->ep_attr->tx_ctx_cnt = shmem_transport_ofi_stx_max > 0 ? FI_SHARED_CONTEXT : 0;
+    //info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_RECV;
+    //info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+    //info->p_info->mode = 0;
+    //info->p_info->tx_attr->mode = 0;
+    //info->p_info->rx_attr->mode = 0;
+    //info->p_info->tx_attr->caps = info->p_info->caps;
+    //info->p_info->rx_attr->caps = FI_RECV; /* to drive progress on the CQ */;
 
     ctx->id = id;
+    ctx->ep = (struct fid_ep **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_ep *));
+    ctx->put_cntr = (struct fid_cntr **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cntr *));
+    ctx->get_cntr = (struct fid_cntr **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cntr *));
+#ifdef USE_CTX_LOCK
+    ctx->pending_put_cntr = (uint64_t *) malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
+    ctx->pending_get_cntr = (uint64_t *) malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
+#else
+    ctx->pending_put_cntr = (shmem_internal_cntr_t *) malloc(shmem_transport_ofi_num_nics * sizeof(shmem_internal_cntr_t));
+    ctx->pending_get_cntr = (shmem_internal_cntr_t *) malloc(shmem_transport_ofi_num_nics * sizeof(shmem_internal_cntr_t));
+#endif
+    ctx->cq = (struct fid_cq **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cq *));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+#ifdef USE_CTX_LOCK
+            ctx->pending_put_cntr[idx] = 0;
+            ctx->pending_get_cntr[idx] = 0;
+#else
+            shmem_internal_cntr_write(&ctx->pending_put_cntr[idx], 0);
+            shmem_internal_cntr_write(&ctx->pending_get_cntr[idx], 0);
+#endif
+            /* FIX */
+            //shmem_transport_ofi_eps[idx]->info->ep_attr->tx_ctx_cnt = shmem_transport_ofi_stx_max > 0 ? FI_SHARED_CONTEXT : 0;
+            //shmem_transport_ofi_eps[idx]->info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_RECV;
+            //shmem_transport_ofi_eps[idx]->info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+            //shmem_transport_ofi_eps[idx]->info->mode = 0;
+            //shmem_transport_ofi_eps[idx]->info->tx_attr->mode = 0;
+            //shmem_transport_ofi_eps[idx]->info->rx_attr->mode = 0;
+            //shmem_transport_ofi_eps[idx]->info->tx_attr->caps = info->p_info->caps;
+            //shmem_transport_ofi_eps[idx]->info->rx_attr->caps = FI_RECV; /* to drive progress on the CQ */;
 #ifdef USE_CTX_LOCK
     SHMEM_MUTEX_INIT(ctx->lock);
 #endif
 
-    ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_put_attr,
-                       &ctx->put_cntr, NULL);
-    OFI_CHECK_RETURN_MSG(ret, "put_cntr creation failed (%s)\n", fi_strerror(errno));
+        ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_put_attr,
+                        &ctx->put_cntr[idx], NULL);
+        OFI_CHECK_RETURN_MSG(ret, "put_cntr creation failed (%s)\n", fi_strerror(errno));
 
-    ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_get_attr,
-                       &ctx->get_cntr, NULL);
-    OFI_CHECK_RETURN_MSG(ret, "get_cntr creation failed (%s)\n", fi_strerror(errno));
+        ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_get_attr,
+                        &ctx->get_cntr[idx], NULL);
+        OFI_CHECK_RETURN_MSG(ret, "get_cntr creation failed (%s)\n", fi_strerror(errno));
 
-    ret = fi_cq_open(shmem_transport_ofi_domainfd, &cq_attr, &ctx->cq, NULL);
-    if (ret && errno == FI_EMFILE) {
-        DEBUG_STR("Context creation failed because of open files limit, consider increasing with 'ulimit' command");
+        ret = fi_cq_open(shmem_transport_ofi_domainfd, &cq_attr, &ctx->cq[idx], NULL);
+        if (ret && errno == FI_EMFILE) {
+            DEBUG_STR("Context creation failed because of open files limit, consider increasing with 'ulimit' command");
+        }
+        OFI_CHECK_RETURN_MSG(ret, "cq_open failed (%s)\n", fi_strerror(errno));
+
+        ret = fi_endpoint(shmem_transport_ofi_domainfd,
+                        info->p_info, &ctx->ep[idx], NULL);
+        OFI_CHECK_RETURN_MSG(ret, "ep creation failed (%s)\n", fi_strerror(errno));
     }
-    OFI_CHECK_RETURN_MSG(ret, "cq_open failed (%s)\n", fi_strerror(errno));
-
-    ret = fi_endpoint(shmem_transport_ofi_domainfd,
-                      info->p_info, &ctx->ep, NULL);
-    OFI_CHECK_RETURN_MSG(ret, "ep creation failed (%s)\n", fi_strerror(errno));
 
     /* TODO: Fill in TX attr */
 
@@ -1773,11 +1839,12 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         shmem_transport_ofi_is_private(ctx->options)) {
             ctx->tid = shmem_transport_ofi_gettid();
     }
-    shmem_transport_ofi_stx_allocate(ctx);
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        shmem_transport_ofi_stx_allocate(ctx, idx);
 
-    ret = bind_enable_ep_resources(ctx);
-    OFI_CHECK_RETURN_MSG(ret, "context bind/enable endpoint failed (%s)\n", fi_strerror(errno));
-
+        ret = bind_enable_ep_resources(ctx, idx);
+        OFI_CHECK_RETURN_MSG(ret, "context bind/enable endpoint failed (%s)\n", fi_strerror(errno));
+    }
     if (ctx->options & SHMEMX_CTX_BOUNCE_BUFFER &&
         shmem_transport_ofi_bounce_buffer_size > 0 &&
         shmem_transport_ofi_max_bounce_buffers > 0)
@@ -1892,7 +1959,7 @@ int shmem_transport_init(void)
     ret = shmem_transport_ofi_target_ep_init();
     if (ret != 0) return ret;
 
-    ret = publish_mr_info();
+    ret = publish_mr_info(shmem_transport_ofi_info.p_info);
     if (ret != 0) return ret;
 
     ret = publish_av_info(&shmem_transport_ofi_info);
@@ -1906,72 +1973,83 @@ int shmem_transport_startup(void)
     int ret;
     int i;
 
-    if (shmem_internal_params.OFI_STX_AUTO && shmem_transport_ofi_stx_max == 0) {
-        RAISE_WARN_STR("STXs disabled, ignoring request for automatic STX management");
+    shmem_transport_ofi_stx_pool = (shmem_transport_ofi_stx_t **) malloc(shmem_transport_ofi_num_nics *
+                                        sizeof(shmem_transport_ofi_stx_t *));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        shmem_transport_ofi_stx_pool[idx] = NULL;
     }
-    else if (shmem_internal_params.OFI_STX_AUTO) {
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        if (shmem_internal_params.OFI_STX_AUTO && shmem_transport_ofi_stx_max == 0) {
+            RAISE_WARN_STR("STXs disabled, ignoring request for automatic STX management");
+        }
+        else if (shmem_internal_params.OFI_STX_AUTO) {
+            long ofi_tx_ctx_cnt = /*shmem_transport_ofi_info.fabrics*/provider_list[idx]->domain_attr->tx_ctx_cnt;
+            int num_on_node = shmem_runtime_get_node_size();
 
-        long ofi_tx_ctx_cnt = shmem_transport_ofi_info.fabrics->domain_attr->tx_ctx_cnt;
-        int num_on_node = shmem_runtime_get_node_size();
+            if (shmem_internal_params.OFI_STX_MAX_provided) {
+                RAISE_WARN_MSG("Auto-setting STX_MAX; ignoring provided STX_MAX value '%ld'\n",
+                            shmem_internal_params.OFI_STX_MAX);
+            }
 
-        if (shmem_internal_params.OFI_STX_MAX_provided) {
-            RAISE_WARN_MSG("Auto-setting STX_MAX; ignoring provided STX_MAX value '%ld'\n",
-                           shmem_internal_params.OFI_STX_MAX);
+            if (ofi_tx_ctx_cnt <= 0)
+                RAISE_ERROR_MSG("Invalid number of TX contexts (%ld)\n", ofi_tx_ctx_cnt);
+
+            /* Paritition TX resources evenly across node-local PEs */
+            /* Note: we assume that the domain reports the same tx_ctx_cnt for
+            * every PE on the node.  We also assume that the resource reported
+            * should be divided equally among all PEs.  These assumptions may not
+            * be valid in all cases, for example when the provider has already
+            * partitioned resources or when a node has multiple NICs. */
+            shmem_transport_ofi_stx_max = ofi_tx_ctx_cnt / num_on_node;
+            int remainder = ofi_tx_ctx_cnt % num_on_node;
+            int node_pe = shmem_internal_my_pe % shmem_internal_num_pes;
+            if (remainder > 0 && ((node_pe % num_on_node) < remainder)) {
+                shmem_transport_ofi_stx_max++;
+            }
+
+            if (shmem_transport_ofi_stx_max <= 0)
+                RAISE_ERROR_MSG("Not enough TX contexts (%d)\n", num_on_node);
+
+            /* When running more PEs than available STXs, must assign each PE at least 1 */
+            if (shmem_transport_ofi_stx_max <= 0) {
+                shmem_transport_ofi_stx_max = 1;
+                RAISE_WARN_MSG("Need at least 1 STX per PE, but detected %ld available STXs for %d PEs\n",
+                            ofi_tx_ctx_cnt, num_on_node);
+            }
+
+            DEBUG_MSG("Auto-set STX max to %ld\n", shmem_transport_ofi_stx_max);
         }
 
-        if (ofi_tx_ctx_cnt <= 0)
-            RAISE_ERROR_MSG("Invalid number of TX contexts (%ld)\n", ofi_tx_ctx_cnt);
-
-        /* Paritition TX resources evenly across node-local PEs */
-        /* Note: we assume that the domain reports the same tx_ctx_cnt for
-         * every PE on the node.  We also assume that the resource reported
-         * should be divided equally among all PEs.  These assumptions may not
-         * be valid in all cases, for example when the provider has already
-         * partitioned resources or when a node has multiple NICs. */
-        shmem_transport_ofi_stx_max = ofi_tx_ctx_cnt / num_on_node;
-        int remainder = ofi_tx_ctx_cnt % num_on_node;
-        int node_pe = shmem_internal_my_pe % shmem_internal_num_pes;
-        if (remainder > 0 && ((node_pe % num_on_node) < remainder)) {
-            shmem_transport_ofi_stx_max++;
+        /* Allocate STX array with max length */
+        if (shmem_transport_ofi_stx_max > 0) {
+            shmem_transport_ofi_stx_pool[idx] = malloc(shmem_transport_ofi_stx_max *
+                                                sizeof(shmem_transport_ofi_stx_t));
+            if (shmem_transport_ofi_stx_pool == NULL) {
+                RAISE_ERROR_STR("Out of memory when allocating OFI STX pool");
+            }
         }
 
-        if (shmem_transport_ofi_stx_max <= 0)
-            RAISE_ERROR_MSG("Not enough TX contexts (%d)\n", num_on_node);
-
-        /* When running more PEs than available STXs, must assign each PE at least 1 */
-        if (shmem_transport_ofi_stx_max <= 0) {
-            shmem_transport_ofi_stx_max = 1;
-            RAISE_WARN_MSG("Need at least 1 STX per PE, but detected %ld available STXs for %d PEs\n",
-                           ofi_tx_ctx_cnt, num_on_node);
-        }
-
-        DEBUG_MSG("Auto-set STX max to %ld\n", shmem_transport_ofi_stx_max);
-    }
-
-    /* Allocate STX array with max length */
-    if (shmem_transport_ofi_stx_max > 0) {
-        shmem_transport_ofi_stx_pool = malloc(shmem_transport_ofi_stx_max *
-                                              sizeof(shmem_transport_ofi_stx_t));
-        if (shmem_transport_ofi_stx_pool == NULL) {
-            RAISE_ERROR_STR("Out of memory when allocating OFI STX pool");
+        for (i = 0; i < shmem_transport_ofi_stx_max; i++) {
+            ret = fi_stx_context(shmem_transport_ofi_domainfd, NULL,
+                                &shmem_transport_ofi_stx_pool[idx][i].stx, NULL);
+            OFI_CHECK_RETURN_MSG(ret, "STX context creation failed (%s)\n", fi_strerror(ret));
+            shmem_transport_ofi_stx_pool[idx][i].ref_cnt = 0;
+            shmem_transport_ofi_stx_pool[idx][i].is_private = 0;
         }
     }
-
-    for (i = 0; i < shmem_transport_ofi_stx_max; i++) {
-        ret = fi_stx_context(shmem_transport_ofi_domainfd, NULL,
-                             &shmem_transport_ofi_stx_pool[i].stx, NULL);
-        OFI_CHECK_RETURN_MSG(ret, "STX context creation failed (%s)\n", fi_strerror(ret));
-        shmem_transport_ofi_stx_pool[i].ref_cnt = 0;
-        shmem_transport_ofi_stx_pool[i].is_private = 0;
-    }
-
     shmem_transport_ctx_default.team = &shmem_internal_team_world;
 
+    shmem_transport_ctx_default.stx_idx = malloc(shmem_transport_ofi_num_nics * sizeof(int));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        shmem_transport_ctx_default.stx_idx[idx] = -1;
+    }
     ret = shmem_transport_ofi_ctx_init(&shmem_transport_ctx_default, SHMEM_TRANSPORT_CTX_DEFAULT_ID);
     if (ret != 0) return ret;
 
-    ret = atomic_limitations_check();
-    if (ret != 0) return ret;
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        ret = atomic_limitations_check(idx);
+        if (ret != 0) return ret;
+    }
 
     ret = populate_mr_tables();
     if (ret != 0) return ret;
@@ -2020,12 +2098,20 @@ int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options,
 
     memset(ctxp, 0, sizeof(shmem_transport_ctx_t));
 
+    ctxp->pending_put_cntr = malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
+    ctxp->pending_get_cntr = malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
+    ctxp->stx_idx = malloc(shmem_transport_ofi_num_nics * sizeof(int));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
 #ifndef USE_CTX_LOCK
-    shmem_internal_cntr_write(&ctxp->pending_put_cntr, 0);
-    shmem_internal_cntr_write(&ctxp->pending_get_cntr, 0);
+        shmem_internal_cntr_write(&ctxp->pending_put_cntr, 0);
+        shmem_internal_cntr_write(&ctxp->pending_get_cntr, 0);
+#else
+        ctxp->pending_put_cntr[idx] = 0;
+        ctxp->pending_get_cntr[idx] = 0;
 #endif
 
-    ctxp->stx_idx = -1;
+        ctxp->stx_idx[idx] = -1;
+    }
     ctxp->options = options;
 
     ctxp->team = team;
@@ -2054,6 +2140,9 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     if(shmem_internal_params.DEBUG) {
         SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
         if (ctx->bounce_buffers) SHMEM_TRANSPORT_OFI_CTX_BB_LOCK(ctx);
+        // TODO: May want to include pending/completed counters for ALL NICs or at least an aggregate
+        // for each counter type
+/* Causes seg. fault right now for obvious reasons
         DEBUG_MSG("id = %d, options = %#0lx, stx_idx = %d\n"
                   RAISE_PE_PREFIX "pending_put_cntr = %9"PRIu64", completed_put_cntr = %9"PRIu64"\n"
                   RAISE_PE_PREFIX "pending_get_cntr = %9"PRIu64", completed_get_cntr = %9"PRIu64"\n"
@@ -2068,60 +2157,67 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
                   shmem_internal_my_pe,
                   ctx->pending_bb_cntr, ctx->completed_bb_cntr
                  );
+*/
         if (ctx->bounce_buffers) SHMEM_TRANSPORT_OFI_CTX_BB_UNLOCK(ctx);
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
     }
 
-    if (ctx->ep) {
-        ret = fi_close(&ctx->ep->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Context endpoint close failed (%s)\n", fi_strerror(errno));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        if (ctx->ep[idx]) {
+            ret = fi_close(&ctx->ep[idx]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Context endpoint close failed (%s)\n", fi_strerror(errno));
+        }
     }
 
     if (ctx->bounce_buffers) {
         shmem_free_list_destroy(ctx->bounce_buffers);
     }
 
-    if (ctx->stx_idx >= 0) {
-        SHMEM_MUTEX_LOCK(shmem_transport_ofi_lock);
-        if (shmem_transport_ofi_is_private(ctx->options)) {
-            shmem_transport_ofi_stx_kvs_t *e;
-            HASH_FIND(hh, shmem_transport_ofi_stx_kvs, &ctx->tid,
-                      sizeof(struct shmem_internal_tid), e);
-            if (e) {
-                shmem_transport_ofi_stx_t *stx = &shmem_transport_ofi_stx_pool[ctx->stx_idx];
-                stx->ref_cnt--;
-                if (stx->ref_cnt == 0) {
-                    HASH_DEL(shmem_transport_ofi_stx_kvs, e);
-                    free(e);
-                    shmem_transport_ofi_stx_pool[ctx->stx_idx].is_private = 0;
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        if (ctx->stx_idx[idx] >= 0) {
+            SHMEM_MUTEX_LOCK(shmem_transport_ofi_lock);
+            if (shmem_transport_ofi_is_private(ctx->options)) {
+                shmem_transport_ofi_stx_kvs_t *e;
+                HASH_FIND(hh, shmem_transport_ofi_stx_kvs, &ctx->tid,
+                        sizeof(struct shmem_internal_tid), e);
+                if (e) {
+                    shmem_transport_ofi_stx_t *stx = &shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]];
+                    stx->ref_cnt--;
+                    if (stx->ref_cnt == 0) {
+                        HASH_DEL(shmem_transport_ofi_stx_kvs, e);
+                        free(e);
+                        shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]].is_private = 0;
+                    }
+                }
+                else {
+                    RAISE_WARN_STR("Unable to locate private STX");
+                }
+            } else {
+                shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]].ref_cnt--;
+                if (shmem_transport_ofi_stx_pool[idx][ctx->stx_idx[idx]].is_private) {
+                    SHMEM_MUTEX_UNLOCK(shmem_transport_ofi_lock);
+                    RAISE_ERROR_STR("Destroyed a ctx with an inconsistent is_private field");
                 }
             }
-            else {
-                RAISE_WARN_STR("Unable to locate private STX");
-            }
-        } else {
-            shmem_transport_ofi_stx_pool[ctx->stx_idx].ref_cnt--;
-            if (shmem_transport_ofi_stx_pool[ctx->stx_idx].is_private) {
-                SHMEM_MUTEX_UNLOCK(shmem_transport_ofi_lock);
-                RAISE_ERROR_STR("Destroyed a ctx with an inconsistent is_private field");
-            }
+            SHMEM_MUTEX_UNLOCK(shmem_transport_ofi_lock);
         }
-        SHMEM_MUTEX_UNLOCK(shmem_transport_ofi_lock);
     }
 
-    if (ctx->put_cntr) {
-        ret = fi_close(&ctx->put_cntr->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
-    }
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        if (ctx->put_cntr && ctx->put_cntr[idx]) {
+            ret = fi_close(&ctx->put_cntr[idx]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
+        }
 
-    if (ctx->get_cntr) {
-        ret = fi_close(&ctx->get_cntr->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
-    }
+        if (ctx->get_cntr && ctx->get_cntr[idx]) {
+            ret = fi_close(&ctx->get_cntr[idx]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
+        }
 
-    if (ctx->cq) {
-        ret = fi_close(&ctx->cq->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
+        if (ctx->cq && ctx->cq[idx]) {
+            ret = fi_close(&ctx->cq[idx]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
+        }
     }
 
 #ifdef USE_CTX_LOCK
@@ -2161,13 +2257,15 @@ int shmem_transport_fini(void)
         RAISE_WARN_MSG("Key/value store contained %d unfreed private contexts\n", stx_len);
     }
 
-    for (long i = 0; i < shmem_transport_ofi_stx_max; ++i) {
-        if (shmem_transport_ofi_stx_pool[i].ref_cnt != 0)
-            RAISE_WARN_MSG("Closing a %s STX (%zu) with nonzero ref. count (%ld)\n",
-                           shmem_transport_ofi_stx_pool[i].is_private ? "private" : "shared",
-                           i, shmem_transport_ofi_stx_pool[i].ref_cnt);
-        ret = fi_close(&shmem_transport_ofi_stx_pool[i].stx->fid);
-        OFI_CHECK_ERROR_MSG(ret, "STX context close failed (%s)\n", fi_strerror(errno));
+    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        for (long i = 0; i < shmem_transport_ofi_stx_max; ++i) {
+            if (shmem_transport_ofi_stx_pool[idx][i].ref_cnt != 0)
+                RAISE_WARN_MSG("Closing a %s STX (%zu) with nonzero ref. count (%ld)\n",
+                            shmem_transport_ofi_stx_pool[idx][i].is_private ? "private" : "shared",
+                            i, shmem_transport_ofi_stx_pool[idx][i].ref_cnt);
+            ret = fi_close(&shmem_transport_ofi_stx_pool[idx][i].stx->fid);
+            OFI_CHECK_ERROR_MSG(ret, "STX context close failed (%s)\n", fi_strerror(errno));
+        }
     }
     if (shmem_transport_ofi_stx_pool) free(shmem_transport_ofi_stx_pool);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -2137,8 +2137,8 @@ int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options,
     ctxp->stx_idx = malloc(shmem_transport_ofi_num_nics * sizeof(int));
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
 #ifndef USE_CTX_LOCK
-        shmem_internal_cntr_write(&ctxp->pending_put_cntr, 0);
-        shmem_internal_cntr_write(&ctxp->pending_get_cntr, 0);
+        shmem_internal_cntr_write(&ctxp->pending_put_cntr[idx], 0);
+        shmem_internal_cntr_write(&ctxp->pending_get_cntr[idx], 0);
 #else
         ctxp->pending_put_cntr[idx] = 0;
         ctxp->pending_get_cntr[idx] = 0;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1790,8 +1790,6 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     struct fi_cq_attr cq_attr = {0};
     cq_attr.format = FI_CQ_FORMAT_CONTEXT;
 
-    struct fabric_info* info = &shmem_transport_ofi_info;
-
     // Need to do these steps for all providers in provider_list?
     //info->p_info->ep_attr->tx_ctx_cnt = shmem_transport_ofi_stx_max > 0 ? FI_SHARED_CONTEXT : 0;
     //info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_RECV;
@@ -2180,7 +2178,6 @@ int shmem_transport_ctx_create(struct shmem_internal_team_t *team, long options,
 void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
 {
     int ret;
-    bool close_default_ctx = false;
 
     if (ctx == NULL)
         return;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -2373,10 +2373,10 @@ int shmem_transport_fini(void)
 
     /* If single-endpoint mode, need to close the default context's put and get counters */
     if (shmem_transport_ofi_single_ep) {
-        ret = fi_close(&shmem_transport_ctx_default.put_cntr->fid);
+        ret = fi_close(&shmem_transport_ctx_default.put_cntr[0]->fid);
         OFI_CHECK_ERROR_MSG(ret, "Default EP put CNTR close failed (%s)\n", fi_strerror(errno));
 
-        ret = fi_close(&shmem_transport_ctx_default.get_cntr->fid);
+        ret = fi_close(&shmem_transport_ctx_default.get_cntr[0]->fid);
         OFI_CHECK_ERROR_MSG(ret, "Default EP get CNTR close failed (%s)\n", fi_strerror(errno));
     }
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1801,12 +1801,12 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     //info->p_info->rx_attr->caps = FI_RECV; /* to drive progress on the CQ */;
 
     ctx->id = id;
-    ctx->fabric = (struct fid_fabric **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_fabric *));
-    ctx->domain = (struct fid_domain **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_domain *));
-    ctx->av = (struct fid_av **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_av *));
-    ctx->ep = (struct fid_ep **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_ep *));
-    ctx->put_cntr = (struct fid_cntr **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cntr *));
-    ctx->get_cntr = (struct fid_cntr **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cntr *));
+    ctx->fabric = (struct fid_fabric **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_fabric *));
+    ctx->domain = (struct fid_domain **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_domain *));
+    ctx->av = (struct fid_av **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_av *));
+    ctx->ep = (struct fid_ep **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_ep *));
+    ctx->put_cntr = (struct fid_cntr **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_cntr *));
+    ctx->get_cntr = (struct fid_cntr **) calloc(shmem_transport_ofi_num_nics, sizeof(struct fid_cntr *));
 #ifdef USE_CTX_LOCK
     ctx->pending_put_cntr = (uint64_t *) malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
     ctx->pending_get_cntr = (uint64_t *) malloc(shmem_transport_ofi_num_nics * sizeof(uint64_t));
@@ -2211,6 +2211,7 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
         if (ctx->ep[idx]) {
             ret = fi_close(&ctx->ep[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context endpoint close failed (%s)\n", fi_strerror(errno));
+            ctx->ep[idx] = NULL;
         }
     }
 
@@ -2252,31 +2253,37 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
         if (ctx->put_cntr && ctx->put_cntr[idx]) {
             ret = fi_close(&ctx->put_cntr[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
+            ctx->put_cntr[idx] = NULL;
         }
 
         if (ctx->get_cntr && ctx->get_cntr[idx]) {
             ret = fi_close(&ctx->get_cntr[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
+            ctx->get_cntr[idx] = NULL;
         }
 
         if (ctx->cq && ctx->cq[idx]) {
             ret = fi_close(&ctx->cq[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
+            ctx->cq[idx] = NULL;
         }
 
         if (ctx->av && ctx->av[idx]) {
             ret = fi_close(&ctx->av[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context AV close failed (%s)\n", fi_strerror(errno));
+            ctx->av[idx] = NULL;
         }
 
         if (ctx->domain && ctx->domain[idx]) {
             ret = fi_close(&ctx->domain[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context domain close failed (%s)\n", fi_strerror(errno));
+            ctx->domain[idx] = NULL;
         }
 
         if (ctx->fabric && ctx->fabric[idx]) {
             ret = fi_close(&ctx->fabric[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context fabric close failed (%s)\n", fi_strerror(errno));
+            ctx->fabric[idx] = NULL;
         }
     }
 
@@ -2367,15 +2374,6 @@ int shmem_transport_fini(void)
 
     ret = fi_close(&shmem_transport_ofi_target_ep->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target endpoint close failed (%s)\n", fi_strerror(errno));
-
-    /* If single-endpoint mode, need to close the default context's put and get counters */
-    if (shmem_transport_ofi_single_ep) {
-        ret = fi_close(&shmem_transport_ctx_default.put_cntr[0]->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Default EP put CNTR close failed (%s)\n", fi_strerror(errno));
-
-        ret = fi_close(&shmem_transport_ctx_default.get_cntr[0]->fid);
-        OFI_CHECK_ERROR_MSG(ret, "Default EP get CNTR close failed (%s)\n", fi_strerror(errno));
-    }
 
     ret = fi_close(&shmem_transport_ofi_target_cq->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target CQ close failed (%s)\n", fi_strerror(errno));

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1385,7 +1385,7 @@ int allocate_fabric_resources(struct fabric_info *info)
  * (socket or NUMA node) with that CPU set. The filtered "close" NIC list is
  * stored in the global provider_list and shmem_transport_ofi_num_nics is updated
  * to reflect how many close NICs were found. One provider is returned for the
- * calling PE using round-robin assignment (my_pe % num_close_nics).
+ * calling PE using round-robin assignment (local_rank % num_close_nics).
  *
  * On any hwloc lookup failure, or if no topologically close NICs are found,
  * the function falls back to the full unfiltered provider list and selects
@@ -1394,6 +1394,9 @@ int allocate_fabric_resources(struct fabric_info *info)
 static inline
 struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **provs, size_t num_nics) {
     int ret = 0;
+    /* Use intra-node rank for NIC assignment so PEs on different nodes with
+     * the same global PE number don't all land on the same NIC. */
+    int local_rank = shmem_runtime_get_node_rank(shmem_internal_my_pe);
     hwloc_bitmap_t bindset = hwloc_bitmap_alloc();
 
     /* Query the CPU set where this process last ran. */
@@ -1401,7 +1404,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     if (ret < 0) {
         /* Fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("hwloc_get_proc_last_cpu_location failed (%s)\n", strerror(errno));
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
         /* TX load balancing: expose all NICs for per-op random selection. */
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         if (!provider_list)
@@ -1411,13 +1414,13 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         }
         shmem_transport_ofi_num_nics = num_nics;
         hwloc_bitmap_free(bindset);
-        return provs[shmem_internal_my_pe % num_nics];
+        return provs[local_rank % num_nics];
 #else
         /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
         provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
         if (!provider_list)
             RAISE_ERROR_MSG("malloc failed for provider_list\n");
-        provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+        provider_list[0] = provs[local_rank % num_nics];
         shmem_transport_ofi_num_nics = 1;
         hwloc_bitmap_free(bindset);
         return provider_list[0];
@@ -1443,7 +1446,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         if (!io_device) {
             /* Fall back to all NICs if topology lookup fails. */
             RAISE_WARN_MSG("hwloc_get_pcidev_by_busid failed\n");
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             if (!provider_list)
                 RAISE_ERROR_MSG("malloc failed for provider_list\n");
@@ -1452,12 +1455,12 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             }
             shmem_transport_ofi_num_nics = num_nics;
             hwloc_bitmap_free(bindset);
-            return provs[shmem_internal_my_pe % num_nics];
+            return provs[local_rank % num_nics];
 #else
             provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
             if (!provider_list)
                 RAISE_ERROR_MSG("malloc failed for provider_list\n");
-            provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+            provider_list[0] = provs[local_rank % num_nics];
             shmem_transport_ofi_num_nics = 1;
             hwloc_bitmap_free(bindset);
             return provider_list[0];
@@ -1468,7 +1471,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         if (!first_non_io) {
             /* Fall back to all NICs if ancestor lookup fails. */
             RAISE_WARN_MSG("hwloc_get_non_io_ancestor_obj failed\n");
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             if (!provider_list)
                 RAISE_ERROR_MSG("malloc failed for provider_list\n");
@@ -1477,12 +1480,12 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             }
             shmem_transport_ofi_num_nics = num_nics;
             hwloc_bitmap_free(bindset);
-            return provs[shmem_internal_my_pe % num_nics];
+            return provs[local_rank % num_nics];
 #else
             provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
             if (!provider_list)
                 RAISE_ERROR_MSG("malloc failed for provider_list\n");
-            provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+            provider_list[0] = provs[local_rank % num_nics];
             shmem_transport_ofi_num_nics = 1;
             hwloc_bitmap_free(bindset);
             return provider_list[0];
@@ -1498,7 +1501,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
                  * corrupt list (wrong num_close_nics, NULL last_added, etc.). */
                 RAISE_WARN_MSG("fi_dupinfo failed for NIC %zu; falling back to all NICs\n", i);
                 hwloc_bitmap_free(bindset);
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
                 provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
                 if (!provider_list)
                     RAISE_ERROR_MSG("malloc failed for provider_list\n");
@@ -1506,12 +1509,12 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
                     provider_list[idx] = provs[idx];
                 }
                 shmem_transport_ofi_num_nics = num_nics;
-                return provs[shmem_internal_my_pe % num_nics];
+                return provs[local_rank % num_nics];
 #else
                 provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
                 if (!provider_list)
                     RAISE_ERROR_MSG("malloc failed for provider_list\n");
-                provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+                provider_list[0] = provs[local_rank % num_nics];
                 shmem_transport_ofi_num_nics = 1;
                 return provider_list[0];
 #endif
@@ -1527,7 +1530,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     if (!close_provs) {
         /* No topologically close NICs found; fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("Could not detect any NICs with affinity to the process\n");
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         if (!provider_list)
             RAISE_ERROR_MSG("malloc failed for provider_list\n");
@@ -1536,13 +1539,13 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         }
         shmem_transport_ofi_num_nics = num_nics;
         hwloc_bitmap_free(bindset);
-        return provs[shmem_internal_my_pe % num_nics];
+        return provs[local_rank % num_nics];
 #else
         /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
         provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
         if (!provider_list)
             RAISE_ERROR_MSG("malloc failed for provider_list\n");
-        provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+        provider_list[0] = provs[local_rank % num_nics];
         shmem_transport_ofi_num_nics = 1;
         hwloc_bitmap_free(bindset);
         return provider_list[0];
@@ -1552,7 +1555,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     last_added->next = NULL;
 
     /* Build provider_list from the filtered close-NIC set. */
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
     /* TX load balancing: expose all close NICs for per-op random selection. */
     int idx = 0;
     provider_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
@@ -1566,14 +1569,14 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     hwloc_bitmap_free(bindset);
 
     /* Assign this PE a NIC from the close set using round-robin. */
-    struct fi_info *provider = provider_list[shmem_internal_my_pe % num_close_nics];
+    struct fi_info *provider = provider_list[local_rank % num_close_nics];
     //free(prov_list);
 
     shmem_transport_ofi_num_nics = num_close_nics;
     return provider;
 #else
     /* Base multi-rail: assign this PE exactly one close NIC via round-robin. */
-    size_t pe_nic_idx = shmem_internal_my_pe % num_close_nics;
+    size_t pe_nic_idx = local_rank % num_close_nics;
     struct fi_info *assigned = close_provs;
     for (size_t i = 0; i < pe_nic_idx; i++) {
         assigned = assigned->next;
@@ -1778,17 +1781,16 @@ int query_for_fabric(struct fabric_info *info)
 #ifdef USE_HWLOC
             info->p_info = assign_nic_with_hwloc(info->p_info, sorted_prov_list, num_nics);
 #else
-            /* Round-robin assignment of NICs to PEs
-             * FIXME: A more suitable indexing value would be
-             * shmem_team_my_pe(SHMEM_TEAM_NODE) % num_nics, but it is too early in initialization to
-             * do that here. We would also want to replace the similar occurrences in the
-             * assign_nic_with_hwloc function. */
-            provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
-            for (size_t idx = 0; idx < num_nics; idx++) {
-                provider_list[idx] = sorted_prov_list[idx];
-            }
-            info->p_info = provider_list[shmem_internal_my_pe % num_nics];
-            shmem_transport_ofi_num_nics = num_nics;
+            /* No hwloc: round-robin assignment using intra-node rank so PEs
+             * on different nodes with the same global index don't collide.
+             * TX load balancing requires hwloc and cannot reach this path. */
+            int local_rank = shmem_runtime_get_node_rank(shmem_internal_my_pe);
+            provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            if (!provider_list)
+                RAISE_ERROR_MSG("malloc failed for provider_list\n");
+            provider_list[0] = sorted_prov_list[local_rank % num_nics];
+            info->p_info = provider_list[0];
+            shmem_transport_ofi_num_nics = 1;
 #endif
             //free(prov_list); //Add free(provider_list) to cleanup
         }
@@ -2004,6 +2006,9 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         ret = fi_fabric(provider_list[idx]->fabric_attr, &ctx->fabric[idx], NULL);
         OFI_CHECK_RETURN_STR(ret, "fabric initialization failed");
 
+        DEBUG_MSG("ctx[%d] NIC[%zu]: domain=%s\n",
+                  id, idx, provider_list[idx]->domain_attr->name);
+
         ret = fi_domain(/*shmem_transport_ofi_fabfd*/ ctx->fabric[idx], provider_list[idx],
                         &ctx->domain[idx], NULL);
         OFI_CHECK_RETURN_STR(ret, "domain initialization failed");
@@ -2197,9 +2202,10 @@ int shmem_transport_startup(void)
     int ret;
     int i;
 
-#ifdef USE_OFI_TX_LOAD_BALANCING
+#if defined(USE_OFI_TX_LOAD_BALANCING_ROUND_ROBIN) || defined(USE_OFI_TX_LOAD_BALANCING_RANDOM)
     /* Stagger each PE's round-robin start position so they don't all begin on
-     * NIC 0.  num_nics is finalized by this point. */
+     * NIC 0.  num_nics is finalized by this point. randr_init() runs after
+     * this and skips the reset when TX LB is active. */
     shmem_internal_nic_rr_idx = shmem_internal_my_pe % shmem_transport_ofi_num_nics;
 #endif
     shmem_transport_ofi_stx_pool = (shmem_transport_ofi_stx_t **) malloc(shmem_transport_ofi_num_nics *

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -631,8 +631,7 @@ int bind_enable_ep_resources(shmem_transport_ctx_t *ctx, size_t idx)
      * removed below.  However, there aren't currently any cases where removing
      * FI_RECV significantly improves performance or resource usage.  */
 
-    ret = fi_ep_bind(ctx->ep[idx], &ctx->cq[idx]->fid,
-                     FI_SELECTIVE_COMPLETION | FI_TRANSMIT | FI_RECV);
+    ret = fi_ep_bind(ctx->ep[idx], &ctx->cq[idx]->fid, FI_SELECTIVE_COMPLETION | FI_TRANSMIT | FI_RECV);
     OFI_CHECK_RETURN_STR(ret, "fi_ep_bind CQ to endpoint failed");
 
     ret = fi_ep_bind(ctx->ep[idx], /*&shmem_transport_ofi_avfd->fid*/ &ctx->av[idx]->fid, 0); /* Currently failing */
@@ -1301,16 +1300,21 @@ int populate_av(void)
         return ret;
     }
 
-    for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
-        ret = fi_av_insert(shmem_transport_ctx_default.av[idx],
-                           alladdrs,
-                           shmem_internal_num_pes,
-                           addr_table,
-                           0,
-                           NULL);
-        if (ret != shmem_internal_num_pes) {
-            RAISE_WARN_STR("av insert failed");
-            return ret;
+    /* In single-ep mode, ctx_default.av[] is never created (the global
+     * shmem_transport_ofi_avfd AV is used instead, already inserted above).
+     * Only insert into per-NIC AVs when running in multi-NIC mode. */
+    if (!shmem_transport_ofi_single_ep) {
+        for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+            ret = fi_av_insert(shmem_transport_ctx_default.av[idx],
+                               alladdrs,
+                               shmem_internal_num_pes,
+                               addr_table,
+                               0,
+                               NULL);
+            if (ret != shmem_internal_num_pes) {
+                RAISE_WARN_STR("av insert failed");
+                return ret;
+            }
         }
     }
 
@@ -1394,12 +1398,21 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     if (ret < 0) {
         /* Fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("hwloc_get_proc_last_cpu_location failed (%s)\n", strerror(errno));
+#ifdef USE_OFI_TX_LOAD_BALANCING
+        /* TX load balancing: expose all NICs for per-op random selection. */
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         for (size_t idx = 0; idx < num_nics; idx++) {
             provider_list[idx] = provs[idx];
         }
         shmem_transport_ofi_num_nics = num_nics;
         return provs[shmem_internal_my_pe % num_nics];
+#else
+        /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
+        provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+        provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+        shmem_transport_ofi_num_nics = 1;
+        return provider_list[0];
+#endif
     }
 
     /* Walk each candidate provider and keep only those whose PCI NIC shares a
@@ -1420,30 +1433,63 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         if (!io_device) {
             /* Fall back to all NICs if topology lookup fails. */
             RAISE_WARN_MSG("hwloc_get_pcidev_by_busid failed\n");
+#ifdef USE_OFI_TX_LOAD_BALANCING
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             for (size_t idx = 0; idx < num_nics; idx++) {
                 provider_list[idx] = provs[idx];
             }
             shmem_transport_ofi_num_nics = num_nics;
             return provs[shmem_internal_my_pe % num_nics];
+#else
+            provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+            shmem_transport_ofi_num_nics = 1;
+            return provider_list[0];
+#endif
         };
         /* Walk up the topology tree to find the first non-I/O ancestor (e.g., NUMA node). */
         hwloc_obj_t first_non_io = hwloc_get_non_io_ancestor_obj(shmem_internal_topology, io_device);
         if (!first_non_io) {
             /* Fall back to all NICs if ancestor lookup fails. */
             RAISE_WARN_MSG("hwloc_get_non_io_ancestor_obj failed\n");
+#ifdef USE_OFI_TX_LOAD_BALANCING
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             for (size_t idx = 0; idx < num_nics; idx++) {
                 provider_list[idx] = provs[idx];
             }
             shmem_transport_ofi_num_nics = num_nics;
             return provs[shmem_internal_my_pe % num_nics];
+#else
+            provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+            shmem_transport_ofi_num_nics = 1;
+            return provider_list[0];
+#endif
         }
 
         /* NIC is "close" if the process CPU set and the NIC's ancestor CPU set overlap. */
         if (hwloc_bitmap_isincluded(bindset, first_non_io->cpuset) ||
             hwloc_bitmap_isincluded(first_non_io->cpuset, bindset)) {
             struct fi_info *dup = fi_dupinfo(cur_prov);
+            if (!dup) {
+                /* fi_dupinfo failure: fall back to all NICs rather than risk a
+                 * corrupt list (wrong num_close_nics, NULL last_added, etc.). */
+                RAISE_WARN_MSG("fi_dupinfo failed for NIC %zu; falling back to all NICs\n", i);
+                hwloc_bitmap_free(bindset);
+#ifdef USE_OFI_TX_LOAD_BALANCING
+                provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+                for (size_t idx = 0; idx < num_nics; idx++) {
+                    provider_list[idx] = provs[idx];
+                }
+                shmem_transport_ofi_num_nics = num_nics;
+                return provs[shmem_internal_my_pe % num_nics];
+#else
+                provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+                provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+                shmem_transport_ofi_num_nics = 1;
+                return provider_list[0];
+#endif
+            }
             if (!close_provs) close_provs = dup;
             if (last_added) last_added->next = dup;
             last_added = dup;
@@ -1455,19 +1501,27 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     if (!close_provs) {
         /* No topologically close NICs found; fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("Could not detect any NICs with affinity to the process\n");
+#ifdef USE_OFI_TX_LOAD_BALANCING
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         for (size_t idx = 0; idx < num_nics; idx++) {
             provider_list[idx] = provs[idx];
         }
         shmem_transport_ofi_num_nics = num_nics;
-
-        /* If no 'close' NICs, select from list of all NICs using round-robin assignment */
         return provs[shmem_internal_my_pe % num_nics];
+#else
+        /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
+        provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+        provider_list[0] = provs[shmem_internal_my_pe % num_nics];
+        shmem_transport_ofi_num_nics = 1;
+        return provider_list[0];
+#endif
     }
 
     last_added->next = NULL;
 
     /* Build provider_list from the filtered close-NIC set. */
+#ifdef USE_OFI_TX_LOAD_BALANCING
+    /* TX load balancing: expose all close NICs for per-op random selection. */
     int idx = 0;
     provider_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
     for (struct fi_info *cur_fabric = close_provs; cur_fabric; cur_fabric = cur_fabric->next) {
@@ -1482,6 +1536,21 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
 
     shmem_transport_ofi_num_nics = num_close_nics;
     return provider;
+#else
+    /* Base multi-rail: assign this PE exactly one close NIC via round-robin. */
+    size_t pe_nic_idx = shmem_internal_my_pe % num_close_nics;
+    struct fi_info *assigned = close_provs;
+    for (size_t i = 0; i < pe_nic_idx; i++) {
+        assigned = assigned->next;
+    }
+    provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+    provider_list[0] = assigned;
+
+    hwloc_bitmap_free(bindset);
+
+    shmem_transport_ofi_num_nics = 1;
+    return provider_list[0];
+#endif
 }
 #endif
 
@@ -1862,6 +1931,10 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     SHMEM_MUTEX_INIT(ctx->lock);
 #endif
 
+		// bman
+		//if (shmem_internal_my_pe == 0) printf("\n\nshmem_transport_ofi_single_ep = %d \n\n", shmem_transport_ofi_single_ep);  // R: 0
+		// /bman
+
         /* In single-endpoint mode, the default context shares target_ep/target_cq.
          * Open counters on the global domain and bind them directly to target_ep. */
         if (shmem_transport_ofi_single_ep && id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0) {
@@ -2132,7 +2205,7 @@ int shmem_transport_startup(void)
         if (shmem_transport_ofi_stx_max > 0) {
             shmem_transport_ofi_stx_pool[idx] = malloc(shmem_transport_ofi_stx_max *
                                                 sizeof(shmem_transport_ofi_stx_t));
-            if (shmem_transport_ofi_stx_pool == NULL) {
+            if (shmem_transport_ofi_stx_pool[idx] == NULL) {
                 RAISE_ERROR_STR("Out of memory when allocating OFI STX pool");
             }
         }
@@ -2317,13 +2390,19 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
-        if (ctx->put_cntr && ctx->put_cntr[idx]) {
+        /* In single-ep mode, put_cntr[0]/get_cntr[0] of the default context are
+         * bound to target_ep, which must be closed first in shmem_transport_fini().
+         * Close them there, not here. */
+        bool skip_shared_cntrs = (shmem_transport_ofi_single_ep &&
+                                  ctx->id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0);
+
+        if (ctx->put_cntr && ctx->put_cntr[idx] && !skip_shared_cntrs) {
             ret = fi_close(&ctx->put_cntr[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context put CNTR close failed (%s)\n", fi_strerror(errno));
             ctx->put_cntr[idx] = NULL;
         }
 
-        if (ctx->get_cntr && ctx->get_cntr[idx]) {
+        if (ctx->get_cntr && ctx->get_cntr[idx] && !skip_shared_cntrs) {
             ret = fi_close(&ctx->get_cntr[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context get CNTR close failed (%s)\n", fi_strerror(errno));
             ctx->get_cntr[idx] = NULL;
@@ -2446,6 +2525,21 @@ int shmem_transport_fini(void)
 
     ret = fi_close(&shmem_transport_ofi_target_ep->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target endpoint close failed (%s)\n", fi_strerror(errno));
+
+    /* In single-ep mode, ctx_default's put/get cntrs were bound to target_ep.
+     * Now that target_ep is closed, we can safely close them. */
+    if (shmem_transport_ofi_single_ep) {
+        if (shmem_transport_ctx_default.put_cntr && shmem_transport_ctx_default.put_cntr[0]) {
+            ret = fi_close(&shmem_transport_ctx_default.put_cntr[0]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Default ctx put CNTR close failed (%s)\n", fi_strerror(errno));
+            shmem_transport_ctx_default.put_cntr[0] = NULL;
+        }
+        if (shmem_transport_ctx_default.get_cntr && shmem_transport_ctx_default.get_cntr[0]) {
+            ret = fi_close(&shmem_transport_ctx_default.get_cntr[0]->fid);
+            OFI_CHECK_ERROR_MSG(ret, "Default ctx get CNTR close failed (%s)\n", fi_strerror(errno));
+            shmem_transport_ctx_default.get_cntr[0] = NULL;
+        }
+    }
 
     ret = fi_close(&shmem_transport_ofi_target_cq->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target CQ close failed (%s)\n", fi_strerror(errno));

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1834,6 +1834,30 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 #ifdef USE_CTX_LOCK
     SHMEM_MUTEX_INIT(ctx->lock);
 #endif
+
+        /* In single-endpoint mode, the default context shares target_ep/target_cq.
+         * Open counters on the global domain and bind them directly to target_ep. */
+        if (shmem_transport_ofi_single_ep && id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0) {
+            ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_put_attr,
+                               &ctx->put_cntr[0], NULL);
+            OFI_CHECK_RETURN_MSG(ret, "put_cntr creation failed (%s)\n", fi_strerror(errno));
+
+            ret = fi_cntr_open(shmem_transport_ofi_domainfd, &cntr_get_attr,
+                               &ctx->get_cntr[0], NULL);
+            OFI_CHECK_RETURN_MSG(ret, "get_cntr creation failed (%s)\n", fi_strerror(errno));
+
+            ret = fi_ep_bind(shmem_transport_ofi_target_ep, &ctx->put_cntr[0]->fid, FI_WRITE);
+            OFI_CHECK_RETURN_STR(ret, "fi_ep_bind put CNTR to target endpoint failed");
+
+            ret = fi_ep_bind(shmem_transport_ofi_target_ep, &ctx->get_cntr[0]->fid, FI_READ);
+            OFI_CHECK_RETURN_STR(ret, "fi_ep_bind get CNTR to target endpoint failed");
+
+            ctx->ep[0] = shmem_transport_ofi_target_ep;
+            ctx->cq[0] = shmem_transport_ofi_target_cq;
+            /* fabric/domain/av/stx are not needed; resources owned by global init */
+            continue;
+        }
+
         ret = fi_fabric(provider_list[idx]->fabric_attr, &ctx->fabric[idx], NULL);
         OFI_CHECK_RETURN_STR(ret, "fabric initialization failed");
 
@@ -1880,6 +1904,11 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
             ctx->tid = shmem_transport_ofi_gettid();
     }
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
+        /* In single-ep mode, target_ep for the default context is already bound
+         * and enabled by shmem_transport_ofi_target_ep_init(); skip it here. */
+        if (shmem_transport_ofi_single_ep && id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0)
+            continue;
+
         shmem_transport_ofi_stx_allocate(ctx, idx);
 
         ret = bind_enable_ep_resources(ctx, idx);
@@ -1957,6 +1986,13 @@ int shmem_transport_init(void)
 
     ret = allocate_fabric_resources(&shmem_transport_ofi_info);
     if (ret != 0) return ret;
+
+    /* Single-endpoint mode is incompatible with TxMuxing (multiple NICs).
+     * Disable it automatically when multiple NICs are in use. */
+    if (shmem_transport_ofi_single_ep && shmem_transport_ofi_num_nics > 1) {
+        DEBUG_STR("Disabling single-endpoint mode: multiple NICs (TxMuxing) in use");
+        shmem_transport_ofi_single_ep = 0;
+    }
 
     /* STX sharing settings */
     char *type = shmem_internal_params.OFI_STX_ALLOCATOR;
@@ -2208,7 +2244,11 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
     }
 
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
-        if (ctx->ep[idx]) {
+        /* In single-ep mode, ep[0]/cq[0] of the default context are shared with
+         * target_ep/target_cq, which are closed later in shmem_transport_fini(). */
+        bool skip_shared = (shmem_transport_ofi_single_ep &&
+                            ctx->id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0);
+        if (ctx->ep[idx] && !skip_shared) {
             ret = fi_close(&ctx->ep[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context endpoint close failed (%s)\n", fi_strerror(errno));
             ctx->ep[idx] = NULL;
@@ -2262,7 +2302,12 @@ void shmem_transport_ctx_destroy(shmem_transport_ctx_t *ctx)
             ctx->get_cntr[idx] = NULL;
         }
 
-        if (ctx->cq && ctx->cq[idx]) {
+        /* In single-ep mode, cq[0] of the default context is shared with
+         * target_cq, which is closed later in shmem_transport_fini(). */
+        bool skip_shared = (shmem_transport_ofi_single_ep &&
+                            ctx->id == SHMEM_TRANSPORT_CTX_DEFAULT_ID && idx == 0);
+
+        if (ctx->cq && ctx->cq[idx] && !skip_shared) {
             ret = fi_close(&ctx->cq[idx]->fid);
             OFI_CHECK_ERROR_MSG(ret, "Context CQ close failed (%s)\n", fi_strerror(errno));
             ctx->cq[idx] = NULL;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -2154,6 +2154,11 @@ int shmem_transport_startup(void)
     int ret;
     int i;
 
+#ifdef USE_OFI_TX_LOAD_BALANCING
+    /* Stagger each PE's round-robin start position so they don't all begin on
+     * NIC 0.  num_nics is finalized by this point. */
+    shmem_internal_nic_rr_idx = shmem_internal_my_pe % shmem_transport_ofi_num_nics;
+#endif
     shmem_transport_ofi_stx_pool = (shmem_transport_ofi_stx_t **) malloc(shmem_transport_ofi_num_nics *
                                         sizeof(shmem_transport_ofi_stx_t *));
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1371,13 +1371,28 @@ int allocate_fabric_resources(struct fabric_info *info)
 }
 
 #ifdef USE_HWLOC
+/* Selects the best OFI provider for this PE based on CPU/NIC locality using hwloc.
+ *
+ * Queries where the current process last ran (CPU set), then walks the candidate
+ * provider list and keeps only NICs whose PCI device shares a topology ancestor
+ * (socket or NUMA node) with that CPU set. The filtered "close" NIC list is
+ * stored in the global provider_list and shmem_transport_ofi_num_nics is updated
+ * to reflect how many close NICs were found. One provider is returned for the
+ * calling PE using round-robin assignment (my_pe % num_close_nics).
+ *
+ * On any hwloc lookup failure, or if no topologically close NICs are found,
+ * the function falls back to the full unfiltered provider list and selects
+ * round-robin from all available NICs.
+ */
 static inline
 struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **provs, size_t num_nics) {
     int ret = 0;
     hwloc_bitmap_t bindset = hwloc_bitmap_alloc();
 
+    /* Query the CPU set where this process last ran. */
     ret = hwloc_get_proc_last_cpu_location(shmem_internal_topology, getpid(), bindset, HWLOC_CPUBIND_PROCESS);
     if (ret < 0) {
+        /* Fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("hwloc_get_proc_last_cpu_location failed (%s)\n", strerror(errno));
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         for (size_t idx = 0; idx < num_nics; idx++) {
@@ -1387,17 +1402,23 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         return provs[shmem_internal_my_pe % num_nics];
     }
 
-    // Identify which provider entries correspond to NICs with an affinity to the calling process
+    /* Walk each candidate provider and keep only those whose PCI NIC shares a
+     * topology ancestor with the process CPU set (i.e., same socket/NUMA node). */
     struct fi_info *close_provs = NULL;
     struct fi_info *last_added = NULL;
     size_t num_close_nics = 0;
-    for (size_t i = 0; i < num_nics; i++) {
+    for (size_t i = 0; i < num_nics; i++) 
+	{
         struct fi_info *cur_prov = provs[i];
-        if (cur_prov->nic->bus_attr->bus_type != FI_BUS_PCI) continue;
+        if (cur_prov->nic->bus_attr->bus_type != FI_BUS_PCI) {
+			continue;
+		}
 
+        /* Look up the hwloc PCI device object by its bus address. */
         struct fi_pci_attr pci = cur_prov->nic->bus_attr->attr.pci;
         hwloc_obj_t io_device = hwloc_get_pcidev_by_busid(shmem_internal_topology, pci.domain_id, pci.bus_id, pci.device_id, pci.function_id);
         if (!io_device) {
+            /* Fall back to all NICs if topology lookup fails. */
             RAISE_WARN_MSG("hwloc_get_pcidev_by_busid failed\n");
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             for (size_t idx = 0; idx < num_nics; idx++) {
@@ -1406,8 +1427,10 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             shmem_transport_ofi_num_nics = num_nics;
             return provs[shmem_internal_my_pe % num_nics];
         };
+        /* Walk up the topology tree to find the first non-I/O ancestor (e.g., NUMA node). */
         hwloc_obj_t first_non_io = hwloc_get_non_io_ancestor_obj(shmem_internal_topology, io_device);
         if (!first_non_io) {
+            /* Fall back to all NICs if ancestor lookup fails. */
             RAISE_WARN_MSG("hwloc_get_non_io_ancestor_obj failed\n");
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
             for (size_t idx = 0; idx < num_nics; idx++) {
@@ -1417,6 +1440,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             return provs[shmem_internal_my_pe % num_nics];
         }
 
+        /* NIC is "close" if the process CPU set and the NIC's ancestor CPU set overlap. */
         if (hwloc_bitmap_isincluded(bindset, first_non_io->cpuset) ||
             hwloc_bitmap_isincluded(first_non_io->cpuset, bindset)) {
             struct fi_info *dup = fi_dupinfo(cur_prov);
@@ -1429,6 +1453,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     DEBUG_MSG("Num. NICs w/ affinity to process: %zu\n", num_close_nics);
 
     if (!close_provs) {
+        /* No topologically close NICs found; fall back to all NICs, round-robin by PE. */
         RAISE_WARN_MSG("Could not detect any NICs with affinity to the process\n");
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
         for (size_t idx = 0; idx < num_nics; idx++) {
@@ -1442,6 +1467,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
 
     last_added->next = NULL;
 
+    /* Build provider_list from the filtered close-NIC set. */
     int idx = 0;
     provider_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
     for (struct fi_info *cur_fabric = close_provs; cur_fabric; cur_fabric = cur_fabric->next) {
@@ -1450,6 +1476,7 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
 
     hwloc_bitmap_free(bindset);
 
+    /* Assign this PE a NIC from the close set using round-robin. */
     struct fi_info *provider = provider_list[shmem_internal_my_pe % num_close_nics];
     //free(prov_list);
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -54,6 +54,9 @@
 
 struct fi_info **provider_list = NULL;
 size_t shmem_transport_ofi_num_nics = 0;
+/* Head of the fi_dupinfo'd close-NIC chain; freed at shutdown. NULL when
+ * provider_list was built from raw provs[] pointers (fallback paths). */
+static struct fi_info *shmem_transport_ofi_close_provs = NULL;
 
 struct fabric_info {
     struct fi_info *fabrics;
@@ -1401,16 +1404,22 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
 #ifdef USE_OFI_TX_LOAD_BALANCING
         /* TX load balancing: expose all NICs for per-op random selection. */
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+        if (!provider_list)
+            RAISE_ERROR_MSG("malloc failed for provider_list\n");
         for (size_t idx = 0; idx < num_nics; idx++) {
             provider_list[idx] = provs[idx];
         }
         shmem_transport_ofi_num_nics = num_nics;
+        hwloc_bitmap_free(bindset);
         return provs[shmem_internal_my_pe % num_nics];
 #else
         /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
         provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+        if (!provider_list)
+            RAISE_ERROR_MSG("malloc failed for provider_list\n");
         provider_list[0] = provs[shmem_internal_my_pe % num_nics];
         shmem_transport_ofi_num_nics = 1;
+        hwloc_bitmap_free(bindset);
         return provider_list[0];
 #endif
     }
@@ -1423,7 +1432,8 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     for (size_t i = 0; i < num_nics; i++) 
 	{
         struct fi_info *cur_prov = provs[i];
-        if (cur_prov->nic->bus_attr->bus_type != FI_BUS_PCI) {
+        if (!cur_prov->nic || !cur_prov->nic->bus_attr ||
+            cur_prov->nic->bus_attr->bus_type != FI_BUS_PCI) {
 			continue;
 		}
 
@@ -1435,15 +1445,21 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             RAISE_WARN_MSG("hwloc_get_pcidev_by_busid failed\n");
 #ifdef USE_OFI_TX_LOAD_BALANCING
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            if (!provider_list)
+                RAISE_ERROR_MSG("malloc failed for provider_list\n");
             for (size_t idx = 0; idx < num_nics; idx++) {
                 provider_list[idx] = provs[idx];
             }
             shmem_transport_ofi_num_nics = num_nics;
+            hwloc_bitmap_free(bindset);
             return provs[shmem_internal_my_pe % num_nics];
 #else
             provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            if (!provider_list)
+                RAISE_ERROR_MSG("malloc failed for provider_list\n");
             provider_list[0] = provs[shmem_internal_my_pe % num_nics];
             shmem_transport_ofi_num_nics = 1;
+            hwloc_bitmap_free(bindset);
             return provider_list[0];
 #endif
         };
@@ -1454,15 +1470,21 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
             RAISE_WARN_MSG("hwloc_get_non_io_ancestor_obj failed\n");
 #ifdef USE_OFI_TX_LOAD_BALANCING
             provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+            if (!provider_list)
+                RAISE_ERROR_MSG("malloc failed for provider_list\n");
             for (size_t idx = 0; idx < num_nics; idx++) {
                 provider_list[idx] = provs[idx];
             }
             shmem_transport_ofi_num_nics = num_nics;
+            hwloc_bitmap_free(bindset);
             return provs[shmem_internal_my_pe % num_nics];
 #else
             provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+            if (!provider_list)
+                RAISE_ERROR_MSG("malloc failed for provider_list\n");
             provider_list[0] = provs[shmem_internal_my_pe % num_nics];
             shmem_transport_ofi_num_nics = 1;
+            hwloc_bitmap_free(bindset);
             return provider_list[0];
 #endif
         }
@@ -1478,6 +1500,8 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
                 hwloc_bitmap_free(bindset);
 #ifdef USE_OFI_TX_LOAD_BALANCING
                 provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+                if (!provider_list)
+                    RAISE_ERROR_MSG("malloc failed for provider_list\n");
                 for (size_t idx = 0; idx < num_nics; idx++) {
                     provider_list[idx] = provs[idx];
                 }
@@ -1485,6 +1509,8 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
                 return provs[shmem_internal_my_pe % num_nics];
 #else
                 provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+                if (!provider_list)
+                    RAISE_ERROR_MSG("malloc failed for provider_list\n");
                 provider_list[0] = provs[shmem_internal_my_pe % num_nics];
                 shmem_transport_ofi_num_nics = 1;
                 return provider_list[0];
@@ -1503,16 +1529,22 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         RAISE_WARN_MSG("Could not detect any NICs with affinity to the process\n");
 #ifdef USE_OFI_TX_LOAD_BALANCING
         provider_list = (struct fi_info **) malloc(num_nics * sizeof(struct fi_info *));
+        if (!provider_list)
+            RAISE_ERROR_MSG("malloc failed for provider_list\n");
         for (size_t idx = 0; idx < num_nics; idx++) {
             provider_list[idx] = provs[idx];
         }
         shmem_transport_ofi_num_nics = num_nics;
+        hwloc_bitmap_free(bindset);
         return provs[shmem_internal_my_pe % num_nics];
 #else
         /* Base multi-rail: assign this PE exactly one NIC via round-robin. */
         provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+        if (!provider_list)
+            RAISE_ERROR_MSG("malloc failed for provider_list\n");
         provider_list[0] = provs[shmem_internal_my_pe % num_nics];
         shmem_transport_ofi_num_nics = 1;
+        hwloc_bitmap_free(bindset);
         return provider_list[0];
 #endif
     }
@@ -1524,6 +1556,9 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     /* TX load balancing: expose all close NICs for per-op random selection. */
     int idx = 0;
     provider_list = (struct fi_info **) malloc(num_close_nics * sizeof(struct fi_info *));
+    if (!provider_list)
+        RAISE_ERROR_MSG("malloc failed for provider_list\n");
+    shmem_transport_ofi_close_provs = close_provs;
     for (struct fi_info *cur_fabric = close_provs; cur_fabric; cur_fabric = cur_fabric->next) {
         provider_list[idx++] = cur_fabric;
     }
@@ -1544,7 +1579,11 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
         assigned = assigned->next;
     }
     provider_list = (struct fi_info **) malloc(sizeof(struct fi_info *));
+    if (!provider_list)
+        RAISE_ERROR_MSG("malloc failed for provider_list\n");
     provider_list[0] = assigned;
+    /* Store the full dup'd chain so fini can free all entries. */
+    shmem_transport_ofi_close_provs = close_provs;
 
     hwloc_bitmap_free(bindset);
 
@@ -1911,6 +1950,10 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     ctx->pending_get_cntr = (shmem_internal_cntr_t *) malloc(shmem_transport_ofi_num_nics * sizeof(shmem_internal_cntr_t));
 #endif
     ctx->cq = (struct fid_cq **) malloc(shmem_transport_ofi_num_nics * sizeof(struct fid_cq *));
+    if (!ctx->fabric || !ctx->domain || !ctx->av || !ctx->ep ||
+        !ctx->put_cntr || !ctx->get_cntr ||
+        !ctx->pending_put_cntr || !ctx->pending_get_cntr || !ctx->cq)
+        RAISE_ERROR_MSG("ctx_init: allocation failed (out of memory)\n");
     for (size_t idx = 0; idx < shmem_transport_ofi_num_nics; idx++) {
 #ifdef USE_CTX_LOCK
         ctx->pending_put_cntr[idx] = 0;
@@ -2568,6 +2611,14 @@ int shmem_transport_fini(void)
 #endif
 
     fi_freeinfo(shmem_transport_ofi_info.fabrics);
+
+    /* Free the fi_dupinfo'd close-NIC chain (success paths only; NULL in fallbacks). */
+    if (shmem_transport_ofi_close_provs) {
+        fi_freeinfo(shmem_transport_ofi_close_provs);
+        shmem_transport_ofi_close_provs = NULL;
+    }
+    free(provider_list);
+    provider_list = NULL;
 
     SHMEM_MUTEX_DESTROY(shmem_transport_ofi_lock);
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -383,24 +383,16 @@ extern struct fid_ep* shmem_transport_ofi_target_ep;
     } while (0)
 
 static inline
-void shmem_transport_probe(size_t nic_idx)
+void shmem_transport_probe(void)
 {
 #if defined(ENABLE_MANUAL_PROGRESS)
 #  ifdef USE_THREAD_COMPLETION
     if (0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
 #  endif
         struct fi_cq_entry buf;
-        int ret = fi_cq_read(shmem_transport_ctx_default.cq[nic_idx], &buf, 1);
+        int ret = fi_cq_read(shmem_transport_ofi_target_cq, &buf, 1);
         if (ret == 1)
-            RAISE_WARN_STR("Unexpected event A");
-        if (ret < 0)
-            RAISE_WARN_STR("Unexpected event B");
-//        for (size_t i = 0; i < shmem_transport_ofi_num_nics; i++) {
-//            struct fi_cq_entry buf;
-//            int ret = fi_cq_read(shmem_transport_ctx_default.cq[i], &buf, 1);
-//            if (ret == 1)
-//                RAISE_WARN_STR("Unexpected event");
-//        }
+            RAISE_WARN_STR("Unexpected event");
 #  ifdef USE_THREAD_COMPLETION
         pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
     }
@@ -519,19 +511,10 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx, size_t nic_idx)
     while (poll_count < shmem_transport_ofi_put_poll_limit ||
            shmem_transport_ofi_put_poll_limit < 0) {
 
-//        success = 0;
-//        fail = 0;
-//        cnt = 0;
-//        for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
-//            success += fi_cntr_read(ctx->put_cntr[nic_idx]); /* FIXED? */
-//            fail += fi_cntr_readerr(ctx->put_cntr[nic_idx]); /* FIXED? */
-//            cnt += SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr[nic_idx]); /* FIXED? */
-//        }
-//        shmem_transport_probe();
         success = fi_cntr_read(ctx->put_cntr[nic_idx]); /* FIXED? */
         fail = fi_cntr_readerr(ctx->put_cntr[nic_idx]); /* FIXED? */
         cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr[nic_idx]); /* FIXED? */
-        shmem_transport_probe(nic_idx);
+        shmem_transport_probe();
 
         if (success < cnt && fail == 0) {
             SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
@@ -546,16 +529,14 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx, size_t nic_idx)
         poll_count++;
     }
 
-    //for (size_t nic_idx = 0; nic_idx < shmem_transport_ofi_num_nics; nic_idx++) {
+    cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr[nic_idx]); /* FIXED? */
+    do {
+        cnt = cnt_new;
+        ssize_t ret = fi_cntr_wait(ctx->put_cntr[nic_idx], cnt, -1); /* FIXED? */
         cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr[nic_idx]); /* FIXED? */
-        do {
-            cnt = cnt_new;
-            ssize_t ret = fi_cntr_wait(ctx->put_cntr[nic_idx], cnt, -1); /* FIXED? */
-            cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr[nic_idx]); /* FIXED? */
-            OFI_CTX_CHECK_ERROR(ctx, ret);
-        } while (cnt < cnt_new);
-        shmem_internal_assert(cnt == cnt_new);
-    //}
+        OFI_CTX_CHECK_ERROR(ctx, ret);
+    } while (cnt < cnt_new);
+    shmem_internal_assert(cnt == cnt_new);
 
     SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 }
@@ -614,7 +595,7 @@ int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled, size_
                 }
             }
 
-            shmem_transport_probe(nic_idx);
+            shmem_transport_probe();
             
             (*polled)++;
             if ((*polled) <= shmem_transport_ofi_max_poll) {
@@ -1000,7 +981,7 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t nic_idx)
         fail = fi_cntr_readerr(ctx->get_cntr[nic_idx]);
         cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr[nic_idx]);
 
-        shmem_transport_probe(nic_idx);
+        shmem_transport_probe();
 
         if (success < cnt && fail == 0) {
             SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -389,10 +389,16 @@ void shmem_transport_probe(void)
 #  ifdef USE_THREAD_COMPLETION
     if (0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
 #  endif
-        struct fi_cq_entry buf;
-        int ret = fi_cq_read(shmem_transport_ofi_target_cq, &buf, 1);
-        if (ret == 1)
-            RAISE_WARN_STR("Unexpected event");
+//        struct fi_cq_entry buf;
+//        int ret = fi_cq_read(shmem_transport_ofi_target_cq, &buf, 1);
+//        if (ret == 1)
+//            RAISE_WARN_STR("Unexpected event");
+        for (size_t i = 0; i < shmem_transport_ofi_num_nics; i++) {
+            struct fi_cq_entry buf;
+            int ret = fi_cq_read(shmem_transport_ctx_default.cq[i], &buf, 1);
+            if (ret == 1)
+                RAISE_WARN_STR("Unexpected event");
+        }
 #  ifdef USE_THREAD_COMPLETION
         pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
     }

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -1433,9 +1433,9 @@ void shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target,
 static inline
 void shmem_transport_atomic_fetch_nbi(shmem_transport_ctx_t* ctx, void *target,
                                   const void *source, size_t len, int pe,
-                                  int datatype)
+                                  int datatype, size_t nic_idx)
 {
-    shmem_transport_atomic_fetch(ctx, target, source, len, pe, datatype);
+    shmem_transport_atomic_fetch(ctx, target, source, len, pe, datatype, nic_idx);
 }
 
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -423,6 +423,7 @@ static inline void shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t i
 static inline
 void shmem_transport_ofi_drain_cq(shmem_transport_ctx_t *ctx, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     ssize_t ret = 0;
     struct fi_cq_entry buf;
 
@@ -488,6 +489,7 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 static inline
 void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
 
     /* Wait for bounce buffered operations to complete */
@@ -580,6 +582,7 @@ int shmem_transport_fence(shmem_transport_ctx_t* ctx)
  * retry limit (ofi_max_poll) is exceeded, abort. */
 static inline
 int try_again(shmem_transport_ctx_t *ctx, const int ret, uint64_t *polled, size_t nic_idx) {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     if (ret) {
         if (ret == -FI_EAGAIN) {
             if (ctx->bounce_buffers) {
@@ -624,6 +627,7 @@ static inline
 void shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const
                                void *source, size_t len, int pe, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -654,6 +658,7 @@ static inline
 void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, const void *source,
                                    size_t len, int pe, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -694,6 +699,7 @@ static inline
 void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                             int pe, long *completion, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -743,6 +749,7 @@ static inline
 void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                                     uint64_t *sig_addr, uint64_t signal, int sig_op, int pe, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -903,6 +910,7 @@ static inline
 void shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                              int pe, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     if (len <= shmem_transport_ofi_max_buffered_send) {
 
         shmem_transport_put_scalar(ctx, target, source, len, pe, nic_idx);
@@ -917,6 +925,7 @@ void shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const voi
 static inline
 void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -971,6 +980,7 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
 static inline
 void shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     /* wait for get counter to meet outstanding count value */
 
     /* Note: the communication routines increment pending get counters before
@@ -1022,6 +1032,7 @@ void shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const
                                void *source, void *dest, const void *operand,
                                size_t len, int pe, int datatype, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -1118,6 +1129,7 @@ static inline
 void shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                            const void *mask, size_t len, int pe, int datatype, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -1156,6 +1168,7 @@ static inline
 void shmem_transport_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
                             int pe, int op, int datatype, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -1188,6 +1201,7 @@ void shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const voi
                              size_t full_len, int pe, int op, int datatype,
                              long *completion, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     int dt = SHMEM_TRANSPORT_DTYPE(datatype);
@@ -1297,6 +1311,7 @@ void shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target,
                                       const void *source, void *dest,
                                       size_t len, int pe, int op, int datatype, size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
     uint64_t polled = 0;
@@ -1345,6 +1360,7 @@ void shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target,
                                   size_t len, int pe, int op, int datatype,
                                   size_t nic_idx)
 {
+    shmem_internal_assert(nic_idx < shmem_transport_ofi_num_nics);
 #ifdef ENABLE_MR_ENDPOINT
     /* CXI provider currently does not support fetch atomics with FI_DELIVERY_COMPLETE
      * That is why non-blocking API is used which uses FI_INJECT. FI_ATOMIC_READ is

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -729,7 +729,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
                                             .data          = 0
                                           };
         do {
-            ret = fi_writemsg(ctx->ep[nic_idx], &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE); /* FIXED? */
+            ret = fi_writemsg(ctx->ep[nic_idx], &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE); /* FIXED? */	// bman: for bounce--we get CQ events, i think
         } while (try_again(ctx, ret, &polled, nic_idx)); /* FIXED? */
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 
@@ -751,7 +751,8 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
 
     shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 
-    if (len <= shmem_transport_ofi_max_buffered_send) {
+    if (len <= shmem_transport_ofi_max_buffered_send) 
+	{
         uint8_t *src_buf = (uint8_t *) source;
 
         SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
@@ -778,11 +779,13 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
                                       };
 
         do {
-            ret = fi_writemsg(ctx->ep[nic_idx], &msg, FI_DELIVERY_COMPLETE | FI_INJECT); /* FIXED? */
+            ret = fi_writemsg(ctx->ep[nic_idx], &msg, FI_DELIVERY_COMPLETE | FI_INJECT); /* FIXED? */		// bman: is done when ACK'd from other NIC; no CQ events
         } while (try_again(ctx, ret, &polled, nic_idx)); /* FIXED? */
 
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-    } else {
+    } 
+	else 
+	{
         uint8_t *frag_source = (uint8_t *) source;
         uint64_t frag_target = (uint64_t) addr;
         size_t frag_len = len;
@@ -808,7 +811,8 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
                                 };
 
         SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        while (frag_source < (((uint8_t *) source) + len)) {
+        while (frag_source < (((uint8_t *) source) + len)) 
+		{
             frag_len = MIN(shmem_transport_ofi_max_msg_size, 
                           (size_t) (((uint8_t *) source) + len - frag_source));
             polled = 0;

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -811,7 +811,7 @@ void
 shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target,
                           const void *source, void *dest,
                           const void *operand, size_t len, int pe,
-                          ptl_datatype_t datatype)
+                          ptl_datatype_t datatype, size_t nic_idx)
 {
     /* transport_cswap already buffers the source and operand arguments */
     shmem_transport_cswap(ctx, target, source, dest, operand, len, pe, datatype);

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -244,7 +244,7 @@ int shmem_transport_fini(void);
 
 static inline void shmem_transport_get_wait(shmem_transport_ctx_t*, size_t idx);
 
-static inline void shmem_transport_probe(size_t nic_idx) {
+static inline void shmem_transport_probe(void) {
     return;
 }
 

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -368,7 +368,7 @@ shmem_transport_portals4_drain_eq(void)
 
 static inline
 void
-shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     int ret;
     ptl_process_t peer;
@@ -571,7 +571,7 @@ shmem_transport_portals4_put_nbi_internal(shmem_transport_ctx_t* ctx, void *targ
 
 static inline
 void
-shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_put_nbi_internal(ctx, target, source, len, pe,
@@ -588,7 +588,7 @@ shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *so
 static inline
 void
 shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                                int pe, long *completion)
+                                int pe, long *completion, size_t nic_idx)
 {
     if (ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
@@ -603,7 +603,7 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
                                                  shmem_transport_portals4_heap_pt);
 #endif
     } else {
-        shmem_transport_put_nbi(ctx, target, source, len, pe);
+        shmem_transport_put_nbi(ctx, target, source, len, pe, nic_idx);
     }
 }
 
@@ -611,7 +611,7 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
 static inline
 void
 shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *source,
-                          size_t len, int pe, long *completion)
+                          size_t len, int pe, long *completion, size_t nic_idx)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_put_nb_internal((shmem_transport_ctx_t *)SHMEM_CTX_DEFAULT, target, source, len, pe,
@@ -624,7 +624,7 @@ shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *so
 
 static inline
 void
-shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion, size_t nic_idx)
 {
     if (ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
         while (*completion > 0) {
@@ -668,7 +668,7 @@ shmem_transport_portals4_get_internal(shmem_transport_ctx_t* ctx, void *target, 
 
 
 static inline
-void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_get_internal(ctx, target, source, len, pe,
@@ -683,7 +683,8 @@ void shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *s
 
 static inline
 void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
-                            const void *source, size_t len, int pe)
+                            const void *source, size_t len, int pe,
+                            size_t nic_idx)
 {
 #ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
     shmem_transport_portals4_get_internal((shmem_transport_ctx_t *)SHMEM_CTX_DEFAULT, target, source, len, pe, ct->shr_pt, -1);
@@ -718,7 +719,7 @@ shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 static inline
 void
 shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
-                     int pe, ptl_datatype_t datatype)
+                     int pe, ptl_datatype_t datatype, size_t nic_idx)
 {
     int ret;
     ptl_process_t peer;
@@ -758,7 +759,7 @@ static inline
 void
 shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target,
                          const void *source, void *dest, size_t len,
-                         int pe, ptl_datatype_t datatype)
+                         int pe, ptl_datatype_t datatype, size_t nic_idx)
 {
     /* transport_swap already buffers the source argument */
     shmem_transport_swap(ctx, target, source, dest, len, pe, datatype);
@@ -769,7 +770,7 @@ static inline
 void
 shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
-                      ptl_datatype_t datatype)
+                      ptl_datatype_t datatype, size_t nic_idx)
 {
     int ret;
     ptl_process_t peer;
@@ -821,7 +822,7 @@ static inline
 void
 shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
-                      ptl_datatype_t datatype)
+                      ptl_datatype_t datatype, size_t nic_idx)
 {
     int ret;
     ptl_process_t peer;
@@ -860,7 +861,7 @@ shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
 static inline
 void
 shmem_transport_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                       int pe, ptl_op_t op, ptl_datatype_t datatype)
+                       int pe, ptl_op_t op, ptl_datatype_t datatype, size_t nic_idx)
 {
     int ret;
     ptl_pt_index_t pt;
@@ -1020,7 +1021,7 @@ static inline
 void
 shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                              size_t len, int pe, ptl_op_t op,
-                             ptl_datatype_t datatype)
+                             ptl_datatype_t datatype, size_t nic_idx)
 {
     int ret;
     ptl_pt_index_t pt;
@@ -1060,7 +1061,7 @@ void
 shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target,
                                  const void *source, void *dest,
                                  size_t len, int pe, ptl_op_t op,
-                                 ptl_datatype_t datatype)
+                                 ptl_datatype_t datatype, size_t nic_idx)
 {
     /* transport_fetch_atomic already buffers the source argument */
     shmem_transport_fetch_atomic(ctx, target, source, dest, len, pe, op, datatype);
@@ -1070,22 +1071,22 @@ shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target,
 static inline
 void
 shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                           int pe, int datatype)
+                           int pe, int datatype, size_t nic_idx)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_atomic_size);
 
-    shmem_transport_put_scalar(ctx, target, source, len, pe);
+    shmem_transport_put_scalar(ctx, target, source, len, pe, nic_idx);
 }
 
 
 static inline
 void
 shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                             int pe, int datatype)
+                             int pe, int datatype, size_t nic_idx)
 {
     shmem_internal_assert(len <= shmem_transport_portals4_max_fetch_atomic_size);
 
-    shmem_transport_get(ctx, target, source, len, pe);
+    shmem_transport_get(ctx, target, source, len, pe, nic_idx);
 }
 
 
@@ -1102,16 +1103,16 @@ int shmem_transport_atomic_supported(ptl_op_t op, ptl_datatype_t datatype)
 
 static inline
 void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                                    uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
+                                    uint64_t *sig_addr, uint64_t signal, int sig_op, int pe, size_t nic_idx)
 {
     /* FIXME: Need to optimize non-blocking put with signal for Portals. Current implementation below keeps
  *      * the "fence" in between data and signal put */
-    shmem_transport_put_nbi(ctx, target, source, len, pe);
+    shmem_transport_put_nbi(ctx, target, source, len, pe, nic_idx);
     shmem_transport_fence(ctx);
     if (sig_op == SHMEM_SIGNAL_ADD)
-        shmem_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+        shmem_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t), pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
     else
-        shmem_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+        shmem_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t), pe, SHM_INTERNAL_UINT64, nic_idx);
 }
 
 static inline

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -242,7 +242,7 @@ int shmem_transport_startup(void);
 
 int shmem_transport_fini(void);
 
-static inline void shmem_transport_get_wait(shmem_transport_ctx_t*);
+static inline void shmem_transport_get_wait(shmem_transport_ctx_t*, size_t idx);
 
 static inline void shmem_transport_probe(void) {
     return;
@@ -257,7 +257,7 @@ shmem_transport_quiet(shmem_transport_ctx_t* ctx)
     uint64_t cnt, cnt_new;
 
     /* wait for completion of all pending NB get events */
-    shmem_transport_get_wait(ctx);
+    shmem_transport_get_wait(ctx, 0);
 
     /* wait for remote completion (acks) of all buffered puts */
     /* NOTE-MT: continue to wait if additional operations are issued during the quiet */
@@ -696,7 +696,7 @@ void shmem_transport_get_ct(shmem_transport_ct_t *ct, void *target,
 
 static inline
 void
-shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 {
     int ret;
     ptl_ct_event_t ct;

--- a/src/transport_portals4.h
+++ b/src/transport_portals4.h
@@ -244,7 +244,7 @@ int shmem_transport_fini(void);
 
 static inline void shmem_transport_get_wait(shmem_transport_ctx_t*, size_t idx);
 
-static inline void shmem_transport_probe(void) {
+static inline void shmem_transport_probe(size_t nic_idx) {
     return;
 }
 
@@ -624,7 +624,7 @@ shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void *so
 
 static inline
 void
-shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion, size_t nic_idx)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 {
     if (ctx->options & SHMEMX_CTX_BOUNCE_BUFFER) {
         while (*completion > 0) {

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -72,7 +72,7 @@ static int shmem_transport_ucx_progress_thread_enabled = 1;
 static void * shmem_transport_ucx_progress_thread_func(void *arg)
 {
     while (__atomic_load_n(&shmem_transport_ucx_progress_thread_enabled, __ATOMIC_ACQUIRE)) {
-        shmem_transport_probe();
+        shmem_transport_probe(0);
         usleep(shmem_internal_params.PROGRESS_INTERVAL);
     }
 

--- a/src/transport_ucx.c
+++ b/src/transport_ucx.c
@@ -72,7 +72,7 @@ static int shmem_transport_ucx_progress_thread_enabled = 1;
 static void * shmem_transport_ucx_progress_thread_func(void *arg)
 {
     while (__atomic_load_n(&shmem_transport_ucx_progress_thread_enabled, __ATOMIC_ACQUIRE)) {
-        shmem_transport_probe(0);
+        shmem_transport_probe();
         usleep(shmem_internal_params.PROGRESS_INTERVAL);
     }
 

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -442,7 +442,7 @@ static inline
 void
 shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                           const void *operand, size_t len, int pe,
-                          shm_internal_datatype_t datatype)
+                          shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -315,7 +315,7 @@ shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source
 
 static inline
 void
-shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
+shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 {
     /* Blocking fetching ops are completed in place, so this is a nop */
 }

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -230,7 +230,7 @@ shmem_transport_fence(shmem_transport_ctx_t* ctx)
 
 static inline
 void
-shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     ucs_status_t status;
     ucp_rkey_h rkey;
@@ -275,7 +275,7 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
 
 static inline
 void
-shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion, size_t nic_idx)
 {
     while (__atomic_load_n(completion, __ATOMIC_ACQUIRE) > 0)
         shmem_transport_probe();
@@ -284,7 +284,7 @@ shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 static inline
 void
 shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                       int pe)
+                       int pe, size_t nic_idx)
 {
     ucs_status_t status;
     ucp_rkey_h rkey;
@@ -298,7 +298,7 @@ shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const void *so
 
 static inline
 void
-shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe)
+shmem_transport_get(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len, int pe, size_t nic_idx)
 {
     ucs_status_ptr_t pstatus;
     ucp_rkey_h rkey;
@@ -324,7 +324,7 @@ shmem_transport_get_wait(shmem_transport_ctx_t* ctx, size_t idx)
 static inline
 void
 shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
-                     size_t len, int pe, shm_internal_datatype_t datatype)
+                     size_t len, int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -361,7 +361,7 @@ shmem_transport_swap(shmem_transport_ctx_t* ctx, void *target, const void *sourc
 static inline
 void
 shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
-                         size_t len, int pe, shm_internal_datatype_t datatype)
+                         size_t len, int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -402,7 +402,7 @@ static inline
 void
 shmem_transport_cswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *operand, size_t len, int pe,
-                      shm_internal_datatype_t datatype)
+                      shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -484,7 +484,7 @@ shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *
 static inline
 void
 shmem_transport_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                       int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                       int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -530,7 +530,7 @@ shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const void *so
 static inline
 void
 shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
-                             int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -570,7 +570,7 @@ shmem_transport_fetch_atomic(shmem_transport_ctx_t* ctx, void *target, const voi
 static inline
 void
 shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest, size_t len,
-                                 int pe, shm_internal_op_t op, shm_internal_datatype_t datatype)
+                                 int pe, shm_internal_op_t op, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -613,7 +613,7 @@ shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const
 static inline
 void
 shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                             int pe, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -632,7 +632,7 @@ shmem_transport_atomic_fetch(shmem_transport_ctx_t* ctx, void *target, const voi
 static inline
 void
 shmem_transport_atomic_set(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                             int pe, shm_internal_datatype_t datatype)
+                             int pe, shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -675,7 +675,7 @@ static inline
 void
 shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *source, void *dest,
                       const void *mask, size_t len, int pe,
-                      shm_internal_datatype_t datatype)
+                      shm_internal_datatype_t datatype, size_t nic_idx)
 {
     uint8_t *remote_addr;
     ucp_rkey_h rkey;
@@ -718,18 +718,18 @@ void shmem_transport_syncmem(void)
 static inline
 void
 shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, const void *source, size_t len,
-                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
+                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe, size_t nic_idx)
 {
-    shmem_transport_put_nbi(ctx, target, source, len, pe);
+    shmem_transport_put_nbi(ctx, target, source, len, pe, nic_idx);
     shmem_transport_fence(ctx);
     switch (sig_op) {
         case SHMEM_SIGNAL_ADD:
             shmem_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
-                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64, nic_idx);
             break;
         case SHMEM_SIGNAL_SET:
             shmem_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t),
-                                       pe, SHM_INTERNAL_UINT64);
+                                       pe, SHM_INTERNAL_UINT64, nic_idx);
             break;
         default:
             RAISE_ERROR_MSG("Unsupported operation (%d)\n", sig_op);
@@ -772,14 +772,15 @@ void shmem_transport_ct_wait(shmem_transport_ct_t *ct, long wait_for)
 static inline
 void
 shmem_transport_put_ct_nb(shmem_transport_ct_t *ct, void *target, const void
-                          *source, size_t len, int pe, long *completion)
+                          *source, size_t len, int pe, long *completion, size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }
 
 static inline
 void shmem_transport_get_ct(shmem_transport_ct_t *ct, void
-                            *target, const void *source, size_t len, int pe)
+                            *target, const void *source, size_t len, int pe,
+                            size_t nic_idx)
 {
     RAISE_ERROR_STR("No path to peer");
 }

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -83,7 +83,7 @@ int shmem_transport_fini(void);
 
 static inline
 void
-shmem_transport_probe(size_t nic_idx)
+shmem_transport_probe(void)
 {
     ucp_worker_progress(shmem_transport_ucp_worker);
 }
@@ -93,14 +93,14 @@ ucs_status_t shmem_transport_ucx_complete_op(ucs_status_ptr_t req) {
     if (req == NULL) {
         /* All calls to complete_op must generate progress to avoid deadlock
          * in application-level polling loops */
-        shmem_transport_probe(0);
+        shmem_transport_probe();
         return UCS_OK;
     } else if (UCS_PTR_IS_ERR(req)) {
         return UCS_PTR_STATUS(req);
     } else {
         ucs_status_t status;
         do {
-            shmem_transport_probe(0);
+            shmem_transport_probe();
             status = ucp_request_check_status(req);
         } while (status == UCS_INPROGRESS);
         ucp_request_free(req);
@@ -278,7 +278,7 @@ void
 shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 {
     while (__atomic_load_n(completion, __ATOMIC_ACQUIRE) > 0)
-        shmem_transport_probe(0);
+        shmem_transport_probe();
 }
 
 static inline
@@ -392,7 +392,7 @@ shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *s
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe(0);
+    shmem_transport_probe();
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -475,7 +475,7 @@ shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe(0);
+    shmem_transport_probe();
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -604,7 +604,7 @@ shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe(0);
+    shmem_transport_probe();
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -698,7 +698,7 @@ shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
         if (*(uint32_t *)dest == v) done = 1;
 
         /* Manual progress to avoid deadlock for application-level polling */
-        shmem_transport_probe(0);
+        shmem_transport_probe();
     }
 }
 

--- a/src/transport_ucx.h
+++ b/src/transport_ucx.h
@@ -83,7 +83,7 @@ int shmem_transport_fini(void);
 
 static inline
 void
-shmem_transport_probe(void)
+shmem_transport_probe(size_t nic_idx)
 {
     ucp_worker_progress(shmem_transport_ucp_worker);
 }
@@ -93,14 +93,14 @@ ucs_status_t shmem_transport_ucx_complete_op(ucs_status_ptr_t req) {
     if (req == NULL) {
         /* All calls to complete_op must generate progress to avoid deadlock
          * in application-level polling loops */
-        shmem_transport_probe();
+        shmem_transport_probe(0);
         return UCS_OK;
     } else if (UCS_PTR_IS_ERR(req)) {
         return UCS_PTR_STATUS(req);
     } else {
         ucs_status_t status;
         do {
-            shmem_transport_probe();
+            shmem_transport_probe(0);
             status = ucp_request_check_status(req);
         } while (status == UCS_INPROGRESS);
         ucp_request_free(req);
@@ -275,10 +275,10 @@ shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void *sou
 
 static inline
 void
-shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion, size_t nic_idx)
+shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion)
 {
     while (__atomic_load_n(completion, __ATOMIC_ACQUIRE) > 0)
-        shmem_transport_probe();
+        shmem_transport_probe(0);
 }
 
 static inline
@@ -392,7 +392,7 @@ shmem_transport_swap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *s
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe();
+    shmem_transport_probe(0);
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -475,7 +475,7 @@ shmem_transport_cswap_nbi(shmem_transport_ctx_t* ctx, void *target, const void *
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe();
+    shmem_transport_probe(0);
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -604,7 +604,7 @@ shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target, const
                                   &shmem_transport_ucx_cb_nop);
 
     /* Manual progress to avoid deadlock for application-level polling */
-    shmem_transport_probe();
+    shmem_transport_probe(0);
 
     ucs_status_t status = shmem_transport_ucx_release_op(pstatus);
     UCX_CHECK_STATUS_INPROGRESS(status);
@@ -698,7 +698,7 @@ shmem_transport_mswap(shmem_transport_ctx_t* ctx, void *target, const void *sour
         if (*(uint32_t *)dest == v) done = 1;
 
         /* Manual progress to avoid deadlock for application-level polling */
-        shmem_transport_probe();
+        shmem_transport_probe(0);
     }
 }
 


### PR DESCRIPTION
This PR extends the OFI transport to support transmit-side NIC
multiplexing: rather than assigning each PE a single NIC at startup,
PEs can now spread individual put/get operations across a set of available
NICs at runtime.  Two mutually exclusive policies are provided via new
configure flags:

- `--enable-ofi-tx-load-balancing-round-robin`: cycles through NICs
  uniformly; staggered per-PE start position avoids thundering-herd on
  NIC[0].
- `--enable-ofi-tx-load-balancing-random`: selects a NIC randomly
  on each operation.

Both modes **require** `--with-hwloc` and configure will error out if hwloc
is absent or if both flags are given simultaneously.

Known Issues:
- Fortran support not fully complete. Fortran is de-featured, no planned fix.

Test Coverage:
- https://github.com/openshmem-org/tests-sos/pull/57
 