### PR TITLE
Issue #1230: transport/ofi: do not constrain inject_size hint to sizeof(long double)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,7 +537,6 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
-       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -537,6 +537,7 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
+       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1470,7 +1470,9 @@ int query_for_fabric(struct fabric_info *info)
     struct fi_fabric_attr fabric_attr = {0};
     struct fi_ep_attr   ep_attr = {0};
 
-    shmem_transport_ofi_max_buffered_send = sizeof(long double);
+    /* Hint 0 = no minimum inject requirement; provider returns its natural
+     * inject_size, which is adopted below after fi_getinfo. */
+    shmem_transport_ofi_max_buffered_send = 0;
 
     fabric_attr.prov_name = info->prov_name;
 


### PR DESCRIPTION
 ## Summary

Addresses Issue #1230.

  - `query_for_fabric` previously initialized `shmem_transport_ofi_max_buffered_send = sizeof(long double)` before calling `fi_getinfo`, which passed that value as
  `tx_attr.inject_size` — telling the provider it *must* support at least 16-byte inject. This caused `fi_getinfo` to filter out providers that advertise a smaller
  natural inject size.
  - This change sets the hint to 0 (no minimum constraint) so the provider reports its natural `inject_size`. The returned value is immediately adopted after
  `fi_getinfo`, and the existing assert (`inject_size >= max_buffered_send`) trivially holds since both are 0 at that point.
  - On providers where the natural inject size is smaller than 16 bytes, the previous behavior could silently fail to select an otherwise valid endpoint, or cause
  `fi_getinfo` to return an inflated `inject_size` that doesn't reflect actual NIC capability.

  ## Test plan

  - [ ] Build and `make check` with CXI provider
  - [ ] Build and `make check` with verbs provider
  - [ ] Confirm `shmem_transport_ofi_max_buffered_send` value logged at startup reflects the provider's natural inject size
  - [ ] Verify no regression in small-message latency (inject path still engaged for messages <= provider's natural inject size)