### PR TITLE
Update hwloc CPU Binding Implementation

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -355,6 +355,119 @@ shmem_internal_heap_preinit(int tl_requested, int *tl_provided)
     abort();
 }
 
+#ifdef USE_HWLOC
+/* Apply the CPU placement policy specified by SHMEM_CPU_PLACEMENT_POLICY.
+ * Must be called after hwloc_topology_load() and shmem_runtime_init().
+ * The "best-network" policy is handled separately in transport_ofi.c
+ * after the NIC is selected. */
+static void
+apply_cpu_placement(void)
+{
+    if (shmem_internal_params.DISABLE_CPU_BINDING) {
+        DEBUG_MSG("PE %d: CPU binding disabled via SHMEM_DISABLE_CPU_BINDING\n",
+                  shmem_internal_my_pe);
+        return;
+    }
+
+    const char *policy = shmem_internal_params.CPU_PLACEMENT_POLICY;
+
+    if (strcmp(policy, "none") == 0 || strcmp(policy, "best-network") == 0)
+        return;
+
+    int ret;
+    hwloc_bitmap_t location = hwloc_bitmap_alloc();
+    if (!location) {
+        RAISE_WARN_MSG("hwloc_bitmap_alloc failed, skipping CPU placement\n");
+        return;
+    }
+
+    ret = hwloc_get_proc_last_cpu_location(shmem_internal_topology, getpid(),
+                                           location, HWLOC_CPUBIND_PROCESS);
+    if (ret != 0) {
+        RAISE_WARN_MSG("hwloc_get_proc_last_cpu_location failed (%s), skipping CPU placement\n",
+                       strerror(errno));
+        goto out;
+    }
+
+    if (strcmp(policy, "best-memory") == 0 || strcmp(policy, "numa-local") == 0) {
+        hwloc_obj_t numa = hwloc_get_next_obj_covering_cpuset_by_type(
+                               shmem_internal_topology, location, HWLOC_OBJ_NUMANODE, NULL);
+        if (!numa) {
+            RAISE_WARN_MSG("PE %d: [%s] could not find covering NUMA node, skipping\n",
+                           shmem_internal_my_pe, policy);
+            goto out;
+        }
+        DEBUG_MSG("PE %d: [%s] binding CPUs to NUMA node %u\n",
+                  shmem_internal_my_pe, policy, numa->os_index);
+        ret = hwloc_set_proc_cpubind(shmem_internal_topology, getpid(),
+                                     numa->cpuset, HWLOC_CPUBIND_PROCESS);
+        if (ret != 0)
+            RAISE_WARN_MSG("PE %d: [%s] hwloc_set_proc_cpubind failed (%s)\n",
+                           shmem_internal_my_pe, policy, strerror(errno));
+
+    } else if (strcmp(policy, "socket-local") == 0) {
+        hwloc_obj_t pkg = hwloc_get_next_obj_covering_cpuset_by_type(
+                              shmem_internal_topology, location, HWLOC_OBJ_PACKAGE, NULL);
+        if (!pkg) {
+            RAISE_WARN_MSG("PE %d: [socket-local] could not find covering socket, skipping\n",
+                           shmem_internal_my_pe);
+            goto out;
+        }
+        DEBUG_MSG("PE %d: [socket-local] binding CPUs to socket %u\n",
+                  shmem_internal_my_pe, pkg->os_index);
+        ret = hwloc_set_proc_cpubind(shmem_internal_topology, getpid(),
+                                     pkg->cpuset, HWLOC_CPUBIND_PROCESS);
+        if (ret != 0)
+            RAISE_WARN_MSG("PE %d: [socket-local] hwloc_set_proc_cpubind failed (%s)\n",
+                           shmem_internal_my_pe, strerror(errno));
+
+    } else if (strcmp(policy, "balanced-numa") == 0) {
+        int num_numa = hwloc_get_nbobjs_by_type(shmem_internal_topology, HWLOC_OBJ_NUMANODE);
+        if (num_numa <= 0) {
+            RAISE_WARN_MSG("PE %d: [balanced-numa] could not enumerate NUMA nodes, skipping\n",
+                           shmem_internal_my_pe);
+            goto out;
+        }
+        int local_rank = shmem_runtime_get_node_rank(shmem_internal_my_pe);
+        if (local_rank < 0) {
+            RAISE_WARN_MSG("PE %d: [balanced-numa] could not get local PE rank, skipping\n",
+                           shmem_internal_my_pe);
+            goto out;
+        }
+        hwloc_obj_t numa = hwloc_get_obj_by_type(shmem_internal_topology,
+                                                  HWLOC_OBJ_NUMANODE,
+                                                  local_rank % num_numa);
+        if (!numa) {
+            RAISE_WARN_MSG("PE %d: [balanced-numa] could not get NUMA node %d, skipping\n",
+                           shmem_internal_my_pe, local_rank % num_numa);
+            goto out;
+        }
+        DEBUG_MSG("PE %d: [balanced-numa] local_rank=%d, assigning to NUMA node %u\n",
+                  shmem_internal_my_pe, local_rank, numa->os_index);
+        ret = hwloc_set_proc_cpubind(shmem_internal_topology, getpid(),
+                                     numa->cpuset, HWLOC_CPUBIND_PROCESS);
+        if (ret != 0) {
+            RAISE_WARN_MSG("PE %d: [balanced-numa] hwloc_set_proc_cpubind failed (%s)\n",
+                           shmem_internal_my_pe, strerror(errno));
+            goto out;
+        }
+        ret = hwloc_set_membind(shmem_internal_topology, numa->nodeset,
+                                HWLOC_MEMBIND_BIND,
+                                HWLOC_MEMBIND_PROCESS | HWLOC_MEMBIND_BYNODESET);
+        if (ret != 0)
+            RAISE_WARN_MSG("PE %d: [balanced-numa] hwloc_set_membind failed (%s)\n",
+                           shmem_internal_my_pe, strerror(errno));
+
+    } else {
+        RAISE_WARN_MSG("PE %d: unknown CPU_PLACEMENT_POLICY '%s', skipping\n",
+                       shmem_internal_my_pe, policy);
+    }
+
+out:
+    hwloc_bitmap_free(location);
+}
+#endif /* USE_HWLOC */
+
 int
 shmem_internal_heap_postinit(void)
 {
@@ -392,34 +505,9 @@ shmem_internal_heap_postinit(void)
 
     ret = hwloc_topology_load(shmem_internal_topology);
     SHMEM_CHECK_GOTO_MSG(ret != 0, hwloc_exit, "hwloc_topology_load failed (%s). Please verify your hwloc installation\n", strerror(errno));
-#if defined(HWLOC_ENFORCE_SINGLE_SOCKET) || defined(HWLOC_ENFORCE_SINGLE_NUMA_NODE)
-    hwloc_bitmap_t bindset = hwloc_bitmap_alloc();
-    hwloc_bitmap_t bindset_all = hwloc_bitmap_alloc();
-    hwloc_bitmap_t bindset_covering_obj = hwloc_bitmap_alloc();
 
-    ret = hwloc_get_proc_last_cpu_location(shmem_internal_topology, getpid(), bindset, HWLOC_CPUBIND_PROCESS);
-    SHMEM_CHECK_GOTO_MSG(ret != 0, hwloc_cleanup, "hwloc_get_proc_last_cpu_location failed (%s). Please verify your hwloc installation\n", strerror(errno));
+    apply_cpu_placement();
 
-    ret = hwloc_get_proc_cpubind(shmem_internal_topology, getpid(), bindset_all, HWLOC_CPUBIND_PROCESS);
-    SHMEM_CHECK_GOTO_MSG(ret != 0, hwloc_cleanup, "hwloc_get_proc_cpubind failed (%s). Please verify your hwloc installation\n", strerror(errno));
-#ifdef HWLOC_ENFORCE_SINGLE_SOCKET
-    hwloc_obj_t covering_obj = hwloc_get_next_obj_covering_cpuset_by_type(shmem_internal_topology, bindset, HWLOC_OBJ_PACKAGE, NULL);
-    SHMEM_CHECK_GOTO_MSG(!covering_obj, hwloc_cleanup,
-                         "hwloc_get_next_obj_covering_cpuset_by_type failed (could not detect object of type 'HWLOC_OBJ_PACKAGE' in provided cpuset). Please verify your hwloc installation\n");
-#else /* HWLOC_ENFORCE_SINGLE_NUMA_NODE */
-    hwloc_obj_t covering_obj = hwloc_get_next_obj_covering_cpuset_by_type(shmem_internal_topology, bindset, HWLOC_OBJ_NUMANODE, NULL);
-    SHMEM_CHECK_GOTO_MSG(!covering_obj, hwloc_cleanup,
-                         "hwloc_get_next_obj_covering_cpuset_by_type failed (could not detect object of type 'HWLOC_OBJ_NUMANODE' in provided cpuset). Please verify your hwloc installation\n");
-#endif
-    hwloc_bitmap_and(bindset_covering_obj, bindset_all, covering_obj->cpuset);
-    ret = hwloc_set_proc_cpubind(shmem_internal_topology, getpid(), bindset_covering_obj, HWLOC_CPUBIND_PROCESS); /* Include HWLOC_CPUBIND_STRICT in flags? */
-    SHMEM_CHECK_GOTO_MSG(ret != 0, hwloc_cleanup, "hwloc_set_proc_cpubind failed (%s). Please verify your hwloc installation\n", strerror(errno));
-
-    hwloc_cleanup:
-        hwloc_bitmap_free(bindset);
-        hwloc_bitmap_free(bindset_all);
-        hwloc_bitmap_free(bindset_covering_obj);
-#endif // HWLOC_ENFORCE_SINGLE_SOCKET || HWLOC_ENFORCE_SINGLE_NUMA_NODE
     hwloc_exit:
 #endif // USE_HWLOC
 

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -123,6 +123,16 @@ SHMEM_INTERNAL_ENV_DEF(MPI_THREAD_LEVEL, string, "MPI_THREAD_SINGLE", SHMEM_INTE
                        "Specify the MPI threading level when MPI is used as the process manager")
 #endif
 
-SHMEM_INTERNAL_ENV_DEF(BACKTRACE, string, "", SHMEM_INTERNAL_ENV_CAT_OTHER,
-                       "Specify the mechanism to use for backtracing on failure")
+#ifdef USE_HWLOC
+SHMEM_INTERNAL_ENV_DEF(CPU_PLACEMENT_POLICY, string, "none", SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "CPU placement policy applied at initialization. Options: none (default), "
+                       "best-memory (bind CPUs to NUMA node of current CPU location), "
+                       "numa-local (same as best-memory), "
+                       "socket-local (bind CPUs to socket of current CPU location), "
+                       "balanced-numa (round-robin PEs across NUMA nodes by local rank; also sets memory binding), "
+                       "best-network (bind CPUs to NUMA node of assigned NIC; applied during transport init). "
+                       "Has no effect when SHMEM_DISABLE_CPU_BINDING is set.")
+SHMEM_INTERNAL_ENV_DEF(DISABLE_CPU_BINDING, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "Disable all hwloc CPU placement. Overrides SHMEM_CPU_PLACEMENT_POLICY.")
+#endif
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1424,6 +1424,33 @@ struct fi_info *assign_nic_with_hwloc(struct fi_info *fabric, struct fi_info **p
     struct fi_info *provider = prov_list[shmem_internal_my_pe % num_close_nics];
     free(prov_list);
 
+    /* Apply best-network CPU placement: bind CPUs to the NUMA domain of the
+     * selected NIC, so the PE's memory traffic is local to its network port. */
+    if (!shmem_internal_params.DISABLE_CPU_BINDING &&
+        strcmp(shmem_internal_params.CPU_PLACEMENT_POLICY, "best-network") == 0 &&
+        provider->nic && provider->nic->bus_attr &&
+        provider->nic->bus_attr->bus_type == FI_BUS_PCI) {
+
+        struct fi_pci_attr pci = provider->nic->bus_attr->attr.pci;
+        hwloc_obj_t io_device = hwloc_get_pcidev_by_busid(shmem_internal_topology,
+                                    pci.domain_id, pci.bus_id, pci.device_id, pci.function_id);
+        hwloc_obj_t non_io = io_device ?
+                             hwloc_get_non_io_ancestor_obj(shmem_internal_topology, io_device) :
+                             NULL;
+        if (!non_io) {
+            RAISE_WARN_MSG("PE %d: [best-network] could not find NUMA ancestor of NIC, skipping CPU placement\n",
+                           shmem_internal_my_pe);
+        } else {
+            DEBUG_MSG("PE %d: [best-network] binding CPUs to NIC NUMA domain\n",
+                      shmem_internal_my_pe);
+            int ret = hwloc_set_proc_cpubind(shmem_internal_topology, getpid(),
+                                             non_io->cpuset, HWLOC_CPUBIND_PROCESS);
+            if (ret != 0)
+                RAISE_WARN_MSG("PE %d: [best-network] hwloc_set_proc_cpubind failed (%s)\n",
+                               shmem_internal_my_pe, strerror(errno));
+        }
+    }
+
     return provider;
 }
 #endif


### PR DESCRIPTION
  ### Problem

  This PR replaces the previous compile-time-gated hwloc CPU binding in `shmem_internal_heap_postinit()`

  ### Solution

 Replace it with an opt-in system controlled by the new `SHMEM_CPU_PLACEMENT_POLICY` environment variable (default: `none`).

  **Available policies:**

  | Policy | Behavior |
  |---|---|
  | `none` (default) | No changes; launcher owns CPU affinity entirely |
  | `best-memory` / `numa-local` | Bind CPUs to the NUMA node of the process's current CPU location |
  | `socket-local` | Bind CPUs to the socket of the process's current CPU location |
  | `balanced-numa` | Round-robin PEs across NUMA nodes by local rank; also sets memory binding via `hwloc_set_membind` |
  | `best-network` | Bind CPUs to the NUMA domain of the assigned NIC; applied inside `assign_nic_with_hwloc()` after NIC selection |

  `SHMEM_DISABLE_CPU_BINDING=true` suppresses all placement regardless of policy. The hwloc topology
  initialization is preserved as it is still required by NIC affinity selection in `transport_ofi.c`.

  ### Files changed

  - `src/init.c` — removed old rebind logic; added `apply_cpu_placement()` dispatching on policy name
  - `src/shmem_env_defs.h` — added `SHMEM_CPU_PLACEMENT_POLICY` env var; updated `SHMEM_DISABLE_CPU_BINDING` description
  - `src/transport_ofi.c` — added `best-network` policy inside `assign_nic_with_hwloc()` where PCI topology is already in scope

**Test coverage**

- Mating PR in tests-sos repo: https://github.com/openshmem-org/tests-sos/pull/56
