### PR TITLE
Multi-phased Hierarchical Barrier

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,13 @@ AC_ARG_ENABLE([shr-atomics],
 AS_IF([test "$enable_shr_atomics" = "yes"],
       [AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])])
 
+AC_ARG_ENABLE([hierarchical-barrier],
+    [AS_HELP_STRING([--enable-hierarchical-barrier],
+                    [Enable the hierarchical barrier: intranode phase uses CPU atomics,
+                     internode phase uses NIC puts. Requires an on-node transport (XPMEM
+                     or CMA) and a network transport (OFI, Portals4, or UCX).
+                     (default: disabled)])])
+
 AC_ARG_ENABLE([manpages],
     [AS_HELP_STRING([--enable-manpages],
                     [Include man pages in the installation (default:disabled)])])
@@ -537,7 +544,6 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
-       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then
@@ -549,6 +555,36 @@ fi
 if test "$enable_shr_atomics" != "no" -a "$transport_xpmem" = "yes" -a "$transport" = "none"; then
     transport_shr_atomics="yes"
     AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])
+fi
+
+dnl Hierarchical barrier: only when explicitly requested.  Validate that an
+dnl on-node transport (XPMEM or CMA) and a network transport are both present;
+dnl error if dependencies are missing.
+transport_hierarchical_barrier="no"
+if test "$enable_hierarchical_barrier" = "yes"; then
+    dnl Check on-node transport dependency
+    if test "$transport_xpmem" != "yes" -a "$transport_cma" != "yes"; then
+        AC_MSG_ERROR([--enable-hierarchical-barrier requires an on-node transport; configure with --with-xpmem or --with-cma])
+    dnl Check network transport dependency
+    elif test "$transport_ofi" != "yes" -a "$transport_portals4" != "yes" -a "$transport_ucx" != "yes"; then
+        AC_MSG_ERROR([--enable-hierarchical-barrier requires a network transport; configure with --with-ofi, --with-portals4, or --with-ucx])
+    else
+        transport_hierarchical_barrier="yes"
+    fi
+fi
+if test "$transport_hierarchical_barrier" = "yes"; then
+    AC_DEFINE([USE_HIERARCHICAL_BARRIER], [1],
+              [If defined, enables the hierarchical barrier: intranode CPU atomics + internode NIC puts.])
+    dnl The hierarchical barrier uses shared-memory puts/gets (XPMEM/CMA) for
+    dnl intranode data movement. USE_SHR_ATOMICS is defined so that the
+    dnl shmem_shr_transport_atomic() function bodies are compiled; the routing
+    dnl logic in shmem_shr_transport_use_atomic() gates them behind a runtime
+    dnl check (shr_size == num_pes), so user-visible AMOs only go through CPU
+    dnl atomics when all PEs are on one node. In the multi-node case they
+    dnl always use the NIC, preserving the single-coherency-domain invariant.
+    AC_DEFINE([USE_SHR_ATOMICS], [1],
+              [If defined, the shared memory layer will perform processor atomics.])
+    transport_shr_atomics="yes"
 fi
 
 AC_ARG_ENABLE([pmi-simple], [AS_HELP_STRING([--enable-pmi-simple],
@@ -1050,6 +1086,7 @@ echo "  XPMEM:          $transport_xpmem"
 echo "  CMA:            $transport_cma"
 echo "  memcpy (self):  $transport_memcpy"
 echo "  Shr. atomics:   $transport_shr_atomics"
+echo "  Hier. barrier:  $transport_hierarchical_barrier"
 echo ""
 echo "Global Options:"
 if test "$enable_remote_virtual_addressing" = "yes"; then

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -53,8 +53,6 @@ long *shmem_internal_hierarchical_local_psync;
  * Total allocation: 2 * shr_size * HIER_SLOT_STRIDE longs. */
 #define HIER_SLOT_STRIDE  8   /* 8 longs = 64 bytes = 1 cache line */
 
-static long hier_sense = 0;
-
 /* Per-phase timing accumulators (root PE: all three phases;
  * non-root PEs: phase1_us = gather wait, phase3_us = fanout wait). */
 static double hier_phase1_us = 0.0;
@@ -596,6 +594,15 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
 
     if (PE_size == 1) return;
 
+    /* Determine sense state: for TEAM_WORLD (0, 1, num_pes) use per-team state; else static fallback. */
+    long *sense_ptr;
+    if (PE_start == 0 && PE_stride == 1 && PE_size == shmem_internal_num_pes) {
+        sense_ptr = &shmem_internal_team_world.hier_sense;
+    } else {
+        static long fallback_sense = 0;
+        sense_ptr = &fallback_sense;
+    }
+
     /* Collect local and root PE sets for this active set */
     int *local_pes = alloca(sizeof(int) * PE_size);
     int local_count = 0;
@@ -639,7 +646,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
     /* Sense-alternating signal — monotonically increasing, no slot resets needed.
      * up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
      * down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE] */
-    long signal   = SHMEM_SYNC_VALUE + 1 + hier_sense;
+    long signal   = SHMEM_SYNC_VALUE + 1 + *sense_ptr;
     int  shr_size = shmem_internal_get_shr_size();
     long *up_pSync   = local_pSync;
     long *down_pSync = local_pSync + (long)(shr_size * HIER_SLOT_STRIDE);
@@ -705,7 +712,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
             hier_call_count++;
         }
 
-        hier_sense++;
+        (*sense_ptr)++;
         return;
     }
 
@@ -800,7 +807,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
         }
     }
 
-    if (my_vidx >= 0) { hier_sense++; }
+    if (my_vidx >= 0) { (*sense_ptr)++; }
     /* PEs absent from local_pes (my_vidx < 0) fall through silently. */
 }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include <string.h>
+#include <time.h>
 
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
@@ -30,13 +31,53 @@ coll_type_t shmem_internal_collect_type = AUTO;
 coll_type_t shmem_internal_fcollect_type = AUTO;
 long *shmem_internal_barrier_all_psync;
 long *shmem_internal_sync_all_psync;
+#ifdef USE_HIERARCHICAL_BARRIER
+long *shmem_internal_barrier_all_local_psync;
+long *shmem_internal_sync_all_local_psync;
+long *shmem_internal_hierarchical_local_psync;
+
+/* Layout of local_pSync — two cache-line-padded arrays, one slot per PE:
+ *
+ *   up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
+ *   down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE]
+ *
+ * Phase 1 (gather): each PE writes signal to its OWN up-slot once it has
+ *   collected all its children; parent reads children's up-slots.
+ *   One writer per slot — no MESI contention on the parent's cache line.
+ *
+ * Phase 3 (fanout): parent writes signal to each child's down-slot.
+ *   One writer per slot — same property.
+ *
+ * Sense-alternation (hier_sense) avoids explicit resets between calls.
+ *
+ * Total allocation: 2 * shr_size * HIER_SLOT_STRIDE longs. */
+#define HIER_SLOT_STRIDE  8   /* 8 longs = 64 bytes = 1 cache line */
+
+static long hier_sense = 0;
+
+/* Per-phase timing accumulators (root PE: all three phases;
+ * non-root PEs: phase1_us = gather wait, phase3_us = fanout wait). */
+static double hier_phase1_us = 0.0;
+static double hier_phase2_us = 0.0;
+static double hier_phase3_us = 0.0;
+static long   hier_call_count = 0;
+
+static inline double
+hier_now_us(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e6 + ts.tv_nsec * 1e-3;
+}
+#endif
 
 char *coll_type_str[] = { "AUTO",
                           "LINEAR",
                           "TREE",
                           "DISSEM",
                           "RING",
-                          "RECDBL" };
+                          "RECDBL",
+                          "HIERARCHICAL" };
 
 static int *full_tree_children;
 static int full_tree_num_children;
@@ -134,6 +175,44 @@ shmem_internal_collectives_init(void)
     for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++)
         shmem_internal_sync_all_psync[i] = SHMEM_SYNC_VALUE;
 
+#ifdef USE_HIERARCHICAL_BARRIER
+    /* Allocate local (intranode, CPU-atomic) pSync arrays for the hierarchical
+     * barrier.  Each PE owns HIER_SLOT_STRIDE longs (one cache line) within
+     * the array, indexed by shr_rank.  The stride prevents false sharing:
+     * PE r's slot is at local_pSync[r * HIER_SLOT_STRIDE].
+     * These arrays are touched only by on-node CPU stores/loads via XPMEM;
+     * the global pSync arrays above are touched only by NIC puts. */
+    int shr_size = shmem_internal_get_shr_size();
+    int local_psync_len = 2 * shr_size * HIER_SLOT_STRIDE;
+
+    shmem_internal_barrier_all_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_barrier_all_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_barrier_all_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    shmem_internal_sync_all_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_sync_all_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_sync_all_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    /* Shared local pSync for general barriers/syncs.  Safe to share because
+     * barriers are serialized — a PE cannot enter a new barrier until it has
+     * exited the previous one. */
+    shmem_internal_hierarchical_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_hierarchical_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_hierarchical_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+#endif
+
     /* initialize the binomial tree for collective operations over
        entire tree */
     full_tree_num_children = 0;
@@ -176,6 +255,10 @@ shmem_internal_collectives_init(void)
             shmem_internal_barrier_type = TREE;
         } else if (0 == strcmp(type, "dissem")) {
             shmem_internal_barrier_type = DISSEM;
+#ifdef USE_HIERARCHICAL_BARRIER
+        } else if (0 == strcmp(type, "hierarchical")) {
+            shmem_internal_barrier_type = HIERARCHICAL;
+#endif
         } else {
             RAISE_WARN_MSG("Ignoring bad barrier algorithm '%s'\n", type);
         }
@@ -418,6 +501,331 @@ shmem_internal_sync_dissem(int PE_start, int PE_stride, int PE_size, long *pSync
     /* Ensure local pSync decrements are done before a subsequent barrier */
     shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
+
+
+/*****************************************
+ *
+ * HIERARCHICAL BARRIER/SYNC
+ *
+ * Three-phase algorithm for USE_HIERARCHICAL_BARRIER builds:
+ *
+ * Phase 1 (intranode gather, CPU stores/loads via XPMEM):
+ *   All local PEs run an intranode dissemination barrier using plain
+ *   (non-atomic) stores and acquire-loads.  Each PE owns one cache-line-padded
+ *   slot (HIER_SLOT_STRIDE longs apart) so no two PEs share a cache line.
+ *   Sense alternation (hier_sense) removes the need for explicit slot resets.
+ *   ceil(log2(local_count)) rounds; each round: store signal to partner's slot,
+ *   spin-load own slot until partner's signal arrives.
+ *
+ * Phase 2 (internode, NIC puts, root PEs only):
+ *   Root PEs run a dissemination barrier among themselves using NIC puts
+ *   across per-round pSync slots (ceil(log2(N)) rounds). A shmem_quiet
+ *   after the last round ensures all outbound puts are retired before
+ *   phase 3.
+ *
+ * Phase 3 (intranode fanout, CPU stores/loads via XPMEM):
+ *   Same dissemination algorithm as phase 1, run in reverse sense so that the
+ *   "all clear" propagates back to all local PEs without NIC involvement.
+ *
+ *****************************************/
+#ifdef USE_HIERARCHICAL_BARRIER
+
+/* Count and list the PEs in the active set that reside on this node. */
+static void
+shmem_internal_build_local_set(int PE_start, int PE_stride, int PE_size,
+                                int *local_pes, int *local_count)
+{
+    int i, pe;
+    *local_count = 0;
+
+    for (i = 0, pe = PE_start; i < PE_size; i++, pe += PE_stride) {
+        if (shmem_internal_get_shr_rank(pe) != -1) {
+            local_pes[(*local_count)++] = pe;
+        }
+    }
+}
+
+/* Build an active set of root PEs (the lowest-ranked PE on each node) from
+ * the original active set.  shmem_runtime_get_node_rank() only returns the
+ * node-local rank for on-node PEs; for off-node PEs it returns -1.  We
+ * therefore use shmem_runtime_is_node_root_pe() which reflects each PE's
+ * absolute rank within its own node, computed during init via global exchange.
+ */
+static void
+shmem_internal_build_root_active_set(int PE_start, int PE_stride, int PE_size,
+                                     int *root_pes, int *root_count)
+{
+    int i, pe;
+    *root_count = 0;
+
+    for (i = 0, pe = PE_start; i < PE_size; i++, pe += PE_stride) {
+        if (shmem_runtime_is_node_root_pe(pe)) {
+            root_pes[(*root_count)++] = pe;
+        }
+    }
+}
+
+/* CPU atomic load of the long at `target` via local mapped pointer. */
+static inline long
+shmem_internal_cpu_atomic_load_long(long *target, int noderank)
+{
+    void *remote_ptr;
+    long val;
+    shmem_shr_transport_ptr(target, noderank, &remote_ptr);
+    __atomic_load((long *)remote_ptr, &val, __ATOMIC_ACQUIRE);
+    return val;
+}
+
+/* CPU atomic store of `val` to the long at `target` via local mapped pointer. */
+static inline void
+shmem_internal_cpu_atomic_store_long(long *target, int noderank, long val)
+{
+    void *remote_ptr;
+    shmem_shr_transport_ptr(target, noderank, &remote_ptr);
+    __atomic_store((long *)remote_ptr, &val, __ATOMIC_RELEASE);
+}
+
+void
+shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
+                                  long *pSync, long *local_pSync)
+{
+    int node_root_pe = shmem_internal_get_node_root_pe();
+    int is_root      = (shmem_internal_my_pe == node_root_pe);
+    int my_shr_rank  = shmem_runtime_get_node_rank(shmem_internal_my_pe);
+    long one = 1;
+
+    if (PE_size == 1) return;
+
+    /* Collect local and root PE sets for this active set */
+    int *local_pes = alloca(sizeof(int) * PE_size);
+    int local_count = 0;
+    shmem_internal_build_local_set(PE_start, PE_stride, PE_size,
+                                   local_pes, &local_count);
+
+    int *root_pes = alloca(sizeof(int) * PE_size);
+    int root_count = 0;
+    shmem_internal_build_root_active_set(PE_start, PE_stride, PE_size,
+                                         root_pes, &root_count);
+
+    /* Assign virtual indices 0..local_count-1, rotating so node_root_pe = vidx 0.
+     * Precompute tree parent shr_rank and children shr_ranks. */
+    int my_local_idx   = -1;
+    int root_local_idx = 0;
+    for (int i = 0; i < local_count; i++) {
+        if (local_pes[i] == shmem_internal_my_pe) my_local_idx = i;
+        if (local_pes[i] == node_root_pe)          root_local_idx = i;
+    }
+    int my_vidx = (my_local_idx >= 0)
+                  ? (my_local_idx - root_local_idx + local_count) % local_count
+                  : -1;
+
+    int  tree_parent_shr = -1;
+    int  tree_nchildren  = 0;
+    int *tree_child_shr  = alloca(sizeof(int) * tree_radix);
+    if (my_vidx >= 0) {
+        if (my_vidx > 0) {
+            tree_parent_shr = shmem_runtime_get_node_rank(
+                local_pes[((my_vidx - 1) / tree_radix + root_local_idx) % local_count]);
+        }
+        for (int j = 1; j <= tree_radix; j++) {
+            int cv = my_vidx * tree_radix + j;
+            if (cv < local_count) {
+                tree_child_shr[tree_nchildren++] = shmem_runtime_get_node_rank(
+                    local_pes[(cv + root_local_idx) % local_count]);
+            }
+        }
+    }
+
+    /* Sense-alternating signal — monotonically increasing, no slot resets needed.
+     * up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
+     * down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE] */
+    long signal   = SHMEM_SYNC_VALUE + 1 + hier_sense;
+    int  shr_size = shmem_internal_get_shr_size();
+    long *up_pSync   = local_pSync;
+    long *down_pSync = local_pSync + (long)(shr_size * HIER_SLOT_STRIDE);
+
+    /* Resolve own up-slot and down-slot mapped pointers once. */
+    void *my_up_raw, *my_down_raw;
+    shmem_shr_transport_ptr(&up_pSync[my_shr_rank * HIER_SLOT_STRIDE],   my_shr_rank, &my_up_raw);
+    shmem_shr_transport_ptr(&down_pSync[my_shr_rank * HIER_SLOT_STRIDE], my_shr_rank, &my_down_raw);
+    volatile long *my_up_slot   = (volatile long *)my_up_raw;
+    volatile long *my_down_slot = (volatile long *)my_down_raw;
+
+    /* ---- Degenerate case: all active PEs on one node ---- */
+    if (root_count <= 1 || local_count == PE_size) {
+        if (my_vidx < 0) return;
+
+        double t0 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* Phase 1: gather up tree — wait for children's up-slots, then signal parent */
+        for (int c = 0; c < tree_nchildren; c++) {
+            void *child_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                                    tree_child_shr[c], &child_up_raw);
+            volatile long *child_up = (volatile long *)child_up_raw;
+            long cur;
+            do {
+                __atomic_load(child_up, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+        }
+        if (my_vidx > 0) {
+            void *parent_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[my_shr_rank * HIER_SLOT_STRIDE],
+                                    my_shr_rank, &parent_up_raw);
+            __atomic_store((long *)parent_up_raw, &signal, __ATOMIC_RELEASE);
+        }
+
+        double t1 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* Phase 3: fanout — root stores to children's down-slots, non-roots wait then relay */
+        if (my_vidx == 0) {
+            for (int c = 0; c < tree_nchildren; c++) {
+                shmem_internal_cpu_atomic_store_long(
+                    &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                    tree_child_shr[c], signal);
+            }
+        } else {
+            long cur;
+            do {
+                __atomic_load(my_down_slot, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+            for (int c = 0; c < tree_nchildren; c++) {
+                shmem_internal_cpu_atomic_store_long(
+                    &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                    tree_child_shr[c], signal);
+            }
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double t2 = hier_now_us();
+            hier_phase1_us  += t1 - t0;
+            hier_phase3_us  += t2 - t1;
+            hier_call_count++;
+        }
+
+        hier_sense++;
+        return;
+    }
+
+    /* ---- Normal multi-node case ---- */
+
+    double mn_t0 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+    /* Phase 1: intranode gather (k-ary tree, bottom-up).
+     * Each PE waits on each child's up-slot, then writes its own up-slot.
+     * One writer per up-slot — no cache-line contention on the parent. */
+    if (my_vidx >= 0) {
+        for (int c = 0; c < tree_nchildren; c++) {
+            void *child_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                                    tree_child_shr[c], &child_up_raw);
+            volatile long *child_up = (volatile long *)child_up_raw;
+            long cur;
+            do {
+                __atomic_load(child_up, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+        }
+        if (my_vidx > 0) {
+            /* Signal parent by writing to OWN up-slot (parent reads it). */
+            __atomic_store((long *)my_up_raw, &signal, __ATOMIC_RELEASE);
+        }
+    }
+
+    double mn_t1 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+    if (is_root) {
+        /* ---- Phase 2: internode barrier (NIC puts, root PEs only) ---- */
+        if (root_count > 1) {
+            int my_root_idx = -1;
+            for (int i = 0; i < root_count; i++) {
+                if (root_pes[i] == shmem_internal_my_pe) { my_root_idx = i; break; }
+            }
+            shmem_internal_assert(my_root_idx >= 0);
+
+            int num_rounds = 0;
+            { int n = root_count - 1; while (n > 0) { n >>= 1; num_rounds++; } }
+            shmem_internal_assert(num_rounds <= SHMEM_BARRIER_SYNC_SIZE);
+
+            for (int r = 0; r < num_rounds; r++) {
+                int partner_idx = (my_root_idx + (1 << r)) % root_count;
+                int partner_pe  = root_pes[partner_idx];
+                shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, &pSync[r], &one,
+                                         sizeof(one), partner_pe);
+                SHMEM_WAIT(&pSync[r], SHMEM_SYNC_VALUE);
+                __atomic_store_n(&pSync[r], SHMEM_SYNC_VALUE, __ATOMIC_RELEASE);
+            }
+        }
+
+        shmem_internal_quiet(SHMEM_CTX_DEFAULT);
+
+        double mn_t2 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* ---- Phase 3: intranode fanout (k-ary tree, top-down via down-slots) ---- */
+        for (int c = 0; c < tree_nchildren; c++) {
+            shmem_internal_cpu_atomic_store_long(
+                &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                tree_child_shr[c], signal);
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double mn_t3 = hier_now_us();
+            hier_phase1_us  += mn_t1 - mn_t0;
+            hier_phase2_us  += mn_t2 - mn_t1;
+            hier_phase3_us  += mn_t3 - mn_t2;
+            hier_call_count++;
+        }
+
+    } else if (my_vidx >= 0) {
+        /* Non-root: wait on own down-slot for parent's signal, then relay to children. */
+        long cur;
+        do {
+            __atomic_load(my_down_slot, &cur, __ATOMIC_ACQUIRE);
+            if (cur != signal) { SPINLOCK_BODY(); }
+        } while (cur != signal);
+
+        for (int c = 0; c < tree_nchildren; c++) {
+            shmem_internal_cpu_atomic_store_long(
+                &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                tree_child_shr[c], signal);
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double mn_t3 = hier_now_us();
+            hier_phase1_us  += mn_t1 - mn_t0;
+            hier_phase3_us  += mn_t3 - mn_t1;
+            hier_call_count++;
+        }
+    }
+
+    if (my_vidx >= 0) { hier_sense++; }
+    /* PEs absent from local_pes (my_vidx < 0) fall through silently. */
+}
+
+void
+shmem_internal_hier_barrier_print_stats(void)
+{
+    if (!shmem_internal_params.HIER_BARRIER_DEBUG) return;
+    if (hier_call_count == 0) return;
+
+    /* Each PE prints its own per-phase averages.  At scale the output can be
+     * large; the caller should fence/barrier before this so the lines don't
+     * interleave badly, but we keep this simple intentionally. */
+    fprintf(stderr,
+            "[PE %d] hier_barrier calls=%ld  "
+            "phase1(gather)=%.2f us  phase2(internode)=%.2f us  "
+            "phase3(fanout)=%.2f us  total=%.2f us\n",
+            shmem_internal_my_pe,
+            hier_call_count,
+            hier_phase1_us / hier_call_count,
+            hier_phase2_us / hier_call_count,
+            hier_phase3_us / hier_call_count,
+            (hier_phase1_us + hier_phase2_us + hier_phase3_us) / hier_call_count);
+}
+
+#endif /* USE_HIERARCHICAL_BARRIER */
 
 
 /*****************************************

--- a/src/init.c
+++ b/src/init.c
@@ -147,6 +147,10 @@ shmem_internal_shutdown(void)
 
     shmem_internal_finalized = 1;
 
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_hier_barrier_print_stats();
+#endif
+
     shmem_internal_team_fini();
 
     shmem_transport_fini();
@@ -519,6 +523,20 @@ shmem_internal_heap_postinit(void)
 
     atexit(shmem_internal_shutdown_atexit);
     shmem_internal_initialized = 1;
+
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_my_pe == 0) {
+        const char *effective_barrier =
+            (shmem_internal_barrier_type == AUTO &&
+             shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD)
+            ? "HIERARCHICAL (auto-selected)"
+            : coll_type_str[shmem_internal_barrier_type];
+
+        DEBUG_MSG("Hierarchical barrier enabled: intranode CPU atomics + internode NIC puts\n"
+                  RAISE_PE_PREFIX "Barrier algorithm: %s\n",
+                  shmem_internal_my_pe, effective_barrier);
+    }
+#endif
 
     /* finish up */
 #ifndef USE_PMIX

--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -38,6 +38,7 @@ static int kv_length = 0;
 static int initialized_mpi = 0;
 static int node_size;
 static int *node_ranks;
+static int *is_node_root = NULL;
 
 char* kv_store_me;
 char* kv_store_all;
@@ -103,6 +104,10 @@ shmem_runtime_init(int enable_node_ranks)
     if (size > 1 && enable_node_ranks) {
         node_ranks = malloc(size * sizeof(int));
         if (NULL == node_ranks) return 8;
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = malloc(size * sizeof(int));
+        if (NULL == is_node_root) return 9;
+#endif
     }
 
     return 0;
@@ -117,6 +122,7 @@ shmem_runtime_fini(void)
     if (node_ranks) {
         MPI_Comm_free(&SHMEM_RUNTIME_SHARED);
         free(node_ranks);
+        free(is_node_root);
     }
 
     MPI_Comm_free(&SHMEM_RUNTIME_WORLD);
@@ -203,10 +209,43 @@ shmem_runtime_get_node_size(void)
 }
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (node_ranks[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+int
 shmem_runtime_exchange(void)
 {
     if (size == 1) {
         kv_store_all = kv_store_me;
+        if (is_node_root) is_node_root[0] = 1;
         return 0;
     }
 
@@ -231,6 +270,26 @@ shmem_runtime_exchange(void)
         MPI_Group_free(&world_group);
         MPI_Group_free(&node_group);
         free(world_ranks);
+
+#ifdef USE_HIERARCHICAL_BARRIER
+        /* Exchange absolute node ranks to identify node roots across all nodes.
+         * node_ranks[pe] is the rank of PE pe in the CALLING PE's node group;
+         * for off-node PEs it is MPI_UNDEFINED.  We need each PE's rank in its
+         * OWN node group, so gather those now. */
+        int my_node_rank;
+        MPI_Comm_rank(SHMEM_RUNTIME_SHARED, &my_node_rank);
+
+        int *abs_node_ranks = malloc(size * sizeof(int));
+        if (NULL == abs_node_ranks) return 2;
+
+        MPI_Allgather(&my_node_rank, 1, MPI_INT,
+                      abs_node_ranks, 1, MPI_INT, SHMEM_RUNTIME_WORLD);
+
+        for (int i = 0; i < size; i++)
+            is_node_root[i] = (abs_node_ranks[i] == 0) ? 1 : 0;
+
+        free(abs_node_ranks);
+#endif
     }
 
     int chunkSize = kv_length * sizeof(char) * MAX_KV_LENGTH;

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -38,6 +38,7 @@ static char *kvs_name, *kvs_key, *kvs_value;
 static int max_name_len, max_key_len, max_val_len;
 static int initialized_pmi = 0;
 static int *location_array = NULL;
+static int *is_node_root = NULL;
 
 #define SINGLETON_KEY_LEN 128
 #define SINGLETON_VAL_LEN 1024
@@ -96,6 +97,10 @@ shmem_runtime_init(int enable_node_ranks)
         if (enable_node_ranks) {
             location_array = malloc(sizeof(int) * size);
             if (NULL == location_array) return 10;
+#ifdef USE_HIERARCHICAL_BARRIER
+            is_node_root = malloc(sizeof(int) * size);
+            if (NULL == is_node_root) return 11;
+#endif
         }
     }
     else {
@@ -120,6 +125,7 @@ int
 shmem_runtime_fini(void)
 {
     free(location_array);
+    free(is_node_root);
     free(kvs_name);
     free(kvs_key);
     free(kvs_value);
@@ -195,6 +201,40 @@ shmem_runtime_get_node_size(void)
 
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (location_array[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+
+int
 shmem_runtime_exchange(void)
 {
     int ret;
@@ -224,6 +264,13 @@ shmem_runtime_exchange(void)
         if (0 != ret) {
             RETURN_ERROR_MSG("Node PE mapping failed (%d)\n", ret);
             return 7;
+        }
+    }
+    if (is_node_root) {
+        ret = shmem_runtime_util_populate_global_node_roots(is_node_root, size);
+        if (0 != ret) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return 8;
         }
     }
 

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -42,6 +42,7 @@ static char *kvs_name, *kvs_key, *kvs_value;
 static int max_name_len, max_key_len, max_val_len;
 static int initialized_pmi = 0;
 static int *location_array = NULL;
+static int *is_node_root = NULL;
 
 
 int
@@ -77,6 +78,10 @@ shmem_runtime_init(int enable_node_ranks)
     if (enable_node_ranks) {
         location_array = malloc(sizeof(int) * size);
         if (NULL == location_array) return 8;
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = malloc(sizeof(int) * size);
+        if (NULL == is_node_root) return 9;
+#endif
     }
 
     return 0;
@@ -88,6 +93,9 @@ shmem_runtime_fini(void)
 {
     if (location_array) {
         free(location_array);
+    }
+    if (is_node_root) {
+        free(is_node_root);
     }
 
     if (initialized_pmi == 1) {
@@ -146,6 +154,40 @@ shmem_runtime_get_node_size(void)
 
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (location_array[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+
+int
 shmem_runtime_exchange(void)
 {
     int ret;
@@ -167,6 +209,13 @@ shmem_runtime_exchange(void)
         if (0 != ret) {
             RETURN_ERROR_MSG("Node PE mapping failed (%d)\n", ret);
             return 7;
+        }
+    }
+    if (is_node_root) {
+        ret = shmem_runtime_util_populate_global_node_roots(is_node_root, size);
+        if (0 != ret) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return 8;
         }
     }
 

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -37,6 +37,7 @@ static pmix_proc_t myproc;
 static uint32_t size;
 static uint32_t node_size = 0;
 static int *node_ranks = NULL;
+static int *is_node_root = NULL;
 
 int
 shmem_runtime_init(int enable_node_ranks)
@@ -69,6 +70,13 @@ shmem_runtime_init(int enable_node_ranks)
             RETURN_ERROR_MSG_PREINIT("Out of memory allocating node_ranks\n");
             return 1;
         }
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = (int *)malloc(size * sizeof(int));
+        if (NULL == is_node_root) {
+            RETURN_ERROR_MSG_PREINIT("Out of memory allocating is_node_root\n");
+            return 2;
+        }
+#endif
     }
 
     return PMIX_SUCCESS;
@@ -82,6 +90,8 @@ shmem_runtime_fini(void)
 
     if (node_ranks)
         free(node_ranks);
+    if (is_node_root)
+        free(is_node_root);
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
         RETURN_ERROR_MSG_PREINIT("PMIx_Finalize failed (%d)\n", rc);
@@ -143,13 +153,36 @@ shmem_runtime_get_node_size(void)
     return (int) node_size;
 }
 
-// static void opcbfunc(pmix_status_t status, void *cbdata)
-// {
-//     bool *active = (bool*)cbdata;
 
-//     fprintf(stderr, "%s:%d completed fence_nb", myproc.nspace, myproc.rank);
-//     *active = false;
-// }
+int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    for (i = 0; i < (int) size; i++) {
+        if (node_ranks[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < (int) size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
 
 int
 shmem_runtime_exchange(void)
@@ -157,7 +190,6 @@ shmem_runtime_exchange(void)
     pmix_status_t rc;
     pmix_info_t info;
     bool wantit=true;
-    //bool active = true;
 
     if (node_ranks) {
         pmix_proc_t proc;
@@ -198,6 +230,16 @@ shmem_runtime_exchange(void)
         } else {
            RETURN_ERROR_MSG_PREINIT("PMIX_LOCAL_PEERS is not properly initiated (%d)\n", rc);
         }
+
+        /* Publish hostname so shmem_runtime_util_populate_global_node_roots can
+         * determine which PEs are node roots across all nodes. */
+        if (is_node_root) {
+            int ret = shmem_runtime_util_put_hostname();
+            if (ret != 0) {
+                RETURN_ERROR_MSG("PMIx hostname put failed (%d)\n", ret);
+                return ret;
+            }
+        }
     }
 
     /* commit any values we "put" */
@@ -206,20 +248,21 @@ shmem_runtime_exchange(void)
         return rc;
     }
 
-    /* execute a fence, directing that all info be exchanged */
     PMIX_INFO_CONSTRUCT(&info);
     PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &wantit, PMIX_BOOL);
 
-    // Future optimization for when fabrics are ready to support the non-block-
-    // ing capabilities. The commented out call function above, the commented
-    // variable "bool active," and the PMIx_Fence_nb if-statement are here for
-    // when that is ready. Current implementations will cause the test to hang.
-
-    // if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, &info, 1, opcbfunc, &active))) {
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
         RETURN_ERROR_MSG("PMIx_Fence failed (%d)\n", rc);
     }
     PMIX_INFO_DESTRUCT(&info);
+
+    if (is_node_root) {
+        int ret = shmem_runtime_util_populate_global_node_roots(is_node_root, (int) size);
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return ret;
+        }
+    }
 
     return rc;
 }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -31,6 +31,7 @@ int shmem_runtime_get_size(void);
  * (use shmem_internal_get_shr_rank/size for such queries). */
 int shmem_runtime_get_node_rank(int pe);
 int shmem_runtime_get_node_size(void);
+int shmem_runtime_get_node_root_pe(void);
 
 int shmem_runtime_exchange(void);
 int shmem_runtime_put(char *key, void *value, size_t valuelen);
@@ -41,6 +42,11 @@ void shmem_runtime_barrier(void);
 /* Utility functions used to implement the runtime layer */
 int shmem_runtime_util_put_hostname(void);
 int shmem_runtime_util_populate_node(int *location_array, int size, int *node_size);
+int shmem_runtime_util_populate_global_node_roots(int *is_node_root, int size);
+
+/* Returns 1 if PE pe is the lowest-ranked PE on its own node, 0 otherwise.
+ * Valid after shmem_runtime_exchange(). */
+int shmem_runtime_is_node_root_pe(int pe);
 
 int shmem_runtime_util_encode(const void *inval, int invallen, char *outval, int outvallen);
 int shmem_runtime_util_decode(const char *inval, void *outval, size_t outvallen);

--- a/src/runtime_util.c
+++ b/src/runtime_util.c
@@ -164,3 +164,68 @@ int shmem_runtime_util_populate_node(int *location_array, int size, int *node_si
 
     return 0;
 }
+
+
+/* Populate is_node_root[pe] = 1 if PE pe is the lowest-ranked (first) PE on
+ * its node, 0 otherwise.  This determines which PEs act as internode
+ * representatives in the hierarchical barrier.
+ *
+ * Must be called after shmem_runtime_util_put_hostname and a runtime exchange,
+ * so that every PE's hostname is readable via shmem_runtime_get. */
+int
+shmem_runtime_util_populate_global_node_roots(int *is_node_root, int size)
+{
+    int ret = 0;
+    char **hostnames = (char **) malloc(size * sizeof(char *));
+    size_t *hlens   = (size_t *) malloc(size * sizeof(size_t));
+
+    if (!hostnames || !hlens) {
+        free(hostnames);
+        free(hlens);
+        RETURN_ERROR_MSG("Out of memory allocating hostname arrays\n");
+        return 1;
+    }
+
+    for (int pe = 0; pe < size; pe++) {
+        hostnames[pe] = NULL;
+    }
+
+    for (int pe = 0; pe < size; pe++) {
+        ret = shmem_runtime_get(pe, "hostname_len", &hlens[pe], sizeof(size_t));
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Failed to get hostname_len for PE %d (%d)\n", pe, ret);
+            goto cleanup;
+        }
+        hostnames[pe] = (char *) malloc(hlens[pe] + 1);
+        if (!hostnames[pe]) {
+            RETURN_ERROR_MSG("Out of memory for hostname of PE %d\n", pe);
+            ret = 2;
+            goto cleanup;
+        }
+        ret = shmem_runtime_get(pe, "hostname", hostnames[pe], hlens[pe]);
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Failed to get hostname for PE %d (%d)\n", pe, ret);
+            goto cleanup;
+        }
+    }
+
+    /* PE pe is a node root if no earlier PE (q < pe) has the same hostname. */
+    for (int pe = 0; pe < size; pe++) {
+        is_node_root[pe] = 1;
+        for (int q = 0; q < pe; q++) {
+            if (hlens[pe] == hlens[q] &&
+                memcmp(hostnames[pe], hostnames[q], hlens[pe]) == 0) {
+                is_node_root[pe] = 0;
+                break;
+            }
+        }
+    }
+
+cleanup:
+    for (int pe = 0; pe < size; pe++) {
+        free(hostnames[pe]);
+    }
+    free(hostnames);
+    free(hlens);
+    return ret;
+}

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -25,7 +25,8 @@ enum coll_type_t {
     TREE,
     DISSEM,
     RING,
-    RECDBL
+    RECDBL,
+    HIERARCHICAL
 };
 typedef enum coll_type_t coll_type_t;
 
@@ -33,6 +34,11 @@ extern char *coll_type_str[];
 
 extern long *shmem_internal_barrier_all_psync;
 extern long *shmem_internal_sync_all_psync;
+#ifdef USE_HIERARCHICAL_BARRIER
+extern long *shmem_internal_barrier_all_local_psync;
+extern long *shmem_internal_sync_all_local_psync;
+extern long *shmem_internal_hierarchical_local_psync;
+#endif
 
 extern coll_type_t shmem_internal_barrier_type;
 extern coll_type_t shmem_internal_bcast_type;
@@ -44,6 +50,11 @@ extern coll_type_t shmem_internal_fcollect_type;
 void shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync);
 void shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync);
 void shmem_internal_sync_dissem(int PE_start, int PE_stride, int PE_size, long *pSync);
+#ifdef USE_HIERARCHICAL_BARRIER
+void shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
+                                      long *pSync, long *local_pSync);
+void shmem_internal_hier_barrier_print_stats(void);
+#endif
 
 static inline
 void
@@ -58,6 +69,14 @@ shmem_internal_sync(int PE_start, int PE_stride, int PE_size, long *pSync)
 
     switch (shmem_internal_barrier_type) {
     case AUTO:
+#ifdef USE_HIERARCHICAL_BARRIER
+        if (shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+            shmem_internal_sync_hierarchical(PE_start, PE_stride, PE_size,
+                                             pSync,
+                                             shmem_internal_hierarchical_local_psync);
+            break;
+        }
+#endif
         if (PE_size < shmem_internal_params.COLL_CROSSOVER) {
             shmem_internal_sync_linear(PE_start, PE_stride, PE_size, pSync);
         } else {
@@ -73,6 +92,13 @@ shmem_internal_sync(int PE_start, int PE_stride, int PE_size, long *pSync)
     case DISSEM:
         shmem_internal_sync_dissem(PE_start, PE_stride, PE_size, pSync);
         break;
+#ifdef USE_HIERARCHICAL_BARRIER
+    case HIERARCHICAL:
+        shmem_internal_sync_hierarchical(PE_start, PE_stride, PE_size,
+                                         pSync,
+                                         shmem_internal_hierarchical_local_psync);
+        break;
+#endif
     default:
         RAISE_ERROR_MSG("Illegal barrier/sync type (%d)\n",
                         shmem_internal_barrier_type);
@@ -88,6 +114,17 @@ static inline
 void
 shmem_internal_sync_all(void)
 {
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_barrier_type == AUTO &&
+        shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+        shmem_internal_sync_hierarchical(0, 1, shmem_internal_num_pes,
+                                         shmem_internal_sync_all_psync,
+                                         shmem_internal_sync_all_local_psync);
+        shmem_internal_membar_acq_rel();
+        shmem_transport_syncmem();
+        return;
+    }
+#endif
     shmem_internal_sync(0, 1, shmem_internal_num_pes, shmem_internal_sync_all_psync);
 }
 
@@ -106,6 +143,17 @@ void
 shmem_internal_barrier_all(void)
 {
     shmem_internal_quiet(SHMEM_CTX_DEFAULT);
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_barrier_type == AUTO &&
+        shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+        shmem_internal_sync_hierarchical(0, 1, shmem_internal_num_pes,
+                                         shmem_internal_barrier_all_psync,
+                                         shmem_internal_barrier_all_local_psync);
+        shmem_internal_membar_acq_rel();
+        shmem_transport_syncmem();
+        return;
+    }
+#endif
     shmem_internal_sync(0, 1, shmem_internal_num_pes, shmem_internal_barrier_all_psync);
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -80,12 +80,29 @@ shmem_internal_put_signal_nbi(shmem_ctx_t ctx, void *target, const void *source,
                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
 {
     if (len == 0) {
-        if (sig_op == SHMEM_SIGNAL_ADD)
-            shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal, sizeof(uint64_t),
-                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
-        else
-            shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
-                                      sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+        /* Signal-only (no data): use shmem_shr_transport_use_atomic() to pick
+         * the right plane.  In the multi-node case this always resolves to the
+         * NIC (preserving FIFO ordering with any prior in-flight NIC puts and
+         * avoiding the CPU/NIC coherency hazard).  In the all-PEs-on-one-node
+         * case it resolves to CPU atomics, consistent with data puts. */
+        if (sig_op == SHMEM_SIGNAL_ADD) {
+            if (shmem_shr_transport_use_atomic(ctx, sig_addr, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64))
+                shmem_shr_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                           pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+            else
+                shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
+                                       sizeof(uint64_t), pe, SHM_INTERNAL_SUM,
+                                       SHM_INTERNAL_UINT64);
+        } else {
+            if (shmem_shr_transport_use_atomic(ctx, sig_addr, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64))
+                shmem_shr_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64);
+            else
+                shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
+                                           sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+        }
         return;
     }
 

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -58,7 +58,11 @@ SHMEM_INTERNAL_ENV_DEF(COLL_SIZE_CROSSOVER, size, 16384, SHMEM_INTERNAL_ENV_CAT_
 SHMEM_INTERNAL_ENV_DEF(COLL_RADIX, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Radix for tree-based collectives")
 SHMEM_INTERNAL_ENV_DEF(BARRIER_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
-                       "Algorithm for barrier.  Options are auto, linear, tree, dissem")
+                       "Algorithm for barrier.  Options are auto, linear, tree, dissem, hierarchical")
+SHMEM_INTERNAL_ENV_DEF(HIER_BARRIER_THRESHOLD, long, 2, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
+                       "Minimum local PE count per node to auto-select the hierarchical barrier")
+SHMEM_INTERNAL_ENV_DEF(HIER_BARRIER_DEBUG, bool, 0, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
+                       "Print per-phase hierarchical barrier timing at finalize")
 SHMEM_INTERNAL_ENV_DEF(BCAST_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Algorithm for broadcast.  Options are auto, linear, tree")
 SHMEM_INTERNAL_ENV_DEF(REDUCE_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -546,6 +546,17 @@ static inline int shmem_internal_get_shr_size(void)
 #endif
 }
 
+/* Return the global PE rank of the lowest-ranked PE on this node (node_rank==0).
+ * Used as the internode representative in hierarchical collectives. */
+static inline int shmem_internal_get_node_root_pe(void)
+{
+#ifdef USE_ON_NODE_COMMS
+    return shmem_runtime_get_node_root_pe();
+#else
+    return shmem_internal_my_pe;
+#endif
+}
+
 static inline double shmem_internal_wtime(void)
 {
     double wtime = 0.0;

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -85,6 +85,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_world.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_world.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_world.hier_sense     = 0;
+#endif
     SHMEM_TEAM_WORLD = (shmem_team_t) &shmem_internal_team_world;
 
     /* Initialize SHMEM_TEAM_SHARED */
@@ -95,6 +98,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_shared.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_shared.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_shared.hier_sense    = 0;
+#endif
     SHMEM_TEAM_SHARED = (shmem_team_t) &shmem_internal_team_shared;
 
     /* Initialize SHMEM_TEAM_NODE */
@@ -105,6 +111,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_node.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_node.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_node.hier_sense      = 0;
+#endif
     SHMEMX_TEAM_NODE = (shmem_team_t) &shmem_internal_team_node;
 
     if (shmem_internal_params.TEAM_SHARED_ONLY_SELF) {

--- a/src/shmem_team.h
+++ b/src/shmem_team.h
@@ -26,6 +26,9 @@ struct shmem_internal_team_t {
     long                           config_mask;
     size_t                         contexts_len;
     struct shmem_transport_ctx_t **contexts;
+#ifdef USE_HIERARCHICAL_BARRIER
+    long                           hier_sense;
+#endif
 };
 typedef struct shmem_internal_team_t shmem_internal_team_t;
 

--- a/src/shr_transport.h4
+++ b/src/shr_transport.h4
@@ -122,12 +122,24 @@ shmem_shr_transport_use_read(shmem_ctx_t ctx, void *target, const void *source,
 /* Each OpenSHMEM AMO has only one symmetric pointer.  Check whether shared
  * transport AMOs are in use with respect to the given symmetric target
  * pointer and datatype. For a given datatype, all atomic operations must
- * use the same transport; therefore, op is not needed in this check. */
+ * use the same transport; therefore, op is not needed in this check.
+ *
+ * Under USE_HIERARCHICAL_BARRIER, CPU atomics and NIC AMOs are not coherent
+ * with each other; mixing them on the same variable produces lost updates.
+ * CPU atomics are therefore only safe when ALL PEs are on the same node —
+ * in that case no NIC AMOs will ever be issued to any variable, so there is
+ * only one coherency domain in play. */
 static inline int
 shmem_shr_transport_use_atomic(shmem_ctx_t ctx, void *target, size_t len,
                                int pe, shm_internal_datatype_t datatype)
 {
-#if USE_SHR_ATOMICS
+#if USE_HIERARCHICAL_BARRIER
+    /* Use CPU atomics only when all PEs are local (no off-node peers). */
+    if (shmem_internal_get_shr_size() == shmem_internal_num_pes) {
+        return -1 != shmem_internal_get_shr_rank(pe);
+    }
+    return 0;
+#elif USE_SHR_ATOMICS
     return -1 != shmem_internal_get_shr_rank(pe);
 #else
     return 0;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1650,6 +1650,10 @@ int query_for_fabric(struct fabric_info *info)
 #endif
 
 #ifndef DISABLE_OFI_INJECT
+    DEBUG_MSG(RAISE_PE_PREFIX "tx_attr->inject_size (provider): %zu, requested: %zu\n",
+              shmem_internal_my_pe,
+              info->p_info->tx_attr->inject_size,
+              shmem_transport_ofi_max_buffered_send);
     shmem_internal_assertp(info->p_info->tx_attr->inject_size >= shmem_transport_ofi_max_buffered_send);
     shmem_transport_ofi_max_buffered_send = info->p_info->tx_attr->inject_size;
 #else


### PR DESCRIPTION
## Summary

  Adds a three-phase hierarchical barrier (--enable-hierarchical-barrier) that keeps intranode traffic off the NIC: phases 1 and 3 use CPU atomics over XPMEM; phase 2 restricts NIC puts to node roots only.

  - Phase 1 (gather): PEs signal up a k-ary tree. Each PE writes to its own cache-line-padded slot (HIER_SLOT_STRIDE=8 longs), so no two PEs share a line — eliminating
  the MESI serialization of a shared counter.
  - Phase 2 (internode): node roots run a put-based binary dissemination. Each round's slot is reset via CPU store rather than a self-put, saving ceil(log2(N_nodes)) NIC
  round-trips per barrier.
  - Phase 3 (fanout): node root stores an ack to each child's down-slot; children relay down the tree with reset-before-signal ordering.

  AUTO selection activates when local PE count ≥ SHMEM_HIER_BARRIER_THRESHOLD (default 2). Also selectable via SHMEM_BARRIER_ALGORITHM=hierarchical.

## Test plan

  - Build: --enable-hierarchical-barrier --with-xpmem --with-ofi
  - make check with SHMEM_BARRIER_ALGORITHM=hierarchical
  - hierarchical_barrier unit test at NP=2, NP=8, NP=128 — https://github.com/openshmem-org/tests-sos/pull/62
  - shmem_barrier_perf vs dissemination baseline at PPN ≥ 64
