### PR TITLE
Add 2MB Huge Page Support for Symmetric Heap + CXI Fence Optimization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,156 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+Sandia OpenSHMEM (SOS) is a C implementation of the [OpenSHMEM specification](http://openshmem.org/) for Partitioned Global Address Space (PGAS) parallel programming. It runs over three network transports — **OFI (libfabric)**, **Portals 4**, and **UCX** — with optional on-node acceleration via **XPMEM** or **CMA**. Exactly one network transport must be selected at configure time.
+
+Target deployment scale: PPN >= 104, thousands of nodes. Evaluate all algorithm and data structure tradeoffs at this scale.
+
+## Build
+
+```bash
+./autogen.sh                          # Only needed after fresh clone or configure.ac changes
+./configure --with-ofi=<DIR> --enable-pmi-simple
+make -j$(nproc)
+make install
+```
+
+Key configure flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--with-ofi=<DIR>` | OFI/libfabric transport (most common) |
+| `--with-portals4=<DIR>` | Portals 4 transport |
+| `--with-ucx=<DIR>` | UCX transport |
+| `--with-xpmem=<DIR>` | XPMEM on-node optimization |
+| `--with-cma` | CMA on-node optimization |
+| `--enable-pmi-simple` | Bundled PMI 1.0 client (works with MPICH/Hydra/SLURM) |
+| `--enable-pmi-mpi CC=mpicc` | Use MPI for process management |
+| `--enable-error-checking` | Runtime argument validation |
+| `--enable-remote-virtual-addressing` | Performance optimization (assumes symmetric virtual addresses) |
+| `--enable-mr-endpoint` | Use FI_MR_ENDPOINT (required for CXI provider) |
+| `--enable-mr-local` | Use FI_MR_LOCAL to require local MR descriptors in RMA operations |
+| `--enable-debug` | Debug symbols |
+| `--enable-picky` | Strict compiler warnings (developer mode; replaces a dedicated lint target) |
+| `--disable-fortran` | Skip Fortran bindings |
+
+## Tests
+
+```bash
+make check                             # Full test suite
+make check NPROCS=4                    # Override number of PEs
+make check TEST_RUNNER="mpiexec -n 4 -ppn 2 -hosts node1,node2"
+```
+
+Run a single test after `make install`:
+```bash
+oshrun -n 4 ./modules/tests-sos/test/unit/shmem_put_get
+```
+
+Tests live in the `modules/tests-sos/` git submodule under `test/unit/`, `test/apps/`, `test/performance/`, and `test/shmemx/`.
+
+## Architecture
+
+```
+Public API (shmem.h / pshmem.h)         ← generated from mpp/*.h4 via M4
+        ↓
+API Implementations (src/init_c.c, src/data_c.c4, src/atomic_c.c4, …)
+        ↓
+Transport Abstraction (src/transport.h)  ← compile-time dispatch
+        ↓                                    (USE_OFI / USE_PORTALS4 / USE_UCX)
+Network Transport                        Runtime/PMI Layer
+  transport_ofi.c                          runtime-pmi.c
+  transport_portals4.c                     runtime-pmi2.c
+  transport_ucx.c                          runtime-pmix.c
+                                           runtime-mpi.c
+        ↓
+On-node Transport (optional, layered on top)
+  transport_xpmem.c / transport_cma.c
+```
+
+### Key directories
+
+| Directory | Role |
+|-----------|------|
+| `src/` | Core library (`libsma`): transport, runtime, collectives, init, memory |
+| `mpp/` | Public header templates (`.h4`) — `shmem.h`, `shmemx.h`, `pshmem.h` |
+| `bindings/` | M4 macros for type-generic binding generation |
+| `pmi-simple/` | Bundled PMI 1.0 client for `--enable-pmi-simple` builds |
+| `modules/tests-sos/` | Test suite (git submodule) |
+| `examples/` | Minimal usage examples (`hello.c`, `pi.c`) |
+| `scripts/` | CI helpers, man page generation, build convenience scripts |
+
+### Transport abstraction
+
+`src/transport.h` selects the active transport at compile time via `#ifdef USE_OFI / USE_PORTALS4 / USE_UCX`. All transports implement the same inline function interface declared in their respective `transport_*.h` headers. When adding transport-level features, apply changes consistently across all three transports (and `transport_none.c` for the no-transport stub).
+
+### Runtime/PMI layer
+
+`src/runtime.h` declares the runtime interface. Exactly one of `runtime-pmi.c`, `runtime-pmi2.c`, `runtime-pmix.c`, or `runtime-mpi.c` is compiled in, selected by configure flags. Handles PE discovery, KVS exchange, and barriers during `shmem_init()`.
+
+### Collectives
+
+`src/collectives.c` and `src/shmem_collectives.h` implement barrier, broadcast, reduction, scan, collect, and fcollect. Each operation has a `coll_type_t` (AUTO, LINEAR, TREE, DISSEM, RING, RECDBL) selectable at runtime via `SHMEM_` env vars. AUTO selects based on `SHMEM_COLL_CROSSOVER` (default 4 PEs) and `SHMEM_COLL_SIZE_CROSSOVER` (default 16 KB). The k-ary tree builder (`shmem_internal_build_kary_tree`) is shared across tree-based algorithms; radix is controlled by `SHMEM_COLL_RADIX` (default 4).
+
+## Code Generation (M4 Templates)
+
+Many `src/` files and all `mpp/` headers are **generated from M4 templates** — do not edit generated files directly.
+
+| Template | Generated output |
+|----------|-----------------|
+| `src/*.c4` | `src/*.c` |
+| `mpp/*.h4`, `src/shr_transport.h4` | `*.h` |
+
+Templates `include(shmem_bind_c.m4)` (and Fortran/C11 variants) from `bindings/` to expand type-generic macros. Running `make` regenerates them automatically. Generated files carry `/* This is a generated file, do not edit directly. */`.
+
+## Key Conventions
+
+### Naming prefixes
+
+| Prefix | Scope |
+|--------|-------|
+| `shmem_internal_` | Internal implementation; not public API |
+| `shmem_transport_` | Transport layer |
+| `shmem_runtime_` | Runtime/PMI layer |
+| `shmemx_` | Extended/experimental (non-standard) API |
+| `pshmem_` | Profiling API wrappers |
+
+### Internal header guard
+
+Internal source files must define `SHMEM_INTERNAL_INCLUDE` before including `shmem.h`:
+```c
+#define SHMEM_INTERNAL_INCLUDE
+#include "shmem.h"
+#include "shmem_internal.h"
+```
+
+### Error handling
+
+Use macros from `shmem_internal.h` rather than `abort()`/`exit()`:
+```c
+RAISE_ERROR(ret)             // non-zero return code
+RAISE_ERROR_STR("message")   // string message
+RAISE_ERROR_MSG("fmt", ...)  // printf-style message
+```
+
+### Symmetric heap globals
+
+`shmem_internal_heap_base` / `shmem_internal_heap_length` and `shmem_internal_data_base` / `shmem_internal_data_length` are set during `shmem_init()`. Pointer validity checks use macros in `shmem_internal.h`.
+
+### Runtime environment variables
+
+Controlled via `SHMEM_`-prefixed env vars defined in `src/shmem_env_defs.h` using the `SHMEM_INTERNAL_ENV_DEF` macro. Key ones for collective tuning: `SHMEM_BARRIER_ALGORITHM`, `SHMEM_BCAST_ALGORITHM`, `SHMEM_REDUCE_ALGORITHM`, `SHMEM_FCOLLECT_ALGORITHM`, `SHMEM_COLL_RADIX`, `SHMEM_COLL_CROSSOVER`, `SHMEM_SYMMETRIC_SIZE`.
+
+### File mode lines
+
+C source files begin with `/* -*- C -*- */`. M4 templates begin with `dnl vi: set ft=m4`.
+
+### Compiler wrappers
+
+After install: `oshcc` / `oshc++` / `oshfort` to compile; `oshrun` to launch jobs.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) tests a matrix of OFI versions (v1.7.x through v2.1.x) and feature combinations: PMI simple, error checking, RVA, XPMEM, UCX, and various collective algorithm settings.

--- a/configure.ac
+++ b/configure.ac
@@ -537,7 +537,6 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
-       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,12 @@ AC_ARG_ENABLE([mr-endpoint],
 AS_IF([test "$enable_mr_endpoint" = "yes"],
       [AC_DEFINE([ENABLE_MR_ENDPOINT], [1], [If defined, the OFI transport will use FI_MR_ENDPOINT])])
 
+AC_ARG_ENABLE([mr-local],
+    [AS_HELP_STRING([--enable-mr-local],
+                    [Use FI_MR_LOCAL to require local memory descriptors in RMA operations. (default: disabled)])])
+AS_IF([test "$enable_mr_local" = "yes"],
+      [AC_DEFINE([ENABLE_MR_LOCAL], [1], [If defined, the OFI transport will use FI_MR_LOCAL])])
+
 AC_ARG_ENABLE([ofi-manual-progress],
     [AS_HELP_STRING([--enable-ofi-manual-progress],
                     [Use FI_MANUAL_PROGRESS for data progress control mode. (default: disabled)])])

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,13 @@ AC_ARG_ENABLE([shr-atomics],
 AS_IF([test "$enable_shr_atomics" = "yes"],
       [AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])])
 
+AC_ARG_ENABLE([hierarchical-barrier],
+    [AS_HELP_STRING([--enable-hierarchical-barrier],
+                    [Enable the hierarchical barrier: intranode phase uses CPU atomics,
+                     internode phase uses NIC puts. Requires an on-node transport (XPMEM
+                     or CMA) and a network transport (OFI, Portals4, or UCX).
+                     (default: disabled)])])
+
 AC_ARG_ENABLE([manpages],
     [AS_HELP_STRING([--enable-manpages],
                     [Include man pages in the installation (default:disabled)])])
@@ -537,7 +544,6 @@ AM_CONDITIONAL([USE_CMA], [test "$transport_cma" = "yes"])
 
 AS_IF([test "$transport_xpmem" = "yes" -o "$transport_cma" = "yes"],
       [AC_DEFINE([USE_ON_NODE_COMMS], [1], [Define if any on-node comm transport is available])
-       AC_DEFINE([ENABLE_HARD_POLLING], [1], [Enable hard polling])
       ])
 
 if test "$enable_shr_atomics" = "yes"; then
@@ -549,6 +555,36 @@ fi
 if test "$enable_shr_atomics" != "no" -a "$transport_xpmem" = "yes" -a "$transport" = "none"; then
     transport_shr_atomics="yes"
     AC_DEFINE([USE_SHR_ATOMICS], [1], [If defined, the shared memory layer will perform processor atomics.])
+fi
+
+dnl Hierarchical barrier: only when explicitly requested.  Validate that an
+dnl on-node transport (XPMEM or CMA) and a network transport are both present;
+dnl error if dependencies are missing.
+transport_hierarchical_barrier="no"
+if test "$enable_hierarchical_barrier" = "yes"; then
+    dnl Check on-node transport dependency
+    if test "$transport_xpmem" != "yes" -a "$transport_cma" != "yes"; then
+        AC_MSG_ERROR([--enable-hierarchical-barrier requires an on-node transport; configure with --with-xpmem or --with-cma])
+    dnl Check network transport dependency
+    elif test "$transport_ofi" != "yes" -a "$transport_portals4" != "yes" -a "$transport_ucx" != "yes"; then
+        AC_MSG_ERROR([--enable-hierarchical-barrier requires a network transport; configure with --with-ofi, --with-portals4, or --with-ucx])
+    else
+        transport_hierarchical_barrier="yes"
+    fi
+fi
+if test "$transport_hierarchical_barrier" = "yes"; then
+    AC_DEFINE([USE_HIERARCHICAL_BARRIER], [1],
+              [If defined, enables the hierarchical barrier: intranode CPU atomics + internode NIC puts.])
+    dnl The hierarchical barrier uses shared-memory puts/gets (XPMEM/CMA) for
+    dnl intranode data movement. USE_SHR_ATOMICS is defined so that the
+    dnl shmem_shr_transport_atomic() function bodies are compiled; the routing
+    dnl logic in shmem_shr_transport_use_atomic() gates them behind a runtime
+    dnl check (shr_size == num_pes), so user-visible AMOs only go through CPU
+    dnl atomics when all PEs are on one node. In the multi-node case they
+    dnl always use the NIC, preserving the single-coherency-domain invariant.
+    AC_DEFINE([USE_SHR_ATOMICS], [1],
+              [If defined, the shared memory layer will perform processor atomics.])
+    transport_shr_atomics="yes"
 fi
 
 AC_ARG_ENABLE([pmi-simple], [AS_HELP_STRING([--enable-pmi-simple],
@@ -1050,6 +1086,7 @@ echo "  XPMEM:          $transport_xpmem"
 echo "  CMA:            $transport_cma"
 echo "  memcpy (self):  $transport_memcpy"
 echo "  Shr. atomics:   $transport_shr_atomics"
+echo "  Hier. barrier:  $transport_hierarchical_barrier"
 echo ""
 echo "Global Options:"
 if test "$enable_remote_virtual_addressing" = "yes"; then

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -53,8 +53,6 @@ long *shmem_internal_hierarchical_local_psync;
  * Total allocation: 2 * shr_size * HIER_SLOT_STRIDE longs. */
 #define HIER_SLOT_STRIDE  8   /* 8 longs = 64 bytes = 1 cache line */
 
-static long hier_sense = 0;
-
 /* Per-phase timing accumulators (root PE: all three phases;
  * non-root PEs: phase1_us = gather wait, phase3_us = fanout wait). */
 static double hier_phase1_us = 0.0;
@@ -596,6 +594,15 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
 
     if (PE_size == 1) return;
 
+    /* Determine sense state: for TEAM_WORLD (0, 1, num_pes) use per-team state; else static fallback. */
+    long *sense_ptr;
+    if (PE_start == 0 && PE_stride == 1 && PE_size == shmem_internal_num_pes) {
+        sense_ptr = &shmem_internal_team_world.hier_sense;
+    } else {
+        static long fallback_sense = 0;
+        sense_ptr = &fallback_sense;
+    }
+
     /* Collect local and root PE sets for this active set */
     int *local_pes = alloca(sizeof(int) * PE_size);
     int local_count = 0;
@@ -639,7 +646,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
     /* Sense-alternating signal — monotonically increasing, no slot resets needed.
      * up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
      * down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE] */
-    long signal   = SHMEM_SYNC_VALUE + 1 + hier_sense;
+    long signal   = SHMEM_SYNC_VALUE + 1 + *sense_ptr;
     int  shr_size = shmem_internal_get_shr_size();
     long *up_pSync   = local_pSync;
     long *down_pSync = local_pSync + (long)(shr_size * HIER_SLOT_STRIDE);
@@ -705,7 +712,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
             hier_call_count++;
         }
 
-        hier_sense++;
+        (*sense_ptr)++;
         return;
     }
 
@@ -800,7 +807,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
         }
     }
 
-    if (my_vidx >= 0) { hier_sense++; }
+    if (my_vidx >= 0) { (*sense_ptr)++; }
     /* PEs absent from local_pes (my_vidx < 0) fall through silently. */
 }
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -14,6 +14,7 @@
  */
 
 #include "config.h"
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
@@ -603,13 +604,18 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
         sense_ptr = &fallback_sense;
     }
 
-    /* Collect local and root PE sets for this active set */
-    int *local_pes = alloca(sizeof(int) * PE_size);
+    /* Collect local and root PE sets for this active set.
+     * Use malloc — PE_size can reach num_pes (100K+) at scale; alloca of
+     * that size would blow the stack. */
+    int *pe_bufs = malloc(2 * sizeof(int) * PE_size);
+    if (!pe_bufs)
+        RAISE_ERROR_STR("malloc failed for hierarchical barrier PE arrays");
+    int *local_pes = pe_bufs;
     int local_count = 0;
     shmem_internal_build_local_set(PE_start, PE_stride, PE_size,
                                    local_pes, &local_count);
 
-    int *root_pes = alloca(sizeof(int) * PE_size);
+    int *root_pes = pe_bufs + PE_size;
     int root_count = 0;
     shmem_internal_build_root_active_set(PE_start, PE_stride, PE_size,
                                          root_pes, &root_count);
@@ -660,7 +666,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
 
     /* ---- Degenerate case: all active PEs on one node ---- */
     if (root_count <= 1 || local_count == PE_size) {
-        if (my_vidx < 0) return;
+        if (my_vidx < 0) { free(pe_bufs); return; }
 
         double t0 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
 
@@ -713,6 +719,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
         }
 
         (*sense_ptr)++;
+        free(pe_bufs);
         return;
     }
 
@@ -809,6 +816,7 @@ shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
 
     if (my_vidx >= 0) { (*sense_ptr)++; }
     /* PEs absent from local_pes (my_vidx < 0) fall through silently. */
+    free(pe_bufs);
 }
 
 void

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 #include <string.h>
+#include <time.h>
 
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
@@ -30,13 +31,53 @@ coll_type_t shmem_internal_collect_type = AUTO;
 coll_type_t shmem_internal_fcollect_type = AUTO;
 long *shmem_internal_barrier_all_psync;
 long *shmem_internal_sync_all_psync;
+#ifdef USE_HIERARCHICAL_BARRIER
+long *shmem_internal_barrier_all_local_psync;
+long *shmem_internal_sync_all_local_psync;
+long *shmem_internal_hierarchical_local_psync;
+
+/* Layout of local_pSync — two cache-line-padded arrays, one slot per PE:
+ *
+ *   up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
+ *   down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE]
+ *
+ * Phase 1 (gather): each PE writes signal to its OWN up-slot once it has
+ *   collected all its children; parent reads children's up-slots.
+ *   One writer per slot — no MESI contention on the parent's cache line.
+ *
+ * Phase 3 (fanout): parent writes signal to each child's down-slot.
+ *   One writer per slot — same property.
+ *
+ * Sense-alternation (hier_sense) avoids explicit resets between calls.
+ *
+ * Total allocation: 2 * shr_size * HIER_SLOT_STRIDE longs. */
+#define HIER_SLOT_STRIDE  8   /* 8 longs = 64 bytes = 1 cache line */
+
+static long hier_sense = 0;
+
+/* Per-phase timing accumulators (root PE: all three phases;
+ * non-root PEs: phase1_us = gather wait, phase3_us = fanout wait). */
+static double hier_phase1_us = 0.0;
+static double hier_phase2_us = 0.0;
+static double hier_phase3_us = 0.0;
+static long   hier_call_count = 0;
+
+static inline double
+hier_now_us(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1e6 + ts.tv_nsec * 1e-3;
+}
+#endif
 
 char *coll_type_str[] = { "AUTO",
                           "LINEAR",
                           "TREE",
                           "DISSEM",
                           "RING",
-                          "RECDBL" };
+                          "RECDBL",
+                          "HIERARCHICAL" };
 
 static int *full_tree_children;
 static int full_tree_num_children;
@@ -134,6 +175,44 @@ shmem_internal_collectives_init(void)
     for (i = 0; i < SHMEM_BARRIER_SYNC_SIZE; i++)
         shmem_internal_sync_all_psync[i] = SHMEM_SYNC_VALUE;
 
+#ifdef USE_HIERARCHICAL_BARRIER
+    /* Allocate local (intranode, CPU-atomic) pSync arrays for the hierarchical
+     * barrier.  Each PE owns HIER_SLOT_STRIDE longs (one cache line) within
+     * the array, indexed by shr_rank.  The stride prevents false sharing:
+     * PE r's slot is at local_pSync[r * HIER_SLOT_STRIDE].
+     * These arrays are touched only by on-node CPU stores/loads via XPMEM;
+     * the global pSync arrays above are touched only by NIC puts. */
+    int shr_size = shmem_internal_get_shr_size();
+    int local_psync_len = 2 * shr_size * HIER_SLOT_STRIDE;
+
+    shmem_internal_barrier_all_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_barrier_all_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_barrier_all_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    shmem_internal_sync_all_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_sync_all_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_sync_all_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+
+    /* Shared local pSync for general barriers/syncs.  Safe to share because
+     * barriers are serialized — a PE cannot enter a new barrier until it has
+     * exited the previous one. */
+    shmem_internal_hierarchical_local_psync =
+        shmem_internal_shmalloc(sizeof(long) * local_psync_len);
+    if (NULL == shmem_internal_hierarchical_local_psync) return -1;
+
+    for (i = 0; i < local_psync_len; i++) {
+        shmem_internal_hierarchical_local_psync[i] = SHMEM_SYNC_VALUE;
+    }
+#endif
+
     /* initialize the binomial tree for collective operations over
        entire tree */
     full_tree_num_children = 0;
@@ -176,6 +255,10 @@ shmem_internal_collectives_init(void)
             shmem_internal_barrier_type = TREE;
         } else if (0 == strcmp(type, "dissem")) {
             shmem_internal_barrier_type = DISSEM;
+#ifdef USE_HIERARCHICAL_BARRIER
+        } else if (0 == strcmp(type, "hierarchical")) {
+            shmem_internal_barrier_type = HIERARCHICAL;
+#endif
         } else {
             RAISE_WARN_MSG("Ignoring bad barrier algorithm '%s'\n", type);
         }
@@ -418,6 +501,331 @@ shmem_internal_sync_dissem(int PE_start, int PE_stride, int PE_size, long *pSync
     /* Ensure local pSync decrements are done before a subsequent barrier */
     shmem_internal_quiet(SHMEM_CTX_DEFAULT);
 }
+
+
+/*****************************************
+ *
+ * HIERARCHICAL BARRIER/SYNC
+ *
+ * Three-phase algorithm for USE_HIERARCHICAL_BARRIER builds:
+ *
+ * Phase 1 (intranode gather, CPU stores/loads via XPMEM):
+ *   All local PEs run an intranode dissemination barrier using plain
+ *   (non-atomic) stores and acquire-loads.  Each PE owns one cache-line-padded
+ *   slot (HIER_SLOT_STRIDE longs apart) so no two PEs share a cache line.
+ *   Sense alternation (hier_sense) removes the need for explicit slot resets.
+ *   ceil(log2(local_count)) rounds; each round: store signal to partner's slot,
+ *   spin-load own slot until partner's signal arrives.
+ *
+ * Phase 2 (internode, NIC puts, root PEs only):
+ *   Root PEs run a dissemination barrier among themselves using NIC puts
+ *   across per-round pSync slots (ceil(log2(N)) rounds). A shmem_quiet
+ *   after the last round ensures all outbound puts are retired before
+ *   phase 3.
+ *
+ * Phase 3 (intranode fanout, CPU stores/loads via XPMEM):
+ *   Same dissemination algorithm as phase 1, run in reverse sense so that the
+ *   "all clear" propagates back to all local PEs without NIC involvement.
+ *
+ *****************************************/
+#ifdef USE_HIERARCHICAL_BARRIER
+
+/* Count and list the PEs in the active set that reside on this node. */
+static void
+shmem_internal_build_local_set(int PE_start, int PE_stride, int PE_size,
+                                int *local_pes, int *local_count)
+{
+    int i, pe;
+    *local_count = 0;
+
+    for (i = 0, pe = PE_start; i < PE_size; i++, pe += PE_stride) {
+        if (shmem_internal_get_shr_rank(pe) != -1) {
+            local_pes[(*local_count)++] = pe;
+        }
+    }
+}
+
+/* Build an active set of root PEs (the lowest-ranked PE on each node) from
+ * the original active set.  shmem_runtime_get_node_rank() only returns the
+ * node-local rank for on-node PEs; for off-node PEs it returns -1.  We
+ * therefore use shmem_runtime_is_node_root_pe() which reflects each PE's
+ * absolute rank within its own node, computed during init via global exchange.
+ */
+static void
+shmem_internal_build_root_active_set(int PE_start, int PE_stride, int PE_size,
+                                     int *root_pes, int *root_count)
+{
+    int i, pe;
+    *root_count = 0;
+
+    for (i = 0, pe = PE_start; i < PE_size; i++, pe += PE_stride) {
+        if (shmem_runtime_is_node_root_pe(pe)) {
+            root_pes[(*root_count)++] = pe;
+        }
+    }
+}
+
+/* CPU atomic load of the long at `target` via local mapped pointer. */
+static inline long
+shmem_internal_cpu_atomic_load_long(long *target, int noderank)
+{
+    void *remote_ptr;
+    long val;
+    shmem_shr_transport_ptr(target, noderank, &remote_ptr);
+    __atomic_load((long *)remote_ptr, &val, __ATOMIC_ACQUIRE);
+    return val;
+}
+
+/* CPU atomic store of `val` to the long at `target` via local mapped pointer. */
+static inline void
+shmem_internal_cpu_atomic_store_long(long *target, int noderank, long val)
+{
+    void *remote_ptr;
+    shmem_shr_transport_ptr(target, noderank, &remote_ptr);
+    __atomic_store((long *)remote_ptr, &val, __ATOMIC_RELEASE);
+}
+
+void
+shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
+                                  long *pSync, long *local_pSync)
+{
+    int node_root_pe = shmem_internal_get_node_root_pe();
+    int is_root      = (shmem_internal_my_pe == node_root_pe);
+    int my_shr_rank  = shmem_runtime_get_node_rank(shmem_internal_my_pe);
+    long one = 1;
+
+    if (PE_size == 1) return;
+
+    /* Collect local and root PE sets for this active set */
+    int *local_pes = alloca(sizeof(int) * PE_size);
+    int local_count = 0;
+    shmem_internal_build_local_set(PE_start, PE_stride, PE_size,
+                                   local_pes, &local_count);
+
+    int *root_pes = alloca(sizeof(int) * PE_size);
+    int root_count = 0;
+    shmem_internal_build_root_active_set(PE_start, PE_stride, PE_size,
+                                         root_pes, &root_count);
+
+    /* Assign virtual indices 0..local_count-1, rotating so node_root_pe = vidx 0.
+     * Precompute tree parent shr_rank and children shr_ranks. */
+    int my_local_idx   = -1;
+    int root_local_idx = 0;
+    for (int i = 0; i < local_count; i++) {
+        if (local_pes[i] == shmem_internal_my_pe) my_local_idx = i;
+        if (local_pes[i] == node_root_pe)          root_local_idx = i;
+    }
+    int my_vidx = (my_local_idx >= 0)
+                  ? (my_local_idx - root_local_idx + local_count) % local_count
+                  : -1;
+
+    int  tree_parent_shr = -1;
+    int  tree_nchildren  = 0;
+    int *tree_child_shr  = alloca(sizeof(int) * tree_radix);
+    if (my_vidx >= 0) {
+        if (my_vidx > 0) {
+            tree_parent_shr = shmem_runtime_get_node_rank(
+                local_pes[((my_vidx - 1) / tree_radix + root_local_idx) % local_count]);
+        }
+        for (int j = 1; j <= tree_radix; j++) {
+            int cv = my_vidx * tree_radix + j;
+            if (cv < local_count) {
+                tree_child_shr[tree_nchildren++] = shmem_runtime_get_node_rank(
+                    local_pes[(cv + root_local_idx) % local_count]);
+            }
+        }
+    }
+
+    /* Sense-alternating signal — monotonically increasing, no slot resets needed.
+     * up-slot   for PE r: local_pSync[r * HIER_SLOT_STRIDE]
+     * down-slot for PE r: local_pSync[shr_size * HIER_SLOT_STRIDE + r * HIER_SLOT_STRIDE] */
+    long signal   = SHMEM_SYNC_VALUE + 1 + hier_sense;
+    int  shr_size = shmem_internal_get_shr_size();
+    long *up_pSync   = local_pSync;
+    long *down_pSync = local_pSync + (long)(shr_size * HIER_SLOT_STRIDE);
+
+    /* Resolve own up-slot and down-slot mapped pointers once. */
+    void *my_up_raw, *my_down_raw;
+    shmem_shr_transport_ptr(&up_pSync[my_shr_rank * HIER_SLOT_STRIDE],   my_shr_rank, &my_up_raw);
+    shmem_shr_transport_ptr(&down_pSync[my_shr_rank * HIER_SLOT_STRIDE], my_shr_rank, &my_down_raw);
+    volatile long *my_up_slot   = (volatile long *)my_up_raw;
+    volatile long *my_down_slot = (volatile long *)my_down_raw;
+
+    /* ---- Degenerate case: all active PEs on one node ---- */
+    if (root_count <= 1 || local_count == PE_size) {
+        if (my_vidx < 0) return;
+
+        double t0 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* Phase 1: gather up tree — wait for children's up-slots, then signal parent */
+        for (int c = 0; c < tree_nchildren; c++) {
+            void *child_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                                    tree_child_shr[c], &child_up_raw);
+            volatile long *child_up = (volatile long *)child_up_raw;
+            long cur;
+            do {
+                __atomic_load(child_up, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+        }
+        if (my_vidx > 0) {
+            void *parent_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[my_shr_rank * HIER_SLOT_STRIDE],
+                                    my_shr_rank, &parent_up_raw);
+            __atomic_store((long *)parent_up_raw, &signal, __ATOMIC_RELEASE);
+        }
+
+        double t1 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* Phase 3: fanout — root stores to children's down-slots, non-roots wait then relay */
+        if (my_vidx == 0) {
+            for (int c = 0; c < tree_nchildren; c++) {
+                shmem_internal_cpu_atomic_store_long(
+                    &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                    tree_child_shr[c], signal);
+            }
+        } else {
+            long cur;
+            do {
+                __atomic_load(my_down_slot, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+            for (int c = 0; c < tree_nchildren; c++) {
+                shmem_internal_cpu_atomic_store_long(
+                    &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                    tree_child_shr[c], signal);
+            }
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double t2 = hier_now_us();
+            hier_phase1_us  += t1 - t0;
+            hier_phase3_us  += t2 - t1;
+            hier_call_count++;
+        }
+
+        hier_sense++;
+        return;
+    }
+
+    /* ---- Normal multi-node case ---- */
+
+    double mn_t0 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+    /* Phase 1: intranode gather (k-ary tree, bottom-up).
+     * Each PE waits on each child's up-slot, then writes its own up-slot.
+     * One writer per up-slot — no cache-line contention on the parent. */
+    if (my_vidx >= 0) {
+        for (int c = 0; c < tree_nchildren; c++) {
+            void *child_up_raw;
+            shmem_shr_transport_ptr(&up_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                                    tree_child_shr[c], &child_up_raw);
+            volatile long *child_up = (volatile long *)child_up_raw;
+            long cur;
+            do {
+                __atomic_load(child_up, &cur, __ATOMIC_ACQUIRE);
+                if (cur != signal) { SPINLOCK_BODY(); }
+            } while (cur != signal);
+        }
+        if (my_vidx > 0) {
+            /* Signal parent by writing to OWN up-slot (parent reads it). */
+            __atomic_store((long *)my_up_raw, &signal, __ATOMIC_RELEASE);
+        }
+    }
+
+    double mn_t1 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+    if (is_root) {
+        /* ---- Phase 2: internode barrier (NIC puts, root PEs only) ---- */
+        if (root_count > 1) {
+            int my_root_idx = -1;
+            for (int i = 0; i < root_count; i++) {
+                if (root_pes[i] == shmem_internal_my_pe) { my_root_idx = i; break; }
+            }
+            shmem_internal_assert(my_root_idx >= 0);
+
+            int num_rounds = 0;
+            { int n = root_count - 1; while (n > 0) { n >>= 1; num_rounds++; } }
+            shmem_internal_assert(num_rounds <= SHMEM_BARRIER_SYNC_SIZE);
+
+            for (int r = 0; r < num_rounds; r++) {
+                int partner_idx = (my_root_idx + (1 << r)) % root_count;
+                int partner_pe  = root_pes[partner_idx];
+                shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, &pSync[r], &one,
+                                         sizeof(one), partner_pe);
+                SHMEM_WAIT(&pSync[r], SHMEM_SYNC_VALUE);
+                __atomic_store_n(&pSync[r], SHMEM_SYNC_VALUE, __ATOMIC_RELEASE);
+            }
+        }
+
+        shmem_internal_quiet(SHMEM_CTX_DEFAULT);
+
+        double mn_t2 = shmem_internal_params.HIER_BARRIER_DEBUG ? hier_now_us() : 0.0;
+
+        /* ---- Phase 3: intranode fanout (k-ary tree, top-down via down-slots) ---- */
+        for (int c = 0; c < tree_nchildren; c++) {
+            shmem_internal_cpu_atomic_store_long(
+                &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                tree_child_shr[c], signal);
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double mn_t3 = hier_now_us();
+            hier_phase1_us  += mn_t1 - mn_t0;
+            hier_phase2_us  += mn_t2 - mn_t1;
+            hier_phase3_us  += mn_t3 - mn_t2;
+            hier_call_count++;
+        }
+
+    } else if (my_vidx >= 0) {
+        /* Non-root: wait on own down-slot for parent's signal, then relay to children. */
+        long cur;
+        do {
+            __atomic_load(my_down_slot, &cur, __ATOMIC_ACQUIRE);
+            if (cur != signal) { SPINLOCK_BODY(); }
+        } while (cur != signal);
+
+        for (int c = 0; c < tree_nchildren; c++) {
+            shmem_internal_cpu_atomic_store_long(
+                &down_pSync[tree_child_shr[c] * HIER_SLOT_STRIDE],
+                tree_child_shr[c], signal);
+        }
+
+        if (shmem_internal_params.HIER_BARRIER_DEBUG) {
+            double mn_t3 = hier_now_us();
+            hier_phase1_us  += mn_t1 - mn_t0;
+            hier_phase3_us  += mn_t3 - mn_t1;
+            hier_call_count++;
+        }
+    }
+
+    if (my_vidx >= 0) { hier_sense++; }
+    /* PEs absent from local_pes (my_vidx < 0) fall through silently. */
+}
+
+void
+shmem_internal_hier_barrier_print_stats(void)
+{
+    if (!shmem_internal_params.HIER_BARRIER_DEBUG) return;
+    if (hier_call_count == 0) return;
+
+    /* Each PE prints its own per-phase averages.  At scale the output can be
+     * large; the caller should fence/barrier before this so the lines don't
+     * interleave badly, but we keep this simple intentionally. */
+    fprintf(stderr,
+            "[PE %d] hier_barrier calls=%ld  "
+            "phase1(gather)=%.2f us  phase2(internode)=%.2f us  "
+            "phase3(fanout)=%.2f us  total=%.2f us\n",
+            shmem_internal_my_pe,
+            hier_call_count,
+            hier_phase1_us / hier_call_count,
+            hier_phase2_us / hier_call_count,
+            hier_phase3_us / hier_call_count,
+            (hier_phase1_us + hier_phase2_us + hier_phase3_us) / hier_call_count);
+}
+
+#endif /* USE_HIERARCHICAL_BARRIER */
 
 
 /*****************************************

--- a/src/init.c
+++ b/src/init.c
@@ -386,6 +386,10 @@ shmem_internal_heap_postinit(void)
               shmem_internal_heap_base, shmem_internal_heap_length,
               shmem_internal_data_base, shmem_internal_data_length);
 
+    if (shmem_internal_params.BOUNCE_MLOCK) {
+        DEBUG_MSG("Bounce buffer locking enabled\n");
+    }
+
 #ifdef HAVE_SCHED_GETAFFINITY
 #ifdef USE_HWLOC
     ret = hwloc_topology_init(&shmem_internal_topology);

--- a/src/init.c
+++ b/src/init.c
@@ -147,6 +147,10 @@ shmem_internal_shutdown(void)
 
     shmem_internal_finalized = 1;
 
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_hier_barrier_print_stats();
+#endif
+
     shmem_internal_team_fini();
 
     shmem_transport_fini();
@@ -519,6 +523,20 @@ shmem_internal_heap_postinit(void)
 
     atexit(shmem_internal_shutdown_atexit);
     shmem_internal_initialized = 1;
+
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_my_pe == 0) {
+        const char *effective_barrier =
+            (shmem_internal_barrier_type == AUTO &&
+             shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD)
+            ? "HIERARCHICAL (auto-selected)"
+            : coll_type_str[shmem_internal_barrier_type];
+
+        DEBUG_MSG("Hierarchical barrier enabled: intranode CPU atomics + internode NIC puts\n"
+                  RAISE_PE_PREFIX "Barrier algorithm: %s\n",
+                  shmem_internal_my_pe, effective_barrier);
+    }
+#endif
 
     /* finish up */
 #ifndef USE_PMIX

--- a/src/init.c
+++ b/src/init.c
@@ -386,10 +386,6 @@ shmem_internal_heap_postinit(void)
               shmem_internal_heap_base, shmem_internal_heap_length,
               shmem_internal_data_base, shmem_internal_data_length);
 
-    if (shmem_internal_params.BOUNCE_MLOCK) {
-        DEBUG_MSG("Bounce buffer locking enabled\n");
-    }
-
 #ifdef HAVE_SCHED_GETAFFINITY
 #ifdef USE_HWLOC
     ret = hwloc_topology_init(&shmem_internal_topology);

--- a/src/runtime-mpi.c
+++ b/src/runtime-mpi.c
@@ -38,6 +38,7 @@ static int kv_length = 0;
 static int initialized_mpi = 0;
 static int node_size;
 static int *node_ranks;
+static int *is_node_root = NULL;
 
 char* kv_store_me;
 char* kv_store_all;
@@ -103,6 +104,10 @@ shmem_runtime_init(int enable_node_ranks)
     if (size > 1 && enable_node_ranks) {
         node_ranks = malloc(size * sizeof(int));
         if (NULL == node_ranks) return 8;
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = malloc(size * sizeof(int));
+        if (NULL == is_node_root) return 9;
+#endif
     }
 
     return 0;
@@ -117,6 +122,7 @@ shmem_runtime_fini(void)
     if (node_ranks) {
         MPI_Comm_free(&SHMEM_RUNTIME_SHARED);
         free(node_ranks);
+        free(is_node_root);
     }
 
     MPI_Comm_free(&SHMEM_RUNTIME_WORLD);
@@ -203,10 +209,43 @@ shmem_runtime_get_node_size(void)
 }
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (node_ranks[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+int
 shmem_runtime_exchange(void)
 {
     if (size == 1) {
         kv_store_all = kv_store_me;
+        if (is_node_root) is_node_root[0] = 1;
         return 0;
     }
 
@@ -231,6 +270,26 @@ shmem_runtime_exchange(void)
         MPI_Group_free(&world_group);
         MPI_Group_free(&node_group);
         free(world_ranks);
+
+#ifdef USE_HIERARCHICAL_BARRIER
+        /* Exchange absolute node ranks to identify node roots across all nodes.
+         * node_ranks[pe] is the rank of PE pe in the CALLING PE's node group;
+         * for off-node PEs it is MPI_UNDEFINED.  We need each PE's rank in its
+         * OWN node group, so gather those now. */
+        int my_node_rank;
+        MPI_Comm_rank(SHMEM_RUNTIME_SHARED, &my_node_rank);
+
+        int *abs_node_ranks = malloc(size * sizeof(int));
+        if (NULL == abs_node_ranks) return 2;
+
+        MPI_Allgather(&my_node_rank, 1, MPI_INT,
+                      abs_node_ranks, 1, MPI_INT, SHMEM_RUNTIME_WORLD);
+
+        for (int i = 0; i < size; i++)
+            is_node_root[i] = (abs_node_ranks[i] == 0) ? 1 : 0;
+
+        free(abs_node_ranks);
+#endif
     }
 
     int chunkSize = kv_length * sizeof(char) * MAX_KV_LENGTH;

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -209,6 +209,10 @@ shmem_runtime_get_node_root_pe(void)
         return 0;
     }
 
+    if (NULL == location_array) {
+        return 0;
+    }
+
     for (i = 0; i < size; i++) {
         if (location_array[i] == 0)
             return i;

--- a/src/runtime-pmi.c
+++ b/src/runtime-pmi.c
@@ -38,6 +38,7 @@ static char *kvs_name, *kvs_key, *kvs_value;
 static int max_name_len, max_key_len, max_val_len;
 static int initialized_pmi = 0;
 static int *location_array = NULL;
+static int *is_node_root = NULL;
 
 #define SINGLETON_KEY_LEN 128
 #define SINGLETON_VAL_LEN 1024
@@ -96,6 +97,10 @@ shmem_runtime_init(int enable_node_ranks)
         if (enable_node_ranks) {
             location_array = malloc(sizeof(int) * size);
             if (NULL == location_array) return 10;
+#ifdef USE_HIERARCHICAL_BARRIER
+            is_node_root = malloc(sizeof(int) * size);
+            if (NULL == is_node_root) return 11;
+#endif
         }
     }
     else {
@@ -120,6 +125,7 @@ int
 shmem_runtime_fini(void)
 {
     free(location_array);
+    free(is_node_root);
     free(kvs_name);
     free(kvs_key);
     free(kvs_value);
@@ -195,6 +201,40 @@ shmem_runtime_get_node_size(void)
 
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (location_array[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+
+int
 shmem_runtime_exchange(void)
 {
     int ret;
@@ -224,6 +264,13 @@ shmem_runtime_exchange(void)
         if (0 != ret) {
             RETURN_ERROR_MSG("Node PE mapping failed (%d)\n", ret);
             return 7;
+        }
+    }
+    if (is_node_root) {
+        ret = shmem_runtime_util_populate_global_node_roots(is_node_root, size);
+        if (0 != ret) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return 8;
         }
     }
 

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -42,6 +42,7 @@ static char *kvs_name, *kvs_key, *kvs_value;
 static int max_name_len, max_key_len, max_val_len;
 static int initialized_pmi = 0;
 static int *location_array = NULL;
+static int *is_node_root = NULL;
 
 
 int
@@ -77,6 +78,10 @@ shmem_runtime_init(int enable_node_ranks)
     if (enable_node_ranks) {
         location_array = malloc(sizeof(int) * size);
         if (NULL == location_array) return 8;
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = malloc(sizeof(int) * size);
+        if (NULL == is_node_root) return 9;
+#endif
     }
 
     return 0;
@@ -88,6 +93,9 @@ shmem_runtime_fini(void)
 {
     if (location_array) {
         free(location_array);
+    }
+    if (is_node_root) {
+        free(is_node_root);
     }
 
     if (initialized_pmi == 1) {
@@ -146,6 +154,40 @@ shmem_runtime_get_node_size(void)
 
 
 int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    if (size == 1) {
+        return 0;
+    }
+
+    for (i = 0; i < size; i++) {
+        if (location_array[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
+
+int
 shmem_runtime_exchange(void)
 {
     int ret;
@@ -167,6 +209,13 @@ shmem_runtime_exchange(void)
         if (0 != ret) {
             RETURN_ERROR_MSG("Node PE mapping failed (%d)\n", ret);
             return 7;
+        }
+    }
+    if (is_node_root) {
+        ret = shmem_runtime_util_populate_global_node_roots(is_node_root, size);
+        if (0 != ret) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return 8;
         }
     }
 

--- a/src/runtime-pmi2.c
+++ b/src/runtime-pmi2.c
@@ -162,6 +162,10 @@ shmem_runtime_get_node_root_pe(void)
         return 0;
     }
 
+    if (NULL == location_array) {
+        return 0;
+    }
+
     for (i = 0; i < size; i++) {
         if (location_array[i] == 0)
             return i;

--- a/src/runtime-pmix.c
+++ b/src/runtime-pmix.c
@@ -37,6 +37,7 @@ static pmix_proc_t myproc;
 static uint32_t size;
 static uint32_t node_size = 0;
 static int *node_ranks = NULL;
+static int *is_node_root = NULL;
 
 int
 shmem_runtime_init(int enable_node_ranks)
@@ -69,6 +70,13 @@ shmem_runtime_init(int enable_node_ranks)
             RETURN_ERROR_MSG_PREINIT("Out of memory allocating node_ranks\n");
             return 1;
         }
+#ifdef USE_HIERARCHICAL_BARRIER
+        is_node_root = (int *)malloc(size * sizeof(int));
+        if (NULL == is_node_root) {
+            RETURN_ERROR_MSG_PREINIT("Out of memory allocating is_node_root\n");
+            return 2;
+        }
+#endif
     }
 
     return PMIX_SUCCESS;
@@ -82,6 +90,8 @@ shmem_runtime_fini(void)
 
     if (node_ranks)
         free(node_ranks);
+    if (is_node_root)
+        free(is_node_root);
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
         RETURN_ERROR_MSG_PREINIT("PMIx_Finalize failed (%d)\n", rc);
@@ -143,13 +153,36 @@ shmem_runtime_get_node_size(void)
     return (int) node_size;
 }
 
-// static void opcbfunc(pmix_status_t status, void *cbdata)
-// {
-//     bool *active = (bool*)cbdata;
 
-//     fprintf(stderr, "%s:%d completed fence_nb", myproc.nspace, myproc.rank);
-//     *active = false;
-// }
+int
+shmem_runtime_get_node_root_pe(void)
+{
+    int i;
+
+    for (i = 0; i < (int) size; i++) {
+        if (node_ranks[i] == 0)
+            return i;
+    }
+
+    /* Should not be reached */
+    return 0;
+}
+
+
+int
+shmem_runtime_is_node_root_pe(int pe)
+{
+    shmem_internal_assert(pe < (int) size && pe >= 0);
+
+    if (size == 1)
+        return 1;
+
+    if (NULL == is_node_root)
+        return 0;
+
+    return is_node_root[pe];
+}
+
 
 int
 shmem_runtime_exchange(void)
@@ -157,7 +190,6 @@ shmem_runtime_exchange(void)
     pmix_status_t rc;
     pmix_info_t info;
     bool wantit=true;
-    //bool active = true;
 
     if (node_ranks) {
         pmix_proc_t proc;
@@ -198,6 +230,16 @@ shmem_runtime_exchange(void)
         } else {
            RETURN_ERROR_MSG_PREINIT("PMIX_LOCAL_PEERS is not properly initiated (%d)\n", rc);
         }
+
+        /* Publish hostname so shmem_runtime_util_populate_global_node_roots can
+         * determine which PEs are node roots across all nodes. */
+        if (is_node_root) {
+            int ret = shmem_runtime_util_put_hostname();
+            if (ret != 0) {
+                RETURN_ERROR_MSG("PMIx hostname put failed (%d)\n", ret);
+                return ret;
+            }
+        }
     }
 
     /* commit any values we "put" */
@@ -206,20 +248,21 @@ shmem_runtime_exchange(void)
         return rc;
     }
 
-    /* execute a fence, directing that all info be exchanged */
     PMIX_INFO_CONSTRUCT(&info);
     PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &wantit, PMIX_BOOL);
 
-    // Future optimization for when fabrics are ready to support the non-block-
-    // ing capabilities. The commented out call function above, the commented
-    // variable "bool active," and the PMIx_Fence_nb if-statement are here for
-    // when that is ready. Current implementations will cause the test to hang.
-
-    // if (PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, &info, 1, opcbfunc, &active))) {
     if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
         RETURN_ERROR_MSG("PMIx_Fence failed (%d)\n", rc);
     }
     PMIX_INFO_DESTRUCT(&info);
+
+    if (is_node_root) {
+        int ret = shmem_runtime_util_populate_global_node_roots(is_node_root, (int) size);
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Global node root mapping failed (%d)\n", ret);
+            return ret;
+        }
+    }
 
     return rc;
 }

--- a/src/runtime.h
+++ b/src/runtime.h
@@ -31,6 +31,7 @@ int shmem_runtime_get_size(void);
  * (use shmem_internal_get_shr_rank/size for such queries). */
 int shmem_runtime_get_node_rank(int pe);
 int shmem_runtime_get_node_size(void);
+int shmem_runtime_get_node_root_pe(void);
 
 int shmem_runtime_exchange(void);
 int shmem_runtime_put(char *key, void *value, size_t valuelen);
@@ -41,6 +42,11 @@ void shmem_runtime_barrier(void);
 /* Utility functions used to implement the runtime layer */
 int shmem_runtime_util_put_hostname(void);
 int shmem_runtime_util_populate_node(int *location_array, int size, int *node_size);
+int shmem_runtime_util_populate_global_node_roots(int *is_node_root, int size);
+
+/* Returns 1 if PE pe is the lowest-ranked PE on its own node, 0 otherwise.
+ * Valid after shmem_runtime_exchange(). */
+int shmem_runtime_is_node_root_pe(int pe);
 
 int shmem_runtime_util_encode(const void *inval, int invallen, char *outval, int outvallen);
 int shmem_runtime_util_decode(const char *inval, void *outval, size_t outvallen);

--- a/src/runtime_util.c
+++ b/src/runtime_util.c
@@ -164,3 +164,68 @@ int shmem_runtime_util_populate_node(int *location_array, int size, int *node_si
 
     return 0;
 }
+
+
+/* Populate is_node_root[pe] = 1 if PE pe is the lowest-ranked (first) PE on
+ * its node, 0 otherwise.  This determines which PEs act as internode
+ * representatives in the hierarchical barrier.
+ *
+ * Must be called after shmem_runtime_util_put_hostname and a runtime exchange,
+ * so that every PE's hostname is readable via shmem_runtime_get. */
+int
+shmem_runtime_util_populate_global_node_roots(int *is_node_root, int size)
+{
+    int ret = 0;
+    char **hostnames = (char **) malloc(size * sizeof(char *));
+    size_t *hlens   = (size_t *) malloc(size * sizeof(size_t));
+
+    if (!hostnames || !hlens) {
+        free(hostnames);
+        free(hlens);
+        RETURN_ERROR_MSG("Out of memory allocating hostname arrays\n");
+        return 1;
+    }
+
+    for (int pe = 0; pe < size; pe++) {
+        hostnames[pe] = NULL;
+    }
+
+    for (int pe = 0; pe < size; pe++) {
+        ret = shmem_runtime_get(pe, "hostname_len", &hlens[pe], sizeof(size_t));
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Failed to get hostname_len for PE %d (%d)\n", pe, ret);
+            goto cleanup;
+        }
+        hostnames[pe] = (char *) malloc(hlens[pe] + 1);
+        if (!hostnames[pe]) {
+            RETURN_ERROR_MSG("Out of memory for hostname of PE %d\n", pe);
+            ret = 2;
+            goto cleanup;
+        }
+        ret = shmem_runtime_get(pe, "hostname", hostnames[pe], hlens[pe]);
+        if (ret != 0) {
+            RETURN_ERROR_MSG("Failed to get hostname for PE %d (%d)\n", pe, ret);
+            goto cleanup;
+        }
+    }
+
+    /* PE pe is a node root if no earlier PE (q < pe) has the same hostname. */
+    for (int pe = 0; pe < size; pe++) {
+        is_node_root[pe] = 1;
+        for (int q = 0; q < pe; q++) {
+            if (hlens[pe] == hlens[q] &&
+                memcmp(hostnames[pe], hostnames[q], hlens[pe]) == 0) {
+                is_node_root[pe] = 0;
+                break;
+            }
+        }
+    }
+
+cleanup:
+    for (int pe = 0; pe < size; pe++) {
+        free(hostnames[pe]);
+    }
+    free(hostnames);
+    free(hlens);
+    return ret;
+}

--- a/src/shmem_collectives.h
+++ b/src/shmem_collectives.h
@@ -25,7 +25,8 @@ enum coll_type_t {
     TREE,
     DISSEM,
     RING,
-    RECDBL
+    RECDBL,
+    HIERARCHICAL
 };
 typedef enum coll_type_t coll_type_t;
 
@@ -33,6 +34,11 @@ extern char *coll_type_str[];
 
 extern long *shmem_internal_barrier_all_psync;
 extern long *shmem_internal_sync_all_psync;
+#ifdef USE_HIERARCHICAL_BARRIER
+extern long *shmem_internal_barrier_all_local_psync;
+extern long *shmem_internal_sync_all_local_psync;
+extern long *shmem_internal_hierarchical_local_psync;
+#endif
 
 extern coll_type_t shmem_internal_barrier_type;
 extern coll_type_t shmem_internal_bcast_type;
@@ -44,6 +50,11 @@ extern coll_type_t shmem_internal_fcollect_type;
 void shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync);
 void shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync);
 void shmem_internal_sync_dissem(int PE_start, int PE_stride, int PE_size, long *pSync);
+#ifdef USE_HIERARCHICAL_BARRIER
+void shmem_internal_sync_hierarchical(int PE_start, int PE_stride, int PE_size,
+                                      long *pSync, long *local_pSync);
+void shmem_internal_hier_barrier_print_stats(void);
+#endif
 
 static inline
 void
@@ -58,6 +69,14 @@ shmem_internal_sync(int PE_start, int PE_stride, int PE_size, long *pSync)
 
     switch (shmem_internal_barrier_type) {
     case AUTO:
+#ifdef USE_HIERARCHICAL_BARRIER
+        if (shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+            shmem_internal_sync_hierarchical(PE_start, PE_stride, PE_size,
+                                             pSync,
+                                             shmem_internal_hierarchical_local_psync);
+            break;
+        }
+#endif
         if (PE_size < shmem_internal_params.COLL_CROSSOVER) {
             shmem_internal_sync_linear(PE_start, PE_stride, PE_size, pSync);
         } else {
@@ -73,6 +92,13 @@ shmem_internal_sync(int PE_start, int PE_stride, int PE_size, long *pSync)
     case DISSEM:
         shmem_internal_sync_dissem(PE_start, PE_stride, PE_size, pSync);
         break;
+#ifdef USE_HIERARCHICAL_BARRIER
+    case HIERARCHICAL:
+        shmem_internal_sync_hierarchical(PE_start, PE_stride, PE_size,
+                                         pSync,
+                                         shmem_internal_hierarchical_local_psync);
+        break;
+#endif
     default:
         RAISE_ERROR_MSG("Illegal barrier/sync type (%d)\n",
                         shmem_internal_barrier_type);
@@ -88,6 +114,17 @@ static inline
 void
 shmem_internal_sync_all(void)
 {
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_barrier_type == AUTO &&
+        shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+        shmem_internal_sync_hierarchical(0, 1, shmem_internal_num_pes,
+                                         shmem_internal_sync_all_psync,
+                                         shmem_internal_sync_all_local_psync);
+        shmem_internal_membar_acq_rel();
+        shmem_transport_syncmem();
+        return;
+    }
+#endif
     shmem_internal_sync(0, 1, shmem_internal_num_pes, shmem_internal_sync_all_psync);
 }
 
@@ -106,6 +143,17 @@ void
 shmem_internal_barrier_all(void)
 {
     shmem_internal_quiet(SHMEM_CTX_DEFAULT);
+#ifdef USE_HIERARCHICAL_BARRIER
+    if (shmem_internal_barrier_type == AUTO &&
+        shmem_internal_get_shr_size() >= shmem_internal_params.HIER_BARRIER_THRESHOLD) {
+        shmem_internal_sync_hierarchical(0, 1, shmem_internal_num_pes,
+                                         shmem_internal_barrier_all_psync,
+                                         shmem_internal_barrier_all_local_psync);
+        shmem_internal_membar_acq_rel();
+        shmem_transport_syncmem();
+        return;
+    }
+#endif
     shmem_internal_sync(0, 1, shmem_internal_num_pes, shmem_internal_barrier_all_psync);
 }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -80,12 +80,29 @@ shmem_internal_put_signal_nbi(shmem_ctx_t ctx, void *target, const void *source,
                               uint64_t *sig_addr, uint64_t signal, int sig_op, int pe)
 {
     if (len == 0) {
-        if (sig_op == SHMEM_SIGNAL_ADD)
-            shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal, sizeof(uint64_t),
-                                   pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
-        else
-            shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
-                                      sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+        /* Signal-only (no data): use shmem_shr_transport_use_atomic() to pick
+         * the right plane.  In the multi-node case this always resolves to the
+         * NIC (preserving FIFO ordering with any prior in-flight NIC puts and
+         * avoiding the CPU/NIC coherency hazard).  In the all-PEs-on-one-node
+         * case it resolves to CPU atomics, consistent with data puts. */
+        if (sig_op == SHMEM_SIGNAL_ADD) {
+            if (shmem_shr_transport_use_atomic(ctx, sig_addr, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64))
+                shmem_shr_transport_atomic(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                           pe, SHM_INTERNAL_SUM, SHM_INTERNAL_UINT64);
+            else
+                shmem_transport_atomic((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
+                                       sizeof(uint64_t), pe, SHM_INTERNAL_SUM,
+                                       SHM_INTERNAL_UINT64);
+        } else {
+            if (shmem_shr_transport_use_atomic(ctx, sig_addr, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64))
+                shmem_shr_transport_atomic_set(ctx, sig_addr, &signal, sizeof(uint64_t),
+                                               pe, SHM_INTERNAL_UINT64);
+            else
+                shmem_transport_atomic_set((shmem_transport_ctx_t *) ctx, sig_addr, &signal,
+                                           sizeof(uint64_t), pe, SHM_INTERNAL_UINT64);
+        }
         return;
     }
 

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -442,11 +442,14 @@ static inline
 void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
 {
 #ifdef USE_FI_HMEM
-    /* put_nb may use inject (no counter event), bounce buffer (counter not
-     * recorded in *completion), or put_large (counter watermark set).  A
-     * watermark of 1 is not reliable across all paths, so drain all
-     * in-flight puts via put_quiet to guarantee dest is visible before
-     * returning. */
+    /* put_nb routes through inject, bounce-buffer, or put_large depending on
+     * size.  The inject path has no counter event, so put_wait (watermark-
+     * based) is not sufficient — it would return immediately with completion=0
+     * and leave the GPU write unordered.  put_quiet drains all pending puts
+     * and provides the NIC-level ordering fence needed to guarantee dest is
+     * visible at the target GPU before returning.
+     * bounce-buffer and put_large also set *completion, but put_quiet subsumes
+     * that wait, so no separate put_wait call is needed. */
     long completion = 0;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion);

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -261,7 +261,7 @@ shmem_internal_atomic(shmem_ctx_t ctx, void *target, const void *source, size_t 
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_atomic(ctx, target, source, len, pe, op, datatype);
     } else {
-#ifdef DISABLE_NONFETCH_AMO
+#if defined(DISABLE_NONFETCH_AMO) && defined(USE_OFI)
         /* FIXME: This is a temporary workaround to resolve a known issue with non-fetching AMOs when using
            the CXI provider */
         unsigned long long tmp_fetch = 0;
@@ -301,7 +301,7 @@ shmem_internal_atomic_set(shmem_ctx_t ctx, void *target, const void *source, siz
     if (shmem_shr_transport_use_atomic(ctx, target, len, pe, datatype)) {
         shmem_shr_transport_atomic_set(ctx, target, source, len, pe, datatype);
     } else {
-#ifdef DISABLE_NONFETCH_AMO
+#if defined(DISABLE_NONFETCH_AMO) && defined(USE_OFI)
         /* FIXME: This is a temporary workaround to resolve a known issue with non-fetching AMOs when using
            the CXI provider */
         unsigned long long tmp_fetch = 0;
@@ -343,7 +343,7 @@ shmem_internal_atomicv(shmem_ctx_t ctx, void *target, const void *source,
     size_t len = type_size * count;
     shmem_internal_assert(len > 0);
 
-#ifdef DISABLE_NONFETCH_AMO
+#if defined(DISABLE_NONFETCH_AMO) && defined(USE_OFI)
     /* FIXME: This is a temporary workaround to resolve a known issue with non-fetching AMOs when using
         the CXI provider */
     unsigned long long tmp_fetch = 0;

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -442,13 +442,15 @@ static inline
 void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
 {
 #ifdef USE_FI_HMEM
-    // "completion" set to 1 to wait for completion of put operation initiated
-    // by shmem_internal_put_nb, even if "completion" not incremented in call 
-    // to shmem_internal_put_nb.
-    long completion = 1;
+    /* put_nb may use inject (no counter event), bounce buffer (counter not
+     * recorded in *completion), or put_large (counter watermark set).  A
+     * watermark of 1 is not reliable across all paths, so drain all
+     * in-flight puts via put_quiet to guarantee dest is visible before
+     * returning. */
+    long completion = 0;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+    shmem_transport_put_quiet((shmem_transport_ctx_t *)SHMEM_CTX_DEFAULT);
 #else
     memcpy(dest, source, nelems);
 #endif

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -105,6 +105,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_PUT_PIPELINE_DEPTH, long, 0, SHMEM_INTERNAL_ENV_CAT_T
                        "Maximum in-flight puts per context before throttling (0=unlimited, Cray SHMEM uses 512)")
 SHMEM_INTERNAL_ENV_DEF(OFI_AMO_PIPELINE_DEPTH, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum in-flight fetching AMOs per context before throttling (0=unlimited, try 4 at 128 PPN)")
+SHMEM_INTERNAL_ENV_DEF(OFI_CXI_HYBRID_MR_DESC, bool, true, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Enable CXI hybrid local MR descriptor mode (skips internal MR registration when desc is non-NULL); ignored on non-CXI providers")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -44,6 +44,8 @@ SHMEM_INTERNAL_ENV_DEF(DISABLE_ASLR_CHECK, bool, false, SHMEM_INTERNAL_ENV_CAT_O
 
 SHMEM_INTERNAL_ENV_DEF(SYMMETRIC_HEAP_USE_MALLOC, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Allocate the symmetric heap using malloc")
+SHMEM_INTERNAL_ENV_DEF(SYMMETRIC_HEAP_USE_DSMML, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "Allocate the symmetric heap using DSMML (loaded via dlopen at runtime)")
 SHMEM_INTERNAL_ENV_DEF(BOUNCE_SIZE, size, DEFAULT_BOUNCE_SIZE, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum message size to bounce buffer")
 SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, long, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -103,6 +103,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERN
                        "Put completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_PUT_PIPELINE_DEPTH, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum in-flight puts per context before throttling (0=unlimited, Cray SHMEM uses 512)")
+SHMEM_INTERNAL_ENV_DEF(OFI_AMO_PIPELINE_DEPTH, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Maximum in-flight fetching AMOs per context before throttling (0=unlimited, try 4 at 128 PPN)")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -101,6 +101,8 @@ SHMEM_INTERNAL_ENV_DEF(OFI_DOMAIN, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Fabric domain that should be used by the OFI transport")
 SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Put completion poll limit")
+SHMEM_INTERNAL_ENV_DEF(OFI_PUT_PIPELINE_DEPTH, long, 512, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+                       "Maximum in-flight puts per context before throttling (0=unlimited, Cray SHMEM uses 512)")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")
 SHMEM_INTERNAL_ENV_DEF(OFI_STX_MAX, long, 1, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -58,7 +58,11 @@ SHMEM_INTERNAL_ENV_DEF(COLL_SIZE_CROSSOVER, size, 16384, SHMEM_INTERNAL_ENV_CAT_
 SHMEM_INTERNAL_ENV_DEF(COLL_RADIX, long, 4, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Radix for tree-based collectives")
 SHMEM_INTERNAL_ENV_DEF(BARRIER_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
-                       "Algorithm for barrier.  Options are auto, linear, tree, dissem")
+                       "Algorithm for barrier.  Options are auto, linear, tree, dissem, hierarchical")
+SHMEM_INTERNAL_ENV_DEF(HIER_BARRIER_THRESHOLD, long, 2, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
+                       "Minimum local PE count per node to auto-select the hierarchical barrier")
+SHMEM_INTERNAL_ENV_DEF(HIER_BARRIER_DEBUG, bool, 0, SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
+                       "Print per-phase hierarchical barrier timing at finalize")
 SHMEM_INTERNAL_ENV_DEF(BCAST_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,
                        "Algorithm for broadcast.  Options are auto, linear, tree")
 SHMEM_INTERNAL_ENV_DEF(REDUCE_ALGORITHM, string, "auto", SHMEM_INTERNAL_ENV_CAT_COLLECTIVES,

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -48,7 +48,7 @@ SHMEM_INTERNAL_ENV_DEF(SYMMETRIC_HEAP_USE_DSMML, bool, false, SHMEM_INTERNAL_ENV
                        "Allocate the symmetric heap using DSMML (loaded via dlopen at runtime)")
 SHMEM_INTERNAL_ENV_DEF(BOUNCE_SIZE, size, DEFAULT_BOUNCE_SIZE, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum message size to bounce buffer")
-SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, long, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,
+SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, size, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum number of bounce buffers per context")
 SHMEM_INTERNAL_ENV_DEF(TRAP_ON_ABORT, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Generate trap if the program aborts or calls shmem_global_exit")
@@ -138,3 +138,7 @@ SHMEM_INTERNAL_ENV_DEF(MPI_THREAD_LEVEL, string, "MPI_THREAD_SINGLE", SHMEM_INTE
 SHMEM_INTERNAL_ENV_DEF(BACKTRACE, string, "", SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Specify the mechanism to use for backtracing on failure")
 
+SHMEM_INTERNAL_ENV_DEF(BOUNCE_MLOCK, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "Lock bounce buffer memory preventing buffers from being paged out to swap")
+SHMEM_INTERNAL_ENV_DEF(BOUNCE_SHEAP, bool, true, SHMEM_INTERNAL_ENV_CAT_OTHER,
+                       "Allocate bounce buffers using symmetric heap, if supported by transport")

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -101,7 +101,7 @@ SHMEM_INTERNAL_ENV_DEF(OFI_DOMAIN, string, "auto", SHMEM_INTERNAL_ENV_CAT_TRANSP
                        "Fabric domain that should be used by the OFI transport")
 SHMEM_INTERNAL_ENV_DEF(OFI_TX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Put completion poll limit")
-SHMEM_INTERNAL_ENV_DEF(OFI_PUT_PIPELINE_DEPTH, long, 512, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
+SHMEM_INTERNAL_ENV_DEF(OFI_PUT_PIPELINE_DEPTH, long, 0, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Maximum in-flight puts per context before throttling (0=unlimited, Cray SHMEM uses 512)")
 SHMEM_INTERNAL_ENV_DEF(OFI_RX_POLL_LIMIT, long, DEFAULT_POLL_LIMIT, SHMEM_INTERNAL_ENV_CAT_TRANSPORT,
                        "Get completion poll limit")

--- a/src/shmem_env_defs.h
+++ b/src/shmem_env_defs.h
@@ -48,7 +48,7 @@ SHMEM_INTERNAL_ENV_DEF(SYMMETRIC_HEAP_USE_DSMML, bool, false, SHMEM_INTERNAL_ENV
                        "Allocate the symmetric heap using DSMML (loaded via dlopen at runtime)")
 SHMEM_INTERNAL_ENV_DEF(BOUNCE_SIZE, size, DEFAULT_BOUNCE_SIZE, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum message size to bounce buffer")
-SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, size, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,
+SHMEM_INTERNAL_ENV_DEF(MAX_BOUNCE_BUFFERS, long, 128, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Maximum number of bounce buffers per context")
 SHMEM_INTERNAL_ENV_DEF(TRAP_ON_ABORT, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Generate trap if the program aborts or calls shmem_global_exit")
@@ -138,7 +138,3 @@ SHMEM_INTERNAL_ENV_DEF(MPI_THREAD_LEVEL, string, "MPI_THREAD_SINGLE", SHMEM_INTE
 SHMEM_INTERNAL_ENV_DEF(BACKTRACE, string, "", SHMEM_INTERNAL_ENV_CAT_OTHER,
                        "Specify the mechanism to use for backtracing on failure")
 
-SHMEM_INTERNAL_ENV_DEF(BOUNCE_MLOCK, bool, false, SHMEM_INTERNAL_ENV_CAT_OTHER,
-                       "Lock bounce buffer memory preventing buffers from being paged out to swap")
-SHMEM_INTERNAL_ENV_DEF(BOUNCE_SHEAP, bool, true, SHMEM_INTERNAL_ENV_CAT_OTHER,
-                       "Allocate bounce buffers using symmetric heap, if supported by transport")

--- a/src/shmem_free_list.c
+++ b/src/shmem_free_list.c
@@ -22,10 +22,12 @@
 #include "shmem.h"
 #include "shmem_free_list.h"
 
+#define NUM_ELEMENTS	2
 
 shmem_free_list_t*
-shmem_free_list_init(unsigned int element_size,
-                     shmem_free_list_item_init_fn_t init_fn)
+shmem_free_list_init(size_t element_size,
+                     shmem_free_list_item_init_fn_t init_fn,
+		     size_t max_pool_cnt)
 {
     int ret;
     shmem_free_list_t *fl = (shmem_free_list_t*) calloc(1, sizeof(shmem_free_list_t));
@@ -34,6 +36,18 @@ shmem_free_list_init(unsigned int element_size,
     fl->element_size = element_size;
     fl->init_fn = init_fn;
     fl->nalloc = 0;
+    fl->alloc_size = sizeof(shmem_free_list_alloc_t) + NUM_ELEMENTS * fl->element_size;
+    fl->pool_size = 0;
+    fl->pool_ofs = 0;
+    fl->pool = NULL;
+    if (max_pool_cnt) {
+        /* preallocate pool with shmem malloc */
+        /* memory must be reserved as a memory pool to prevent address conflicts between PEs */
+        fl->pool_size = fl->alloc_size * max_pool_cnt;
+        fl->pool = shmem_internal_shmalloc(fl->pool_size);
+    }
+    /* if pool count is zero allocate with bounce buffers with malloc */
+
     SHMEM_MUTEX_INIT(fl->lock);
     ret = shmem_free_list_more(fl);
     if (0 != ret) {
@@ -48,13 +62,20 @@ shmem_free_list_init(unsigned int element_size,
 void
 shmem_free_list_destroy(shmem_free_list_t *fl)
 {
-    shmem_free_list_alloc_t *alloc, *next;
-
-    alloc = fl->allocs;
-    while (NULL != alloc) {
-        next = alloc->next;
-        free(alloc);
-        alloc = next;
+    if (fl->pool) {
+        /* allocated with shmem malloc */
+        shmem_internal_free(fl->pool);
+        fl->pool = NULL;
+        fl->pool_ofs = 0;
+    } else {
+        /* allocated with malloc */
+        shmem_free_list_alloc_t *alloc, *next;
+        alloc = fl->allocs;
+        while (NULL != alloc) {
+            next = alloc->next;
+            free(alloc);
+            alloc = next;
+        }
     }
 
     SHMEM_MUTEX_DESTROY(fl->lock);
@@ -64,25 +85,35 @@ shmem_free_list_destroy(shmem_free_list_t *fl)
 int
 shmem_free_list_more(shmem_free_list_t *fl)
 {
-    size_t page_size = 4096 - sizeof(shmem_free_list_alloc_t);
-    int num_elements = (fl->element_size < page_size) ? page_size / fl->element_size : 1;
     shmem_free_list_item_t *item, *first, *next, *last = NULL;
     shmem_free_list_alloc_t *header;
     char *buf;
-    int i;
+    uint64_t i;
 
-    num_elements = 2;
+    if (fl->pool) {
+       if (fl->pool_ofs >= fl->pool_size) {
+           fprintf(stderr, "[%d] pool memory exhausted\n", shmem_internal_my_pe);
+           return 1;
+       }   
 
-    buf = malloc(sizeof(shmem_free_list_alloc_t) +
-                 num_elements * fl->element_size);
-    if (NULL == buf) return 1;
+       buf = &fl->pool[fl->pool_ofs];
+       fl->pool_ofs += fl->alloc_size;
+
+       if (shmem_internal_params.BOUNCE_MLOCK) {
+           mlock(buf, sizeof(shmem_free_list_alloc_t) + NUM_ELEMENTS * fl->element_size);
+       }
+    } else {
+        buf = malloc(sizeof(shmem_free_list_alloc_t) +
+                     NUM_ELEMENTS * fl->element_size);
+        if (NULL == buf) return 1;
+    }
 
     header = (shmem_free_list_alloc_t*) buf;
     first = item = (shmem_free_list_item_t*) (header + 1);
-    for (i = 0 ; i < num_elements ; ++i) {
+    for (i = 0 ; i < NUM_ELEMENTS ; ++i) {
         fl->init_fn(item);
         next = (shmem_free_list_item_t*)((char*)item + fl->element_size);
-        if (i == num_elements - 1) {
+        if (i == NUM_ELEMENTS - 1) {
             item->next = NULL;
             last = item;
         } else {

--- a/src/shmem_free_list.c
+++ b/src/shmem_free_list.c
@@ -22,12 +22,10 @@
 #include "shmem.h"
 #include "shmem_free_list.h"
 
-#define NUM_ELEMENTS	2
 
 shmem_free_list_t*
-shmem_free_list_init(size_t element_size,
-                     shmem_free_list_item_init_fn_t init_fn,
-		     size_t max_pool_cnt)
+shmem_free_list_init(unsigned int element_size,
+                     shmem_free_list_item_init_fn_t init_fn)
 {
     int ret;
     shmem_free_list_t *fl = (shmem_free_list_t*) calloc(1, sizeof(shmem_free_list_t));
@@ -36,18 +34,6 @@ shmem_free_list_init(size_t element_size,
     fl->element_size = element_size;
     fl->init_fn = init_fn;
     fl->nalloc = 0;
-    fl->alloc_size = sizeof(shmem_free_list_alloc_t) + NUM_ELEMENTS * fl->element_size;
-    fl->pool_size = 0;
-    fl->pool_ofs = 0;
-    fl->pool = NULL;
-    if (max_pool_cnt) {
-        /* preallocate pool with shmem malloc */
-        /* memory must be reserved as a memory pool to prevent address conflicts between PEs */
-        fl->pool_size = fl->alloc_size * max_pool_cnt;
-        fl->pool = shmem_internal_shmalloc(fl->pool_size);
-    }
-    /* if pool count is zero allocate with bounce buffers with malloc */
-
     SHMEM_MUTEX_INIT(fl->lock);
     ret = shmem_free_list_more(fl);
     if (0 != ret) {
@@ -62,20 +48,13 @@ shmem_free_list_init(size_t element_size,
 void
 shmem_free_list_destroy(shmem_free_list_t *fl)
 {
-    if (fl->pool) {
-        /* allocated with shmem malloc */
-        shmem_internal_free(fl->pool);
-        fl->pool = NULL;
-        fl->pool_ofs = 0;
-    } else {
-        /* allocated with malloc */
-        shmem_free_list_alloc_t *alloc, *next;
-        alloc = fl->allocs;
-        while (NULL != alloc) {
-            next = alloc->next;
-            free(alloc);
-            alloc = next;
-        }
+    shmem_free_list_alloc_t *alloc, *next;
+
+    alloc = fl->allocs;
+    while (NULL != alloc) {
+        next = alloc->next;
+        free(alloc);
+        alloc = next;
     }
 
     SHMEM_MUTEX_DESTROY(fl->lock);
@@ -85,35 +64,25 @@ shmem_free_list_destroy(shmem_free_list_t *fl)
 int
 shmem_free_list_more(shmem_free_list_t *fl)
 {
+    size_t page_size = 4096 - sizeof(shmem_free_list_alloc_t);
+    int num_elements = (fl->element_size < page_size) ? page_size / fl->element_size : 1;
     shmem_free_list_item_t *item, *first, *next, *last = NULL;
     shmem_free_list_alloc_t *header;
     char *buf;
-    uint64_t i;
+    int i;
 
-    if (fl->pool) {
-       if (fl->pool_ofs >= fl->pool_size) {
-           fprintf(stderr, "[%d] pool memory exhausted\n", shmem_internal_my_pe);
-           return 1;
-       }   
+    num_elements = 2;
 
-       buf = &fl->pool[fl->pool_ofs];
-       fl->pool_ofs += fl->alloc_size;
-
-       if (shmem_internal_params.BOUNCE_MLOCK) {
-           mlock(buf, sizeof(shmem_free_list_alloc_t) + NUM_ELEMENTS * fl->element_size);
-       }
-    } else {
-        buf = malloc(sizeof(shmem_free_list_alloc_t) +
-                     NUM_ELEMENTS * fl->element_size);
-        if (NULL == buf) return 1;
-    }
+    buf = malloc(sizeof(shmem_free_list_alloc_t) +
+                 num_elements * fl->element_size);
+    if (NULL == buf) return 1;
 
     header = (shmem_free_list_alloc_t*) buf;
     first = item = (shmem_free_list_item_t*) (header + 1);
-    for (i = 0 ; i < NUM_ELEMENTS ; ++i) {
+    for (i = 0 ; i < num_elements ; ++i) {
         fl->init_fn(item);
         next = (shmem_free_list_item_t*)((char*)item + fl->element_size);
-        if (i == NUM_ELEMENTS - 1) {
+        if (i == num_elements - 1) {
             item->next = NULL;
             last = item;
         } else {

--- a/src/shmem_free_list.h
+++ b/src/shmem_free_list.h
@@ -17,7 +17,8 @@
 #define SHMEM_FREE_QUEUE_H
 
 #include <stdint.h>
-
+#include <sys/mman.h>
+#include <unistd.h>
 #include "shmem_internal.h"
 
 struct shmem_free_list_item_t {
@@ -33,9 +34,12 @@ typedef struct shmem_free_list_alloc_t shmem_free_list_alloc_t;
 typedef void (*shmem_free_list_item_init_fn_t)(shmem_free_list_item_t *item);
 
 struct shmem_free_list_t {
-    uint32_t element_size;
+    size_t element_size;
     uint64_t nalloc;
-
+    uint64_t alloc_size;
+    uint64_t pool_size;
+    char *pool;
+    size_t pool_ofs;
     shmem_free_list_item_init_fn_t init_fn;
     shmem_free_list_alloc_t *allocs;
     shmem_free_list_item_t* head;
@@ -45,8 +49,9 @@ struct shmem_free_list_t {
 };
 typedef struct shmem_free_list_t shmem_free_list_t;
 
-shmem_free_list_t* shmem_free_list_init(unsigned int element_size,
-                                        shmem_free_list_item_init_fn_t init_fn);
+shmem_free_list_t* shmem_free_list_init(size_t element_size,
+                                        shmem_free_list_item_init_fn_t init_fn,
+					size_t max_pool_cnt);
 void shmem_free_list_destroy(shmem_free_list_t *fl);
 int shmem_free_list_more(shmem_free_list_t *fl);
 

--- a/src/shmem_free_list.h
+++ b/src/shmem_free_list.h
@@ -17,8 +17,7 @@
 #define SHMEM_FREE_QUEUE_H
 
 #include <stdint.h>
-#include <sys/mman.h>
-#include <unistd.h>
+
 #include "shmem_internal.h"
 
 struct shmem_free_list_item_t {
@@ -34,12 +33,9 @@ typedef struct shmem_free_list_alloc_t shmem_free_list_alloc_t;
 typedef void (*shmem_free_list_item_init_fn_t)(shmem_free_list_item_t *item);
 
 struct shmem_free_list_t {
-    size_t element_size;
+    uint32_t element_size;
     uint64_t nalloc;
-    uint64_t alloc_size;
-    uint64_t pool_size;
-    char *pool;
-    size_t pool_ofs;
+
     shmem_free_list_item_init_fn_t init_fn;
     shmem_free_list_alloc_t *allocs;
     shmem_free_list_item_t* head;
@@ -49,9 +45,8 @@ struct shmem_free_list_t {
 };
 typedef struct shmem_free_list_t shmem_free_list_t;
 
-shmem_free_list_t* shmem_free_list_init(size_t element_size,
-                                        shmem_free_list_item_init_fn_t init_fn,
-					size_t max_pool_cnt);
+shmem_free_list_t* shmem_free_list_init(unsigned int element_size,
+                                        shmem_free_list_item_init_fn_t init_fn);
 void shmem_free_list_destroy(shmem_free_list_t *fl);
 int shmem_free_list_more(shmem_free_list_t *fl);
 

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -56,7 +56,10 @@ extern unsigned int shmem_internal_rand_seed;
 extern hwloc_topology_t shmem_internal_topology;
 #endif
 
-#define SHMEM_INTERNAL_HEAP_OVERHEAD (1024*1024)
+#define SHMEM_INTERNAL_HEAP_OVERHEAD (10*1024*1024)
+/* Note: this is an estimate */
+#define SHMEM_MAX_BOUNCE_BUFFER_OVERHEAD (2*1024*1024)
+
 #define SHMEM_INTERNAL_DIAG_STRLEN 1024
 #define SHMEM_INTERNAL_DIAG_WRAPLEN 72
 

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -546,6 +546,17 @@ static inline int shmem_internal_get_shr_size(void)
 #endif
 }
 
+/* Return the global PE rank of the lowest-ranked PE on this node (node_rank==0).
+ * Used as the internode representative in hierarchical collectives. */
+static inline int shmem_internal_get_node_root_pe(void)
+{
+#ifdef USE_ON_NODE_COMMS
+    return shmem_runtime_get_node_root_pe();
+#else
+    return shmem_internal_my_pe;
+#endif
+}
+
 static inline double shmem_internal_wtime(void)
 {
     double wtime = 0.0;

--- a/src/shmem_internal.h
+++ b/src/shmem_internal.h
@@ -56,10 +56,7 @@ extern unsigned int shmem_internal_rand_seed;
 extern hwloc_topology_t shmem_internal_topology;
 #endif
 
-#define SHMEM_INTERNAL_HEAP_OVERHEAD (10*1024*1024)
-/* Note: this is an estimate */
-#define SHMEM_MAX_BOUNCE_BUFFER_OVERHEAD (2*1024*1024)
-
+#define SHMEM_INTERNAL_HEAP_OVERHEAD (1024*1024)
 #define SHMEM_INTERNAL_DIAG_STRLEN 1024
 #define SHMEM_INTERNAL_DIAG_WRAPLEN 72
 

--- a/src/shmem_team.c
+++ b/src/shmem_team.c
@@ -85,6 +85,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_world.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_world.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_world.hier_sense     = 0;
+#endif
     SHMEM_TEAM_WORLD = (shmem_team_t) &shmem_internal_team_world;
 
     /* Initialize SHMEM_TEAM_SHARED */
@@ -95,6 +98,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_shared.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_shared.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_shared.hier_sense    = 0;
+#endif
     SHMEM_TEAM_SHARED = (shmem_team_t) &shmem_internal_team_shared;
 
     /* Initialize SHMEM_TEAM_NODE */
@@ -105,6 +111,9 @@ int shmem_internal_team_init(void)
     memset(&shmem_internal_team_node.config, 0, sizeof(shmem_team_config_t));
     for (size_t i = 0; i < N_PSYNCS_PER_TEAM; i++)
         shmem_internal_team_node.psync_avail[i] = 1;
+#ifdef USE_HIERARCHICAL_BARRIER
+    shmem_internal_team_node.hier_sense      = 0;
+#endif
     SHMEMX_TEAM_NODE = (shmem_team_t) &shmem_internal_team_node;
 
     if (shmem_internal_params.TEAM_SHARED_ONLY_SELF) {

--- a/src/shmem_team.h
+++ b/src/shmem_team.h
@@ -26,6 +26,9 @@ struct shmem_internal_team_t {
     long                           config_mask;
     size_t                         contexts_len;
     struct shmem_transport_ctx_t **contexts;
+#ifdef USE_HIERARCHICAL_BARRIER
+    long                           hier_sense;
+#endif
 };
 typedef struct shmem_internal_team_t shmem_internal_team_t;
 

--- a/src/shr_transport.h4
+++ b/src/shr_transport.h4
@@ -122,12 +122,24 @@ shmem_shr_transport_use_read(shmem_ctx_t ctx, void *target, const void *source,
 /* Each OpenSHMEM AMO has only one symmetric pointer.  Check whether shared
  * transport AMOs are in use with respect to the given symmetric target
  * pointer and datatype. For a given datatype, all atomic operations must
- * use the same transport; therefore, op is not needed in this check. */
+ * use the same transport; therefore, op is not needed in this check.
+ *
+ * Under USE_HIERARCHICAL_BARRIER, CPU atomics and NIC AMOs are not coherent
+ * with each other; mixing them on the same variable produces lost updates.
+ * CPU atomics are therefore only safe when ALL PEs are on the same node —
+ * in that case no NIC AMOs will ever be issued to any variable, so there is
+ * only one coherency domain in play. */
 static inline int
 shmem_shr_transport_use_atomic(shmem_ctx_t ctx, void *target, size_t len,
                                int pe, shm_internal_datatype_t datatype)
 {
-#if USE_SHR_ATOMICS
+#if USE_HIERARCHICAL_BARRIER
+    /* Use CPU atomics only when all PEs are local (no off-node peers). */
+    if (shmem_internal_get_shr_size() == shmem_internal_num_pes) {
+        return -1 != shmem_internal_get_shr_rank(pe);
+    }
+    return 0;
+#elif USE_SHR_ATOMICS
     return -1 != shmem_internal_get_shr_rank(pe);
 #else
     return 0;

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -191,7 +191,8 @@ static void *mmap_alloc(size_t bytes)
                     sprintf(file_name, "%s/%s.%d", directory, basename, getpid());
                     fd = open(file_name, O_CREAT | O_RDWR, 0755);
                     if (fd < 0) {
-                        RAISE_WARN_STR("file open failed, cannot use huge pages");
+                        RAISE_WARN_MSG("file open failed (%s), cannot use huge pages",
+                                       strerror(errno));
                         fd = 0;
                     } else {
                         /* have to round up by the pagesize being used */

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -184,15 +184,15 @@ static void *mmap_alloc(size_t bytes)
             int size = snprintf(NULL, 0, "%s/%s.%d", directory, basename, getpid());
 
             if (size < 0) {
-                RAISE_WARN_STR("snprintf returned error, cannot use huge pages\n");
+                DEBUG_STR("snprintf returned error, cannot use huge pages");
             } else {
                 file_name = malloc(size + 1);
                 if (file_name) {
                     sprintf(file_name, "%s/%s.%d", directory, basename, getpid());
                     fd = open(file_name, O_CREAT | O_RDWR, 0755);
                     if (fd < 0) {
-                        RAISE_WARN_MSG("file open failed (%s), cannot use huge pages\n",
-                                       strerror(errno));
+                        DEBUG_MSG("file open failed (%s), cannot use huge pages",
+                                  strerror(errno));
                         fd = 0;
                     } else {
                         /* have to round up by the pagesize being used */
@@ -219,8 +219,8 @@ static void *mmap_alloc(size_t bytes)
                        MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
-                                   strerror(errno));
+                    DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages",
+                              strerror(errno));
                 }
             }
         } else {

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -415,21 +415,6 @@ static void *mmap_alloc(size_t bytes)
                        "Try reducing SHMEM_SYMMETRIC_SIZE or number of PEs per node\n",
                        bytes, strerror(errno), shmem_internal_my_pe);
         ret = NULL;
-    } else if (ret != NULL) {
-#ifdef __linux__
-        /* Try transparent huge pages via madvise on non-Linux fallback path too */
-        if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
-            if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
-                               strerror(errno));
-            } else {
-                if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
-                    DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
-                              strerror(errno));
-                }
-            }
-        }
-#endif
     }
     if (fd) {
         if (file_name)

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -371,20 +371,32 @@ static void *mmap_alloc(size_t bytes)
             free(directory);
             free(file_name);
         }
-    } else {
-        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
-        /* Try to use transparent huge pages via madvise if hugetlbfs not available */
-        if (ret != MAP_FAILED && shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
-            if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
-                               strerror(errno));
-            } else {
-                if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
-                    DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
-                              strerror(errno));
+    } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
+        /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages) */
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                   MAP_ANON | MAP_PRIVATE | MAP_HUGETLB, -1, 0);
+        if (ret == MAP_FAILED) {
+            DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",
+                      strerror(errno));
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret != MAP_FAILED) {
+                if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
+                                   strerror(errno));
+                } else {
+                    if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
+                        DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
+                                  strerror(errno));
+                    }
                 }
             }
+        } else {
+            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes",
+                      bytes);
         }
+    } else {
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
     }
 #else
     ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -209,7 +209,7 @@ static void *mmap_alloc(size_t bytes)
          * would silently fall back to regular pages. */
         if (ftruncate(fd, bytes) == -1) {
             RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), "
-                           "falling back to regular pages\n",
+                           "falling back to transparent huge pages via madvise\n",
                            strerror(errno));
             unlink(file_name);
             close(fd);
@@ -217,6 +217,12 @@ static void *mmap_alloc(size_t bytes)
             free(file_name);
             ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
                        MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret != MAP_FAILED) {
+                if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
+                                   strerror(errno));
+                }
+            }
         } else {
             ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
                        MAP_SHARED | MAP_HUGETLB, fd, 0);
@@ -227,6 +233,13 @@ static void *mmap_alloc(size_t bytes)
         }
     } else {
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+        /* Try to use transparent huge pages via madvise if hugetlbfs not available */
+        if (ret != MAP_FAILED && shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
+            if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
+                               strerror(errno));
+            }
+        }
     }
 #else
     ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
@@ -238,6 +251,16 @@ static void *mmap_alloc(size_t bytes)
                        "Try reducing SHMEM_SYMMETRIC_SIZE or number of PEs per node\n",
                        bytes, strerror(errno), shmem_internal_my_pe);
         ret = NULL;
+    } else if (ret != NULL) {
+#ifdef __linux__
+        /* Try transparent huge pages via madvise on non-Linux fallback path too */
+        if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
+            if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
+                               strerror(errno));
+            }
+        }
+#endif
     }
     if (fd) {
         if (file_name)

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -432,7 +432,8 @@ shmem_internal_symmetric_init(void)
 {
     /* add library overhead such that the max can be shmalloc()'ed */
     shmem_internal_heap_length = shmem_internal_params.SYMMETRIC_SIZE +
-                                 SHMEM_INTERNAL_HEAP_OVERHEAD;
+                                 SHMEM_INTERNAL_HEAP_OVERHEAD +
+				 SHMEM_MAX_BOUNCE_BUFFER_OVERHEAD;
 
     if (shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
         shmem_internal_heap_base =

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -184,14 +184,14 @@ static void *mmap_alloc(size_t bytes)
             int size = snprintf(NULL, 0, "%s/%s.%d", directory, basename, getpid());
 
             if (size < 0) {
-                RAISE_WARN_STR("snprintf returned error, cannot use huge pages");
+                RAISE_WARN_STR("snprintf returned error, cannot use huge pages\n");
             } else {
                 file_name = malloc(size + 1);
                 if (file_name) {
                     sprintf(file_name, "%s/%s.%d", directory, basename, getpid());
                     fd = open(file_name, O_CREAT | O_RDWR, 0755);
                     if (fd < 0) {
-                        RAISE_WARN_MSG("file open failed (%s), cannot use huge pages",
+                        RAISE_WARN_MSG("file open failed (%s), cannot use huge pages\n",
                                        strerror(errno));
                         fd = 0;
                     } else {

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -201,14 +201,36 @@ static void *mmap_alloc(size_t bytes)
             }
         }
     }
-#endif /* __linux__ */
 
-    ret = mmap(requested_base,
-               bytes,
-               PROT_READ | PROT_WRITE,
-               MAP_ANON | MAP_PRIVATE,
-               fd,
-               0);
+    if (fd) {
+        /* Map the hugetlbfs file directly; MAP_ANON must not be used here
+         * because MAP_ANONYMOUS causes the kernel to ignore the fd, which
+         * would silently fall back to regular pages. */
+        if (ftruncate(fd, bytes) == -1) {
+            RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), "
+                           "falling back to regular pages\n",
+                           strerror(errno));
+            unlink(file_name);
+            close(fd);
+            free(directory);
+            free(file_name);
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_ANON | MAP_PRIVATE, -1, 0);
+        } else {
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_SHARED | MAP_HUGETLB, fd, 0);
+            unlink(file_name);
+            close(fd);
+            free(directory);
+            free(file_name);
+        }
+    } else {
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    }
+#else
+    ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+               MAP_ANON | MAP_PRIVATE, -1, 0);
+#endif /* __linux__ */
     if (ret == MAP_FAILED) {
         RAISE_WARN_MSG("Unable to allocate sym. heap, size %zuB: %s\n"
                        RAISE_PE_PREFIX

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -372,9 +372,10 @@ static void *mmap_alloc(size_t bytes)
             free(file_name);
         }
     } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
-        /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages) */
+        /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
+         * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB). */
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
-                   MAP_ANON | MAP_PRIVATE | MAP_HUGETLB, -1, 0);
+                   MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
             DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",
                       strerror(errno));

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -294,26 +294,7 @@ shmem_internal_symmetric_init(void)
             malloc(shmem_internal_heap_length);
     }
 
-    if (NULL == shmem_internal_heap_base)
-        return -1;
-
-#ifdef __linux__
-    /* Pre-fault the heap by touching one byte per huge page so that THP
-     * promotion occurs before fi_mr_reg.  Without this, the CXI ATU caches
-     * 4KB page entries (the page table is sparse at registration time), and
-     * every subsequent RMA/AMO incurs an ATU miss instead of hitting a 2MB
-     * entry.  Stride by SYMMETRIC_HEAP_PAGE_SIZE (default 2MB) to match the
-     * THP granularity and keep init time proportional to heap size / 2MB. */
-    if (!shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
-        volatile char *p = (volatile char *) shmem_internal_heap_base;
-        volatile char *end = p + shmem_internal_heap_length;
-        size_t stride = shmem_internal_params.SYMMETRIC_HEAP_PAGE_SIZE;
-        for (; p < end; p += stride)
-            *p = 0;
-    }
-#endif
-
-    return 0;
+    return (NULL == shmem_internal_heap_base) ? -1 : 0;
 }
 
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -432,8 +432,7 @@ shmem_internal_symmetric_init(void)
 {
     /* add library overhead such that the max can be shmalloc()'ed */
     shmem_internal_heap_length = shmem_internal_params.SYMMETRIC_SIZE +
-                                 SHMEM_INTERNAL_HEAP_OVERHEAD +
-				 SHMEM_MAX_BOUNCE_BUFFER_OVERHEAD;
+                                 SHMEM_INTERNAL_HEAP_OVERHEAD;
 
     if (shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
         shmem_internal_heap_base =

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -294,7 +294,26 @@ shmem_internal_symmetric_init(void)
             malloc(shmem_internal_heap_length);
     }
 
-    return (NULL == shmem_internal_heap_base) ? -1 : 0;
+    if (NULL == shmem_internal_heap_base)
+        return -1;
+
+#ifdef __linux__
+    /* Pre-fault the heap by touching one byte per huge page so that THP
+     * promotion occurs before fi_mr_reg.  Without this, the CXI ATU caches
+     * 4KB page entries (the page table is sparse at registration time), and
+     * every subsequent RMA/AMO incurs an ATU miss instead of hitting a 2MB
+     * entry.  Stride by SYMMETRIC_HEAP_PAGE_SIZE (default 2MB) to match the
+     * THP granularity and keep init time proportional to heap size / 2MB. */
+    if (!shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
+        volatile char *p = (volatile char *) shmem_internal_heap_base;
+        volatile char *end = p + shmem_internal_heap_length;
+        size_t stride = shmem_internal_params.SYMMETRIC_HEAP_PAGE_SIZE;
+        for (; p < end; p += stride)
+            *p = 0;
+    }
+#endif
+
+    return 0;
 }
 
 

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -210,8 +210,8 @@ static void *dsmml_alloc(void *requested_base, size_t bytes)
 
     dsmml_init_info_t init_info = {
         .mype     = shmem_internal_my_pe,
-        .smp_mype = shmem_internal_my_pe % shmem_internal_num_pes,
-        .smp_npes = shmem_internal_num_pes,
+        .smp_mype = shmem_runtime_get_node_rank(shmem_internal_my_pe),
+        .smp_npes = shmem_internal_get_shr_size(),
         .smp_set  = 0,
     };
     if (dsmml_init_fn(&init_info) != DSMML_RC_SUCCESS) {

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -374,8 +374,9 @@ static void *mmap_alloc(size_t bytes)
     } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
         /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
          * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB).
-         * Use NULL as hint to let kernel choose suitable address for huge pages. */
-        ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE,
+         * Use requested_base as hint but don't force it (no MAP_FIXED), so kernel can
+         * choose nearby address if requested_base doesn't work for huge pages. */
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
                    MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
             int hugetlb_errno = errno;

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -373,8 +373,9 @@ static void *mmap_alloc(size_t bytes)
         }
     } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
         /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
-         * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB). */
-        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+         * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB).
+         * Use NULL as hint to let kernel choose suitable address for huge pages. */
+        ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE,
                    MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
             DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -27,6 +27,7 @@
 #include <mntent.h>
 #include <sys/vfs.h>
 #endif
+#include <dlfcn.h>
 
 #define SHMEM_INTERNAL_INCLUDE
 #include "shmem.h"
@@ -126,6 +127,113 @@ static int find_hugepage_dir(size_t page_size, char **directory)
     endmntent(fd);
     return ret;
 }
+#endif /* __linux__ */
+
+/* DSMML runtime support — loaded via dlopen when SHMEM_SYMMETRIC_HEAP_USE_DSMML=1.
+ * Types and constants are inlined here so no dsmml.h is required at build time. */
+#ifdef __linux__
+
+typedef int dsmml_return_t;
+typedef int dsmml_type_t;
+typedef int dsmml_mode_t;
+typedef int dsmml_hpsize_t;
+
+#define DSMML_RC_SUCCESS        0
+#define DSMML_MEM_SYS_DEFAULT   0
+#define DSMML_MODE_DEFAULT      0
+#define DSMML_HPSIZE_DEFAULT    0   /* THP */
+#define DSMML_HPSIZE_2M         5   /* 2MB explicit huge pages */
+
+typedef struct {
+    int            id;
+    void          *act_addr;
+    void          *device_addr;
+    void          *base_addr;
+    size_t         length;
+    dsmml_type_t   type;
+    dsmml_hpsize_t pagesize;
+    dsmml_mode_t   mode;
+    int            smp_mype;
+    int            smp_npes;
+    int            smp_set;
+    int            nnode;
+    int            use_ext_mem;
+} dsmml_sheap_seg_info_t;
+
+typedef struct { int unused; } dsmml_init_info_t;
+
+static void  *dsmml_handle  = NULL;
+static int  (*dsmml_init_fn)(dsmml_init_info_t *)              = NULL;
+static int  (*dsmml_finalize_fn)(void)                         = NULL;
+static int  (*dsmml_create_sheap_seg_fn)(dsmml_sheap_seg_info_t *) = NULL;
+
+static void *dsmml_alloc(void *requested_base, size_t bytes)
+{
+    const char *libname = "libdsmml.so";
+
+    dsmml_handle = dlopen(libname, RTLD_NOW | RTLD_GLOBAL);
+    if (!dsmml_handle) {
+        RAISE_WARN_MSG("SHMEM_SYMMETRIC_HEAP_USE_DSMML=1 but dlopen(%s) failed: %s\n",
+                       libname, dlerror());
+        return NULL;
+    }
+
+    dsmml_init_fn             = dlsym(dsmml_handle, "dsmml_init");
+    dsmml_finalize_fn         = dlsym(dsmml_handle, "dsmml_finalize");
+    dsmml_create_sheap_seg_fn = dlsym(dsmml_handle, "dsmml_create_sheap_seg");
+
+    if (!dsmml_init_fn || !dsmml_finalize_fn || !dsmml_create_sheap_seg_fn) {
+        RAISE_WARN_MSG("DSMML: required symbols not found in %s: %s\n", libname, dlerror());
+        dlclose(dsmml_handle);
+        dsmml_handle = NULL;
+        return NULL;
+    }
+
+    dsmml_init_info_t init_info = {0};
+    if (dsmml_init_fn(&init_info) != DSMML_RC_SUCCESS) {
+        RAISE_WARN_STR("DSMML: dsmml_init failed");
+        dlclose(dsmml_handle);
+        dsmml_handle = NULL;
+        return NULL;
+    }
+
+    /* Try 2MB explicit huge pages first; fall back to THP on failure. */
+    dsmml_sheap_seg_info_t seg = {
+        .base_addr  = requested_base,
+        .length     = bytes,
+        .type       = DSMML_MEM_SYS_DEFAULT,
+        .mode       = DSMML_MODE_DEFAULT,
+        .pagesize   = DSMML_HPSIZE_2M,
+    };
+
+    if (dsmml_create_sheap_seg_fn(&seg) != DSMML_RC_SUCCESS) {
+        DEBUG_STR("DSMML: 2MB huge pages unavailable, falling back to THP");
+        seg.act_addr = NULL;
+        seg.pagesize = DSMML_HPSIZE_DEFAULT;
+        if (dsmml_create_sheap_seg_fn(&seg) != DSMML_RC_SUCCESS) {
+            RAISE_WARN_STR("DSMML: dsmml_create_sheap_seg failed");
+            dsmml_finalize_fn();
+            dlclose(dsmml_handle);
+            dsmml_handle = NULL;
+            return NULL;
+        }
+    }
+
+    DEBUG_MSG("DSMML: heap allocated at %p (requested %p), size %zu, pagesize %s\n",
+              seg.act_addr, requested_base, bytes,
+              seg.pagesize == DSMML_HPSIZE_2M ? "2MB" : "THP");
+
+    return seg.act_addr;
+}
+
+static void dsmml_free(void)
+{
+    if (dsmml_finalize_fn) dsmml_finalize_fn();
+    if (dsmml_handle)      dlclose(dsmml_handle);
+    dsmml_handle      = NULL;
+    dsmml_finalize_fn = NULL;
+}
+
 #endif /* __linux__ */
 
 /* shmalloc and friends are defined to not be thread safe, so this is
@@ -284,14 +392,23 @@ shmem_internal_symmetric_init(void)
     shmem_internal_heap_length = shmem_internal_params.SYMMETRIC_SIZE +
                                  SHMEM_INTERNAL_HEAP_OVERHEAD;
 
-    if (!shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
-        shmem_internal_heap_base =
-            shmem_internal_heap_curr =
-            mmap_alloc(shmem_internal_heap_length);
-    } else {
+    if (shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
         shmem_internal_heap_base =
             shmem_internal_heap_curr =
             malloc(shmem_internal_heap_length);
+#ifdef __linux__
+    } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_DSMML) {
+        void *requested_base =
+            (void*) (((unsigned long) shmem_internal_data_base +
+                      shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
+        shmem_internal_heap_base =
+            shmem_internal_heap_curr =
+            dsmml_alloc(requested_base, shmem_internal_heap_length);
+#endif
+    } else {
+        shmem_internal_heap_base =
+            shmem_internal_heap_curr =
+            mmap_alloc(shmem_internal_heap_length);
     }
 
     return (NULL == shmem_internal_heap_base) ? -1 : 0;
@@ -302,10 +419,14 @@ int
 shmem_internal_symmetric_fini(void)
 {
     if (NULL != shmem_internal_heap_base) {
-        if (!shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
-            munmap( (void*)shmem_internal_heap_base, (size_t)shmem_internal_heap_length );
-        } else {
+        if (shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
             free(shmem_internal_heap_base);
+#ifdef __linux__
+        } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_DSMML) {
+            dsmml_free();
+#endif
+        } else {
+            munmap( (void*)shmem_internal_heap_base, (size_t)shmem_internal_heap_length );
         }
         shmem_internal_heap_length = 0;
         shmem_internal_heap_base = shmem_internal_heap_curr = NULL;

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -378,15 +378,20 @@ static void *mmap_alloc(size_t bytes)
         ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE,
                    MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
-            DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",
-                      strerror(errno));
+            int hugetlb_errno = errno;
+            RAISE_WARN_MSG("mmap(MAP_HUGETLB) failed with errno=%d (%s), falling back to THP via madvise\n",
+                      hugetlb_errno, strerror(hugetlb_errno));
             ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
                        MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
+                RAISE_WARN_MSG("mmap fallback succeeded: addr=%p, bytes=%zu, requested_base=%p\n",
+                          ret, bytes, requested_base);
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
-                                   strerror(errno));
+                    int madvise_errno = errno;
+                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed with errno=%d (%s), using regular pages\n",
+                                   madvise_errno, strerror(madvise_errno));
                 } else {
+                    DEBUG_MSG("madvise(MADV_HUGEPAGE) succeeded");
                     if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
                         DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
                                   strerror(errno));
@@ -394,8 +399,8 @@ static void *mmap_alloc(size_t bytes)
                 }
             }
         } else {
-            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes",
-                      bytes);
+            RAISE_WARN_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB): addr=%p, %zu bytes\n",
+                      ret, bytes);
         }
     } else {
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -26,6 +26,9 @@
 #ifdef __linux__
 #include <mntent.h>
 #include <sys/vfs.h>
+#ifndef MADV_COLLAPSE
+#define MADV_COLLAPSE 25  /* synchronous THP promotion, Linux 5.18+ */
+#endif
 #endif
 #include <dlfcn.h>
 
@@ -130,24 +133,43 @@ static int find_hugepage_dir(size_t page_size, char **directory)
 #endif /* __linux__ */
 
 /* DSMML runtime support — loaded via dlopen when SHMEM_SYMMETRIC_HEAP_USE_DSMML=1.
- * Types and constants are inlined here so no dsmml.h is required at build time. */
+ * Types mirror dsmml.h exactly so dlopen works without a build-time dependency. */
 #ifdef __linux__
 
-typedef int dsmml_return_t;
-typedef int dsmml_type_t;
-typedef int dsmml_mode_t;
-typedef int dsmml_hpsize_t;
+typedef enum {
+    DSMML_RC_SUCCESS        = 0,
+    DSMML_RC_FAILURE        = 1,
+    DSMML_RC_INVALID_PARAM  = 2,
+    DSMML_RC_RESOURCE_ERROR = 3,
+    DSMML_RC_NO_MEMORY      = 4,
+    DSMML_RC_UNKNOWN_FAIL   = 5,
+    DSMML_RC_NOOP           = 6,
+    DSMML_RC_MEM_OVERLAP    = 7,
+    DSMML_RC_MEM_CORRUPT    = 8
+} dsmml_return_t;
 
-#define DSMML_RC_SUCCESS        0
-#define DSMML_MEM_SYS_DEFAULT   0
-#define DSMML_MODE_DEFAULT      0
-#define DSMML_HPSIZE_DEFAULT    0   /* THP */
-#define DSMML_HPSIZE_2M         5   /* 2MB explicit huge pages */
+typedef enum { DSMML_MODE_DEFAULT = 0, DSMML_MODE_PREFERRED, DSMML_MODE_BIND,
+               DSMML_MODE_INTERLEAVE } dsmml_mode_t;
+typedef enum { DSMML_MEM_SYS_DEFAULT = 0, DSMML_MEM_NORMAL = 1,
+               DSMML_MEM_FAST = 2, DSMML_MEM_CUSTOM = 3 } dsmml_type_t;
+typedef enum {
+    DSMML_HPSIZE_DEFAULT = 1,   /* THP */
+    DSMML_HPSIZE_4K      = 2,
+    DSMML_HPSIZE_2M      = 3,
+    DSMML_HPSIZE_4M      = 4,
+} dsmml_hpsize_t;
+typedef enum { DSMML_NNODE_INDEX1 = 0x01 } dsmml_nnode_t;
+
+typedef struct {
+    int            mype;
+    int            smp_mype;
+    int            smp_npes;
+    int            smp_set;
+} dsmml_init_info_t;
 
 typedef struct {
     int            id;
     void          *act_addr;
-    void          *device_addr;
     void          *base_addr;
     size_t         length;
     dsmml_type_t   type;
@@ -156,16 +178,13 @@ typedef struct {
     int            smp_mype;
     int            smp_npes;
     int            smp_set;
-    int            nnode;
-    int            use_ext_mem;
+    dsmml_nnode_t  nnode;
 } dsmml_sheap_seg_info_t;
 
-typedef struct { int unused; } dsmml_init_info_t;
-
-static void  *dsmml_handle  = NULL;
-static int  (*dsmml_init_fn)(dsmml_init_info_t *)              = NULL;
-static int  (*dsmml_finalize_fn)(void)                         = NULL;
-static int  (*dsmml_create_sheap_seg_fn)(dsmml_sheap_seg_info_t *) = NULL;
+static void  *dsmml_handle             = NULL;
+static dsmml_return_t (*dsmml_init_fn)(dsmml_init_info_t *)              = NULL;
+static dsmml_return_t (*dsmml_finalize_fn)(void)                         = NULL;
+static dsmml_return_t (*dsmml_create_sheap_seg_fn)(dsmml_sheap_seg_info_t *) = NULL;
 
 static void *dsmml_alloc(void *requested_base, size_t bytes)
 {
@@ -189,7 +208,12 @@ static void *dsmml_alloc(void *requested_base, size_t bytes)
         return NULL;
     }
 
-    dsmml_init_info_t init_info = {0};
+    dsmml_init_info_t init_info = {
+        .mype     = shmem_internal_my_pe,
+        .smp_mype = shmem_internal_my_pe % shmem_internal_num_pes,
+        .smp_npes = shmem_internal_num_pes,
+        .smp_set  = 0,
+    };
     if (dsmml_init_fn(&init_info) != DSMML_RC_SUCCESS) {
         RAISE_WARN_STR("DSMML: dsmml_init failed");
         dlclose(dsmml_handle);
@@ -204,6 +228,9 @@ static void *dsmml_alloc(void *requested_base, size_t bytes)
         .type       = DSMML_MEM_SYS_DEFAULT,
         .mode       = DSMML_MODE_DEFAULT,
         .pagesize   = DSMML_HPSIZE_2M,
+        .smp_mype   = init_info.smp_mype,
+        .smp_npes   = init_info.smp_npes,
+        .smp_set    = 0,
     };
 
     if (dsmml_create_sheap_seg_fn(&seg) != DSMML_RC_SUCCESS) {
@@ -219,7 +246,7 @@ static void *dsmml_alloc(void *requested_base, size_t bytes)
         }
     }
 
-    DEBUG_MSG("DSMML: heap allocated at %p (requested %p), size %zu, pagesize %s\n",
+    DEBUG_MSG("DSMML: heap at %p (requested %p), %zu bytes, pagesize %s\n",
               seg.act_addr, requested_base, bytes,
               seg.pagesize == DSMML_HPSIZE_2M ? "2MB" : "THP");
 
@@ -329,6 +356,11 @@ static void *mmap_alloc(size_t bytes)
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                     DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages",
                               strerror(errno));
+                } else {
+                    if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
+                        DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
+                                  strerror(errno));
+                    }
                 }
             }
         } else {
@@ -346,6 +378,11 @@ static void *mmap_alloc(size_t bytes)
             if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                 RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
                                strerror(errno));
+            } else {
+                if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
+                    DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
+                              strerror(errno));
+                }
             }
         }
     }
@@ -366,6 +403,11 @@ static void *mmap_alloc(size_t bytes)
             if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                 RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
                                strerror(errno));
+            } else {
+                if (madvise(ret, bytes, MADV_COLLAPSE) != 0) {
+                    DEBUG_MSG("madvise(MADV_COLLAPSE) failed (%s), THP promotion deferred",
+                              strerror(errno));
+                }
             }
         }
 #endif

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -105,7 +105,7 @@ long                            shmem_transport_ofi_amo_pipeline_depth;
 size_t                          shmem_transport_ofi_max_buffered_send;
 size_t                          shmem_transport_ofi_max_msg_size;
 size_t                          shmem_transport_ofi_bounce_buffer_size;
-long                            shmem_transport_ofi_max_bounce_buffers;
+size_t                          shmem_transport_ofi_max_bounce_buffers;
 size_t                          shmem_transport_ofi_addrlen;
 #ifdef ENABLE_MR_RMA_EVENT
 int                             shmem_transport_ofi_mr_rma_event;
@@ -1859,10 +1859,15 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         shmem_transport_ofi_bounce_buffer_size > 0 &&
         shmem_transport_ofi_max_bounce_buffers > 0)
     {
+        size_t max_bb_pool_cnt = 0;
+        if (shmem_internal_params.BOUNCE_SHEAP) {
+            max_bb_pool_cnt = shmem_transport_ofi_max_bounce_buffers;
+        }
         ctx->bounce_buffers =
             shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t) +
                                  shmem_transport_ofi_bounce_buffer_size,
-                                 init_bounce_buffer);
+                                 init_bounce_buffer,
+                                 max_bb_pool_cnt);
     }
     else {
         ctx->options &= ~SHMEMX_CTX_BOUNCE_BUFFER;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1353,6 +1353,31 @@ int allocate_fabric_resources(struct fabric_info *info)
                     &shmem_transport_ofi_domainfd,NULL);
     OFI_CHECK_RETURN_STR(ret, "domain initialization failed");
 
+    /* CXI provider: enable hybrid local MR descriptor mode.  When enabled,
+     * libfabric will skip its internal MR registration if a non-NULL desc is
+     * passed (and proceed without registration if desc is NULL).  This avoids
+     * per-call MR cache lookups for source buffers in fi_write/fi_writemsg.
+     * Must be done BEFORE any endpoints are created (the provider only
+     * propagates this setting to child endpoints at creation time). */
+    if (shmem_internal_params.OFI_CXI_HYBRID_MR_DESC) {
+        struct cxi_dom_ops_v3_local {
+            int (*cntr_read)(struct fid *, unsigned int, uint64_t *, struct timespec *);
+            int (*topology)(struct fid *, unsigned int *, unsigned int *, unsigned int *);
+            int (*enable_hybrid_mr_desc)(struct fid *, bool);
+        } *cxi_dom_ops = NULL;
+        int hret = fi_open_ops(&shmem_transport_ofi_domainfd->fid,
+                               "dom_ops_v3", 0, (void **)&cxi_dom_ops, NULL);
+        if (hret == 0 && cxi_dom_ops && cxi_dom_ops->enable_hybrid_mr_desc) {
+            hret = cxi_dom_ops->enable_hybrid_mr_desc(&shmem_transport_ofi_domainfd->fid, true);
+            if (hret == 0) {
+                DEBUG_STR("CXI: hybrid local MR descriptor mode enabled");
+            } else {
+                DEBUG_MSG("CXI: enable_hybrid_mr_desc failed (%s)\n", fi_strerror(-hret));
+            }
+        }
+        /* Silently ignore non-CXI providers (fi_open_ops returns -FI_ENOSYS) */
+    }
+
     /* AV table set-up for PE mapping */
 
 #ifdef USE_AV_MAP

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -214,7 +214,16 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
 
 static struct fabric_info shmem_transport_ofi_info = {0};
 
-int shmem_transport_ofi_is_cxi = 0;
+static char *shmem_transport_ofi_prov_name = NULL;
+
+/* Check if the current OFI provider matches the given name.
+ * Returns 1 if provider matches, 0 otherwise. */
+static inline int
+shmem_transport_ofi_check_provider(const char *name)
+{
+    return (shmem_transport_ofi_prov_name &&
+            strncmp(shmem_transport_ofi_prov_name, name, strlen(name)) == 0);
+}
 
 static size_t shmem_transport_ofi_grow_size = 128;
 
@@ -1726,11 +1735,8 @@ int query_for_fabric(struct fabric_info *info)
               shmem_transport_ofi_stx_max,
               num_nics);
 
-    /* Set CXI provider flag for fence optimization */
-    shmem_transport_ofi_is_cxi = (info->p_info->fabric_attr->prov_name &&
-                                  strncmp(info->p_info->fabric_attr->prov_name,
-                                          SHMEM_TRANSPORT_OFI_PROV_CXI,
-                                          strlen(SHMEM_TRANSPORT_OFI_PROV_CXI)) == 0);
+    /* Store provider name for runtime checks */
+    shmem_transport_ofi_prov_name = info->p_info->fabric_attr->prov_name;
 
     return ret;
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -100,6 +100,7 @@ struct fid_mr*                  shmem_transport_ofi_mrfd_list[3];
 uint64_t                        shmem_transport_ofi_max_poll;
 long                            shmem_transport_ofi_put_poll_limit;
 long                            shmem_transport_ofi_get_poll_limit;
+long                            shmem_transport_ofi_put_pipeline_depth;
 size_t                          shmem_transport_ofi_max_buffered_send;
 size_t                          shmem_transport_ofi_max_msg_size;
 size_t                          shmem_transport_ofi_bounce_buffer_size;
@@ -1918,8 +1919,9 @@ int shmem_transport_init(void)
         shmem_transport_ofi_max_bounce_buffers = shmem_internal_params.MAX_BOUNCE_BUFFERS;
     }
 
-    shmem_transport_ofi_put_poll_limit = shmem_internal_params.OFI_TX_POLL_LIMIT;
-    shmem_transport_ofi_get_poll_limit = shmem_internal_params.OFI_RX_POLL_LIMIT;
+    shmem_transport_ofi_put_poll_limit    = shmem_internal_params.OFI_TX_POLL_LIMIT;
+    shmem_transport_ofi_get_poll_limit    = shmem_internal_params.OFI_RX_POLL_LIMIT;
+    shmem_transport_ofi_put_pipeline_depth = shmem_internal_params.OFI_PUT_PIPELINE_DEPTH;
 
 #ifdef USE_CTX_LOCK
     /* In multithreaded mode, force completion polling so that threads yield

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -70,12 +70,8 @@ struct fid_cq*                  shmem_transport_ofi_target_cq;
 struct fid_cntr*                shmem_transport_ofi_target_cntrfd;
 #endif
 #ifdef ENABLE_MR_SCALABLE
-#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-struct fid_mr*                  shmem_transport_ofi_target_mrfd;
-#else  /* !ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
-#endif
 #else  /* !ENABLE_MR_SCALABLE */
 struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
@@ -713,30 +709,7 @@ int ofi_mr_reg_bind(uint64_t flags)
     access_flags |= FI_READ;
 #endif
 
-#if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
-    ret = fi_mr_reg(shmem_transport_ofi_domainfd, 0, UINT64_MAX,
-                    access_flags, 0, 0ULL, flags,
-                    &shmem_transport_ofi_target_mrfd, NULL);
-    OFI_CHECK_RETURN_STR(ret, "target memory (all) registration failed");
-
-    /* Bind counter with target memory region for incoming messages */
-#if ENABLE_TARGET_CNTR
-    ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
-                     &shmem_transport_ofi_target_cntrfd->fid,
-                     FI_REMOTE_WRITE);
-    OFI_CHECK_RETURN_STR(ret, "target CNTR binding to MR failed");
-
-#ifdef ENABLE_MR_RMA_EVENT
-    if (shmem_transport_ofi_mr_rma_event) {
-        ret = fi_mr_enable(shmem_transport_ofi_target_mrfd);
-        OFI_CHECK_RETURN_STR(ret, "target MR enable failed");
-    }
-#endif /* ENABLE_MR_RMA_EVENT */
-#endif /* ENABLE_TARGET_CNTR */
-    shmem_transport_ofi_mrfd_list[0] = shmem_transport_ofi_target_mrfd;
-    shmem_transport_ofi_mrfd_list[1] = NULL;
-
-#else
+#ifdef ENABLE_MR_SCALABLE
     /* Register separate data and heap segments using keys 0 and 1,
      * respectively.  In MR_BASIC_MODE, the keys are ignored and selected by
      * the provider. */
@@ -1652,17 +1625,12 @@ int query_for_fabric(struct fabric_info *info)
         shmem_transport_ofi_stx_max = 0;
     }
 
-#if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
-    /* Only use a single MR, no keys required */
-    info->p_info->domain_attr->mr_key_size = 0;
-#else
     /* Heap and data use different MR keys, need at least 1 byte of key space
      * if using provider selected keys */
     if (info->p_info->domain_attr->mr_mode & FI_MR_PROV_KEY)
         info->p_info->domain_attr->mr_key_size = 1;
     else
         info->p_info->domain_attr->mr_key_size = 0;
-#endif
 
 #ifndef DISABLE_OFI_INJECT
     DEBUG_MSG(RAISE_PE_PREFIX "tx_attr->inject_size (provider): %zu, requested: %zu\n",
@@ -2224,16 +2192,11 @@ int shmem_transport_fini(void)
     if (shmem_transport_ofi_stx_pool) free(shmem_transport_ofi_stx_pool);
 
 #if defined(ENABLE_MR_SCALABLE)
-#if defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
-    ret = fi_close(&shmem_transport_ofi_target_mrfd->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Target MR close failed (%s)\n", fi_strerror(errno));
-#else
     ret = fi_close(&shmem_transport_ofi_target_heap_mrfd->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target heap MR close failed (%s)\n", fi_strerror(errno));
 
     ret = fi_close(&shmem_transport_ofi_target_data_mrfd->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Target data MR close failed (%s)\n", fi_strerror(errno));  
-#endif
+    OFI_CHECK_ERROR_MSG(ret, "Target data MR close failed (%s)\n", fi_strerror(errno));
 #else
     free(shmem_transport_ofi_target_heap_keys);
     free(shmem_transport_ofi_target_data_keys);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1480,7 +1480,9 @@ int query_for_fabric(struct fabric_info *info)
     struct fi_fabric_attr fabric_attr = {0};
     struct fi_ep_attr   ep_attr = {0};
 
-    shmem_transport_ofi_max_buffered_send = sizeof(long double);
+    /* Hint 0 = no minimum inject requirement; provider returns its natural
+     * inject_size, which is adopted below after fi_getinfo. */
+    shmem_transport_ofi_max_buffered_send = 0;
 
     fabric_attr.prov_name = info->prov_name;
 

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1650,6 +1650,10 @@ int query_for_fabric(struct fabric_info *info)
 #endif
 
 #ifndef DISABLE_OFI_INJECT
+    DEBUG_MSG(RAISE_PE_PREFIX "tx_attr->inject_size (provider): %zu, requested: %zu\n",
+              shmem_internal_my_pe,
+              info->p_info->tx_attr->inject_size,
+              shmem_transport_ofi_max_buffered_send);
     shmem_internal_assertp(info->p_info->tx_attr->inject_size >= shmem_transport_ofi_max_buffered_send);
     shmem_transport_ofi_max_buffered_send = info->p_info->tx_attr->inject_size;
 #else

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1547,7 +1547,7 @@ int query_for_fabric(struct fabric_info *info)
     ep_attr.type              = FI_EP_RDM; /* reliable connectionless */
     ep_attr.tx_ctx_cnt        = 0;
     hints.fabric_attr         = &fabric_attr;
-    tx_attr.op_flags          = FI_DELIVERY_COMPLETE;
+    tx_attr.op_flags          = FI_TRANSMIT_COMPLETE;
     tx_attr.inject_size       = shmem_transport_ofi_max_buffered_send; /* require provider to support this as a min */
     hints.tx_attr             = &tx_attr; /* TODO: fill tx_attr */
     hints.rx_attr             = NULL;
@@ -1772,7 +1772,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
 
     info->p_info->ep_attr->tx_ctx_cnt = shmem_transport_ofi_stx_max > 0 ? FI_SHARED_CONTEXT : 0;
     info->p_info->caps = FI_RMA | FI_WRITE | FI_READ | FI_ATOMIC | FI_RECV;
-    info->p_info->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+    info->p_info->tx_attr->op_flags = FI_TRANSMIT_COMPLETE;
     info->p_info->mode = 0;
     info->p_info->tx_attr->mode = 0;
     info->p_info->rx_attr->mode = 0;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1369,13 +1369,18 @@ int allocate_fabric_resources(struct fabric_info *info)
                                "dom_ops_v3", 0, (void **)&cxi_dom_ops, NULL);
         if (hret == 0 && cxi_dom_ops && cxi_dom_ops->enable_hybrid_mr_desc) {
             hret = cxi_dom_ops->enable_hybrid_mr_desc(&shmem_transport_ofi_domainfd->fid, true);
-            if (hret == 0) {
-                DEBUG_STR("CXI: hybrid local MR descriptor mode enabled");
-            } else {
-                DEBUG_MSG("CXI: enable_hybrid_mr_desc failed (%s)\n", fi_strerror(-hret));
+            if (shmem_internal_my_pe == 0) {
+                if (hret == 0)
+                    fprintf(stderr, "SOS: CXI hybrid local MR descriptor mode ENABLED\n");
+                else
+                    fprintf(stderr, "SOS: CXI enable_hybrid_mr_desc FAILED (%s)\n", fi_strerror(-hret));
             }
+        } else if (shmem_internal_my_pe == 0) {
+            fprintf(stderr, "SOS: CXI hybrid MR desc not available (fi_open_ops returned %d / %s) — non-CXI provider or older libfabric\n",
+                    hret, hret ? fi_strerror(-hret) : "no ops struct");
         }
-        /* Silently ignore non-CXI providers (fi_open_ops returns -FI_ENOSYS) */
+    } else if (shmem_internal_my_pe == 0) {
+        fprintf(stderr, "SOS: CXI hybrid local MR descriptor mode DISABLED (SHMEM_OFI_CXI_HYBRID_MR_DESC=0)\n");
     }
 
     /* AV table set-up for PE mapping */

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -210,8 +210,11 @@ struct shmem_internal_tid shmem_transport_ofi_gettid(void)
 }
 
 #define SHMEM_TRANSPORT_OFI_PROV_SOCKETS "sockets"
+#define SHMEM_TRANSPORT_OFI_PROV_CXI     "cxi"
 
 static struct fabric_info shmem_transport_ofi_info = {0};
+
+int shmem_transport_ofi_is_cxi = 0;
 
 static size_t shmem_transport_ofi_grow_size = 128;
 
@@ -1722,6 +1725,12 @@ int query_for_fabric(struct fabric_info *info)
               info->p_info->domain_attr->max_ep_stx_ctx == 0 ? "no" : "yes",
               shmem_transport_ofi_stx_max,
               num_nics);
+
+    /* Set CXI provider flag for fence optimization */
+    shmem_transport_ofi_is_cxi = (info->p_info->fabric_attr->prov_name &&
+                                  strncmp(info->p_info->fabric_attr->prov_name,
+                                          SHMEM_TRANSPORT_OFI_PROV_CXI,
+                                          strlen(SHMEM_TRANSPORT_OFI_PROV_CXI)) == 0);
 
     return ret;
 }

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1782,6 +1782,7 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     cntr_put_attr.events   = FI_CNTR_EVENTS_COMP;
     cntr_get_attr.events   = FI_CNTR_EVENTS_COMP;
 
+#if 0
     /* Set FI_WAIT based on the put and get polling limits defined above */
     if (shmem_transport_ofi_put_poll_limit < 0) {
         cntr_put_attr.wait_obj = FI_WAIT_NONE;
@@ -1793,6 +1794,9 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     } else {
         cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
     }
+#endif
+        cntr_put_attr.wait_obj = FI_WAIT_UNSPEC;
+        cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
 
     /* Allow provider to choose CQ size, since we are using FI_RM_ENABLED.
      * Context format is used to return bounce buffer pointers in the event

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -101,6 +101,7 @@ uint64_t                        shmem_transport_ofi_max_poll;
 long                            shmem_transport_ofi_put_poll_limit;
 long                            shmem_transport_ofi_get_poll_limit;
 long                            shmem_transport_ofi_put_pipeline_depth;
+long                            shmem_transport_ofi_amo_pipeline_depth;
 size_t                          shmem_transport_ofi_max_buffered_send;
 size_t                          shmem_transport_ofi_max_msg_size;
 size_t                          shmem_transport_ofi_bounce_buffer_size;
@@ -1922,6 +1923,7 @@ int shmem_transport_init(void)
     shmem_transport_ofi_put_poll_limit    = shmem_internal_params.OFI_TX_POLL_LIMIT;
     shmem_transport_ofi_get_poll_limit    = shmem_internal_params.OFI_RX_POLL_LIMIT;
     shmem_transport_ofi_put_pipeline_depth = shmem_internal_params.OFI_PUT_PIPELINE_DEPTH;
+    shmem_transport_ofi_amo_pipeline_depth = shmem_internal_params.OFI_AMO_PIPELINE_DEPTH;
 
 #ifdef USE_CTX_LOCK
     /* In multithreaded mode, force completion polling so that threads yield

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -655,6 +655,11 @@ int ofi_mr_reg_external_heap(void)
 {
     int ret = 0;
     uint64_t key = 2;
+    uint64_t access_flags = FI_REMOTE_READ | FI_REMOTE_WRITE;
+
+#ifdef ENABLE_MR_LOCAL
+    access_flags |= FI_READ;
+#endif
 
     const struct iovec iov = {
                                .iov_base     = shmem_external_heap_base,
@@ -663,7 +668,7 @@ int ofi_mr_reg_external_heap(void)
     const struct fi_mr_attr mr_attr = {
                                         .mr_iov         = &iov,
                                         .iov_count      = 1,
-                                        .access         = FI_REMOTE_READ | FI_REMOTE_WRITE,
+                                        .access         = access_flags,
                                         .requested_key  = key,
                                         .iface          = (shmem_external_heap_device_type == 
                                                           SHMEMX_EXTERNAL_HEAP_ZE ? FI_HMEM_ZE : FI_HMEM_CUDA),
@@ -702,10 +707,15 @@ static inline
 int ofi_mr_reg_bind(uint64_t flags)
 {
     int ret = 0;
+    uint64_t access_flags = FI_REMOTE_READ | FI_REMOTE_WRITE;
+
+#ifdef ENABLE_MR_LOCAL
+    access_flags |= FI_READ;
+#endif
 
 #if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, 0, UINT64_MAX,
-                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0ULL, flags,
+                    access_flags, 0, 0ULL, flags,
                     &shmem_transport_ofi_target_mrfd, NULL);
     OFI_CHECK_RETURN_STR(ret, "target memory (all) registration failed");
 
@@ -733,14 +743,14 @@ int ofi_mr_reg_bind(uint64_t flags)
     uint64_t key = 1;
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, shmem_internal_heap_base,
                     shmem_internal_heap_length,
-                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, key, flags,
+                    access_flags, 0, key, flags,
                     &shmem_transport_ofi_target_heap_mrfd, NULL);
     OFI_CHECK_RETURN_STR(ret, "target memory (heap) registration failed");
 
     key = 0;
     ret = fi_mr_reg(shmem_transport_ofi_domainfd, shmem_internal_data_base,
                     shmem_internal_data_length,
-                    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, key, flags,
+                    access_flags, 0, key, flags,
                     &shmem_transport_ofi_target_data_mrfd, NULL);
     OFI_CHECK_RETURN_STR(ret, "target memory (data) registration failed");
 
@@ -1507,6 +1517,9 @@ int query_for_fabric(struct fabric_info *info)
 #endif
 #ifdef ENABLE_MR_ENDPOINT
     domain_attr.mr_mode |= FI_MR_ENDPOINT;
+#endif
+#ifdef ENABLE_MR_LOCAL
+    domain_attr.mr_mode |= FI_MR_LOCAL;
 #endif
 #ifdef USE_FI_HMEM
     domain_attr.mr_mode |= FI_MR_HMEM;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -1782,7 +1782,6 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     cntr_put_attr.events   = FI_CNTR_EVENTS_COMP;
     cntr_get_attr.events   = FI_CNTR_EVENTS_COMP;
 
-#if 0
     /* Set FI_WAIT based on the put and get polling limits defined above */
     if (shmem_transport_ofi_put_poll_limit < 0) {
         cntr_put_attr.wait_obj = FI_WAIT_NONE;
@@ -1794,9 +1793,6 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
     } else {
         cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
     }
-#endif
-        cntr_put_attr.wait_obj = FI_WAIT_UNSPEC;
-        cntr_get_attr.wait_obj = FI_WAIT_UNSPEC;
 
     /* Allow provider to choose CQ size, since we are using FI_RM_ENABLED.
      * Context format is used to return bounce buffer pointers in the event

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -70,8 +70,12 @@ struct fid_cq*                  shmem_transport_ofi_target_cq;
 struct fid_cntr*                shmem_transport_ofi_target_cntrfd;
 #endif
 #ifdef ENABLE_MR_SCALABLE
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+struct fid_mr*                  shmem_transport_ofi_target_mrfd;
+#else  /* !ENABLE_REMOTE_VIRTUAL_ADDRESSING */
 struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
+#endif
 #else  /* !ENABLE_MR_SCALABLE */
 struct fid_mr*                  shmem_transport_ofi_target_heap_mrfd;
 struct fid_mr*                  shmem_transport_ofi_target_data_mrfd;
@@ -709,7 +713,30 @@ int ofi_mr_reg_bind(uint64_t flags)
     access_flags |= FI_READ;
 #endif
 
-#ifdef ENABLE_MR_SCALABLE
+#if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
+    ret = fi_mr_reg(shmem_transport_ofi_domainfd, 0, UINT64_MAX,
+                    access_flags, 0, 0ULL, flags,
+                    &shmem_transport_ofi_target_mrfd, NULL);
+    OFI_CHECK_RETURN_STR(ret, "target memory (all) registration failed");
+
+    /* Bind counter with target memory region for incoming messages */
+#if ENABLE_TARGET_CNTR
+    ret = fi_mr_bind(shmem_transport_ofi_target_mrfd,
+                     &shmem_transport_ofi_target_cntrfd->fid,
+                     FI_REMOTE_WRITE);
+    OFI_CHECK_RETURN_STR(ret, "target CNTR binding to MR failed");
+
+#ifdef ENABLE_MR_RMA_EVENT
+    if (shmem_transport_ofi_mr_rma_event) {
+        ret = fi_mr_enable(shmem_transport_ofi_target_mrfd);
+        OFI_CHECK_RETURN_STR(ret, "target MR enable failed");
+    }
+#endif /* ENABLE_MR_RMA_EVENT */
+#endif /* ENABLE_TARGET_CNTR */
+    shmem_transport_ofi_mrfd_list[0] = shmem_transport_ofi_target_mrfd;
+    shmem_transport_ofi_mrfd_list[1] = NULL;
+
+#else
     /* Register separate data and heap segments using keys 0 and 1,
      * respectively.  In MR_BASIC_MODE, the keys are ignored and selected by
      * the provider. */
@@ -1625,12 +1652,17 @@ int query_for_fabric(struct fabric_info *info)
         shmem_transport_ofi_stx_max = 0;
     }
 
+#if defined(ENABLE_MR_SCALABLE) && defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
+    /* Only use a single MR, no keys required */
+    info->p_info->domain_attr->mr_key_size = 0;
+#else
     /* Heap and data use different MR keys, need at least 1 byte of key space
      * if using provider selected keys */
     if (info->p_info->domain_attr->mr_mode & FI_MR_PROV_KEY)
         info->p_info->domain_attr->mr_key_size = 1;
     else
         info->p_info->domain_attr->mr_key_size = 0;
+#endif
 
 #ifndef DISABLE_OFI_INJECT
     DEBUG_MSG(RAISE_PE_PREFIX "tx_attr->inject_size (provider): %zu, requested: %zu\n",
@@ -2192,11 +2224,16 @@ int shmem_transport_fini(void)
     if (shmem_transport_ofi_stx_pool) free(shmem_transport_ofi_stx_pool);
 
 #if defined(ENABLE_MR_SCALABLE)
+#if defined(ENABLE_REMOTE_VIRTUAL_ADDRESSING)
+    ret = fi_close(&shmem_transport_ofi_target_mrfd->fid);
+    OFI_CHECK_ERROR_MSG(ret, "Target MR close failed (%s)\n", fi_strerror(errno));
+#else
     ret = fi_close(&shmem_transport_ofi_target_heap_mrfd->fid);
     OFI_CHECK_ERROR_MSG(ret, "Target heap MR close failed (%s)\n", fi_strerror(errno));
 
     ret = fi_close(&shmem_transport_ofi_target_data_mrfd->fid);
-    OFI_CHECK_ERROR_MSG(ret, "Target data MR close failed (%s)\n", fi_strerror(errno));
+    OFI_CHECK_ERROR_MSG(ret, "Target data MR close failed (%s)\n", fi_strerror(errno));  
+#endif
 #else
     free(shmem_transport_ofi_target_heap_keys);
     free(shmem_transport_ofi_target_data_keys);

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -105,7 +105,7 @@ long                            shmem_transport_ofi_amo_pipeline_depth;
 size_t                          shmem_transport_ofi_max_buffered_send;
 size_t                          shmem_transport_ofi_max_msg_size;
 size_t                          shmem_transport_ofi_bounce_buffer_size;
-size_t                          shmem_transport_ofi_max_bounce_buffers;
+long                            shmem_transport_ofi_max_bounce_buffers;
 size_t                          shmem_transport_ofi_addrlen;
 #ifdef ENABLE_MR_RMA_EVENT
 int                             shmem_transport_ofi_mr_rma_event;
@@ -1855,15 +1855,10 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         shmem_transport_ofi_bounce_buffer_size > 0 &&
         shmem_transport_ofi_max_bounce_buffers > 0)
     {
-        size_t max_bb_pool_cnt = 0;
-        if (shmem_internal_params.BOUNCE_SHEAP) {
-            max_bb_pool_cnt = shmem_transport_ofi_max_bounce_buffers;
-        }
         ctx->bounce_buffers =
             shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t) +
                                  shmem_transport_ofi_bounce_buffer_size,
-                                 init_bounce_buffer,
-                                 max_bb_pool_cnt);
+                                 init_bounce_buffer);
     }
     else {
         ctx->options &= ~SHMEMX_CTX_BOUNCE_BUFFER;

--- a/src/transport_ofi.c
+++ b/src/transport_ofi.c
@@ -105,7 +105,7 @@ long                            shmem_transport_ofi_amo_pipeline_depth;
 size_t                          shmem_transport_ofi_max_buffered_send;
 size_t                          shmem_transport_ofi_max_msg_size;
 size_t                          shmem_transport_ofi_bounce_buffer_size;
-long                            shmem_transport_ofi_max_bounce_buffers;
+size_t                          shmem_transport_ofi_max_bounce_buffers;
 size_t                          shmem_transport_ofi_addrlen;
 #ifdef ENABLE_MR_RMA_EVENT
 int                             shmem_transport_ofi_mr_rma_event;
@@ -1855,10 +1855,15 @@ static int shmem_transport_ofi_ctx_init(shmem_transport_ctx_t *ctx, int id)
         shmem_transport_ofi_bounce_buffer_size > 0 &&
         shmem_transport_ofi_max_bounce_buffers > 0)
     {
+        size_t max_bb_pool_cnt = 0;
+        if (shmem_internal_params.BOUNCE_SHEAP) {
+            max_bb_pool_cnt = shmem_transport_ofi_max_bounce_buffers;
+        }
         ctx->bounce_buffers =
             shmem_free_list_init(sizeof(shmem_transport_ofi_bounce_buffer_t) +
                                  shmem_transport_ofi_bounce_buffer_size,
-                                 init_bounce_buffer);
+                                 init_bounce_buffer,
+                                 max_bb_pool_cnt);
     }
     else {
         ctx->options &= ~SHMEMX_CTX_BOUNCE_BUFFER;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -67,6 +67,7 @@ extern uint64_t                         shmem_transport_ofi_max_poll;
 extern long                             shmem_transport_ofi_put_poll_limit;
 extern long                             shmem_transport_ofi_get_poll_limit;
 extern long                             shmem_transport_ofi_put_pipeline_depth;
+extern long                             shmem_transport_ofi_amo_pipeline_depth;
 extern size_t                           shmem_transport_ofi_max_buffered_send;
 extern size_t                           shmem_transport_ofi_max_msg_size;
 extern size_t                           shmem_transport_ofi_bounce_buffer_size;
@@ -479,6 +480,27 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
     memcpy(buff->data, source, len);
 
     return buff;
+}
+
+/* Throttle in-flight fetching AMOs to at most shmem_transport_ofi_amo_pipeline_depth.
+ * Paces AMO issue rate so that all PEs collectively do not saturate the target
+ * NIC's TRS pool.  At 128 PPN with ~512 TRS slots, a depth of 4 leaves headroom
+ * for each PE.  Called with ctx lock held; temporarily drops it while spinning. */
+static inline
+void shmem_transport_ofi_amo_pipeline_throttle(shmem_transport_ctx_t *ctx)
+{
+    if (shmem_transport_ofi_amo_pipeline_depth <= 0) return;
+
+    uint64_t pending   = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
+    uint64_t completed = fi_cntr_read(ctx->get_cntr);
+
+    while ((long)(pending - completed) >= shmem_transport_ofi_amo_pipeline_depth) {
+        SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+        shmem_transport_probe();
+        SPINLOCK_BODY();
+        SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        completed = fi_cntr_read(ctx->get_cntr);
+    }
 }
 
 /* Throttle in-flight puts to at most shmem_transport_ofi_put_pipeline_depth.
@@ -1335,6 +1357,7 @@ void shmem_transport_fetch_atomic_nbi(shmem_transport_ctx_t* ctx, void *target,
                                };
 
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+    shmem_transport_ofi_amo_pipeline_throttle(ctx);
     SHMEM_TRANSPORT_OFI_CNTR_INC(&ctx->pending_get_cntr);
 
     do {

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -548,28 +548,8 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the put issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t success, fail, cnt, cnt_new;
-    long poll_count = 0;
-    while (poll_count < shmem_transport_ofi_put_poll_limit ||
-           shmem_transport_ofi_put_poll_limit < 0) {
-        success = fi_cntr_read(ctx->put_cntr);
-        fail = fi_cntr_readerr(ctx->put_cntr);
-        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
+    uint64_t cnt, cnt_new;
 
-        shmem_transport_probe();
-
-        if (success < cnt && fail == 0) {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            SPINLOCK_BODY();
-            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
-        } else {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            return;
-        }
-        poll_count++;
-    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
     do {
         cnt = cnt_new;
@@ -1036,31 +1016,10 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the get issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t success, fail, cnt, cnt_new;
-    long poll_count = 0;
+    uint64_t cnt, cnt_new;
 
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
 
-    while (poll_count < shmem_transport_ofi_get_poll_limit ||
-           shmem_transport_ofi_get_poll_limit < 0) {
-        success = fi_cntr_read(ctx->get_cntr);
-        fail = fi_cntr_readerr(ctx->get_cntr);
-        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
-
-        shmem_transport_probe();
-
-        if (success < cnt && fail == 0) {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            SPINLOCK_BODY();
-            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
-        } else {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            return;
-        }
-        poll_count++;
-    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
     do {
         cnt = cnt_new;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -687,7 +687,7 @@ void shmem_transport_put_scalar(shmem_transport_ctx_t* ctx, void *target, const
 
 static inline
 void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, const void *source,
-                                   size_t len, int pe)
+                                   size_t len, int pe, long *completion)
 {
     int ret = 0;
     uint64_t dst = (uint64_t) pe;
@@ -701,8 +701,10 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
     uint64_t frag_target = (uint64_t) addr;
     size_t frag_len = len;
 
-    /* operation generates counting events and must be completed by
-     * quiet. */
+    /* Issue all fragments, then capture the pending_put_cntr watermark.  put_wait
+     * spins until fi_cntr_read(put_cntr) >= watermark, draining only this call's
+     * puts (plus any earlier in-flight ones) rather than triggering a global
+     * put_quiet which would also wait on unrelated subsequent puts. */
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
     shmem_transport_ofi_put_pipeline_throttle(ctx);
     while (frag_source < ((uint8_t *) source) + len) {
@@ -723,6 +725,8 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
         frag_source += frag_len;
         frag_target += frag_len;
     }
+    if (completion)
+        *completion = (long) SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
     SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 }
 
@@ -771,8 +775,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 
     } else {
-        shmem_transport_ofi_put_large(ctx, target, source,len, pe);
-        (*completion)++;
+        shmem_transport_ofi_put_large(ctx, target, source, len, pe, completion);
     }
 }
 
@@ -919,16 +922,38 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
     SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 }
 
-/* compatibility with Portals transport */
+/* Per-call put completion: wait only for puts up through the watermark recorded
+ * at issue time, instead of triggering a global put_quiet that would also wait
+ * on unrelated subsequent puts.  *completion holds the value of pending_put_cntr
+ * captured immediately after the put's fragments were issued. */
 static inline
 void shmem_transport_put_wait(shmem_transport_ctx_t* ctx, long *completion) {
 
     shmem_internal_assert((*completion) >= 0);
 
-    if((*completion) > 0) {
-        shmem_transport_put_quiet(ctx);
-        (*completion)--;
+    if ((*completion) == 0) return;
+
+    uint64_t watermark = (uint64_t) *completion;
+    uint64_t completed = fi_cntr_read(ctx->put_cntr);
+    long poll_count = 0;
+
+    while (completed < watermark) {
+        uint64_t fail = fi_cntr_readerr(ctx->put_cntr);
+        if (fail) {
+            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
+        }
+        shmem_transport_probe();
+        if (poll_count >= shmem_transport_ofi_put_poll_limit &&
+            shmem_transport_ofi_put_poll_limit >= 0) {
+            ssize_t ret = fi_cntr_wait(ctx->put_cntr, watermark, -1);
+            OFI_CTX_CHECK_ERROR(ctx, ret);
+            break;
+        }
+        SPINLOCK_BODY();
+        completed = fi_cntr_read(ctx->put_cntr);
+        poll_count++;
     }
+    *completion = 0;
 }
 
 static inline
@@ -941,7 +966,7 @@ void shmem_transport_put_nbi(shmem_transport_ctx_t* ctx, void *target, const voi
 
     } else {
 
-        shmem_transport_ofi_put_large(ctx, target, source, len, pe);
+        shmem_transport_ofi_put_large(ctx, target, source, len, pe, NULL);
     }
 }
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -597,7 +597,7 @@ static inline
 int shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
-    /* CXI provider maintains per-EP FIFO ordering, so FI_TRANSMIT_COMPLETE
+    /* CXI provider maintains per-EP FIFO ordering, so FI_DELIVERY_COMPLETE
      * guarantees subsequent operations see prior puts at the target. Skip
      * put_quiet poll for ~1-2µs latency improvement. Other providers require
      * explicit put_quiet to ensure remote visibility before fence returns. */

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -552,28 +552,8 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the put issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t success, fail, cnt, cnt_new;
-    long poll_count = 0;
-    while (poll_count < shmem_transport_ofi_put_poll_limit ||
-           shmem_transport_ofi_put_poll_limit < 0) {
-        success = fi_cntr_read(ctx->put_cntr);
-        fail = fi_cntr_readerr(ctx->put_cntr);
-        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
+    uint64_t cnt, cnt_new;
 
-        shmem_transport_probe();
-
-        if (success < cnt && fail == 0) {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            SPINLOCK_BODY();
-            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
-        } else {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            return;
-        }
-        poll_count++;
-    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
     do {
         cnt = cnt_new;
@@ -1040,31 +1020,10 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the get issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t success, fail, cnt, cnt_new;
-    long poll_count = 0;
+    uint64_t cnt, cnt_new;
 
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
 
-    while (poll_count < shmem_transport_ofi_get_poll_limit ||
-           shmem_transport_ofi_get_poll_limit < 0) {
-        success = fi_cntr_read(ctx->get_cntr);
-        fail = fi_cntr_readerr(ctx->get_cntr);
-        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
-
-        shmem_transport_probe();
-
-        if (success < cnt && fail == 0) {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            SPINLOCK_BODY();
-            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
-        } else {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            return;
-        }
-        poll_count++;
-    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
     do {
         cnt = cnt_new;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -71,7 +71,7 @@ extern long                             shmem_transport_ofi_amo_pipeline_depth;
 extern size_t                           shmem_transport_ofi_max_buffered_send;
 extern size_t                           shmem_transport_ofi_max_msg_size;
 extern size_t                           shmem_transport_ofi_bounce_buffer_size;
-extern size_t                             shmem_transport_ofi_max_bounce_buffers;
+extern long                             shmem_transport_ofi_max_bounce_buffers;
 
 extern pthread_mutex_t                  shmem_transport_ofi_progress_lock;
 
@@ -438,7 +438,7 @@ void shmem_transport_ofi_drain_cq(shmem_transport_ctx_t *ctx)
                                      (shmem_transport_ofi_bounce_buffer_t *) frag);
                 ctx->completed_bb_cntr++;
             } else {
-                RAISE_ERROR_MSG("[%d] Unrecognized completion object %p %x mtofs %p\n", shmem_internal_my_pe, frag, frag->mytype, &frag->mytype);
+                RAISE_ERROR_STR("Unrecognized completion object");
             }
         }
 
@@ -474,10 +474,6 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 
     if (NULL == buff)
         RAISE_ERROR_STR("Bounce buffer allocation failed");
-
-    if (buff->frag.mytype != SHMEM_TRANSPORT_OFI_TYPE_BOUNCE) {
-	RAISE_ERROR_STR("Bounce buffer allocation failed");
-    }
 
     shmem_internal_assert(buff->frag.mytype == SHMEM_TRANSPORT_OFI_TYPE_BOUNCE);
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -131,19 +131,13 @@ extern int shmem_transport_ofi_single_ep;
 static inline
 int shmem_transport_ofi_get_mr_desc_index(const void *addr) {
     int ret = -1;
-#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
-    ret = 0;
-#else
     if ((void*) addr >= shmem_internal_data_base &&
         (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
         ret = 0;
     } else if ((void*) addr >= shmem_internal_heap_base &&
                (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
         ret = 1;
-    } else {
-        ret = -1;
     }
-#endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
     return ret;
 }
 #else

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -720,7 +720,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
                                             .data          = 0
                                           };
         do {
-            ret = fi_writemsg(ctx->ep, &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE);
+            ret = fi_writemsg(ctx->ep, &msg, FI_COMPLETION | FI_TRANSMIT_COMPLETE);
         } while (try_again(ctx, ret, &polled));
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 
@@ -769,7 +769,7 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
                                       };
 
         do {
-            ret = fi_writemsg(ctx->ep, &msg, FI_DELIVERY_COMPLETE | FI_INJECT);
+            ret = fi_writemsg(ctx->ep, &msg, FI_TRANSMIT_COMPLETE | FI_INJECT);
         } while (try_again(ctx, ret, &polled));
 
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
@@ -817,7 +817,7 @@ void shmem_transport_put_signal_nbi(shmem_transport_ctx_t* ctx, void *target, co
             SHMEM_TRANSPORT_OFI_CNTR_INC(&ctx->pending_put_cntr);
 
             do {
-                ret = fi_writemsg(ctx->ep, &msg, FI_DELIVERY_COMPLETE);
+                ret = fi_writemsg(ctx->ep, &msg, FI_TRANSMIT_COMPLETE);
             } while (try_again(ctx, ret, &polled));
 
             frag_source += frag_len;
@@ -1242,7 +1242,7 @@ void shmem_transport_atomicv(shmem_transport_ctx_t* ctx, void *target, const voi
                                                .data          = 0
                                              };
         do {
-            ret = fi_atomicmsg(ctx->ep, &msg, FI_COMPLETION | FI_DELIVERY_COMPLETE);
+            ret = fi_atomicmsg(ctx->ep, &msg, FI_COMPLETION | FI_TRANSMIT_COMPLETE);
         } while (try_again(ctx, ret, &polled));
 
     } else {

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -597,9 +597,16 @@ static inline
 int shmem_transport_fence(shmem_transport_ctx_t* ctx)
 {
 #if WANT_TOTAL_DATA_ORDERING == 0
-    /* Communication is unordered; must wait for puts and buffered (injected)
-     * non-fetching atomics to be completed in order to ensure ordering. */
-    shmem_transport_put_quiet(ctx);
+    /* CXI provider maintains per-EP FIFO ordering, so FI_TRANSMIT_COMPLETE
+     * guarantees subsequent operations see prior puts at the target. Skip
+     * put_quiet poll for ~1-2µs latency improvement. Other providers require
+     * explicit put_quiet to ensure remote visibility before fence returns. */
+    extern int shmem_transport_ofi_is_cxi;
+    if (!shmem_transport_ofi_is_cxi) {
+        /* Communication is unordered; must wait for puts and buffered (injected)
+         * non-fetching atomics to be completed in order to ensure ordering. */
+        shmem_transport_put_quiet(ctx);
+    }
 #endif
     /* Complete fetching ops; needed to support nonblocking fetch-atomics */
     shmem_transport_get_wait(ctx);

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -552,8 +552,28 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the put issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t cnt, cnt_new;
+    uint64_t success, fail, cnt, cnt_new;
+    long poll_count = 0;
+    while (poll_count < shmem_transport_ofi_put_poll_limit ||
+           shmem_transport_ofi_put_poll_limit < 0) {
+        success = fi_cntr_read(ctx->put_cntr);
+        fail = fi_cntr_readerr(ctx->put_cntr);
+        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
 
+        shmem_transport_probe();
+
+        if (success < cnt && fail == 0) {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+            SPINLOCK_BODY();
+            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        } else if (fail) {
+            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
+        } else {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+            return;
+        }
+        poll_count++;
+    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
     do {
         cnt = cnt_new;
@@ -1020,10 +1040,31 @@ void shmem_transport_get_wait(shmem_transport_ctx_t* ctx)
      * reverse order: first the fid_cntr event counter, then the get issued
      * counter.  We'll want to preserve this property in the future.
      */
-    uint64_t cnt, cnt_new;
+    uint64_t success, fail, cnt, cnt_new;
+    long poll_count = 0;
 
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
 
+    while (poll_count < shmem_transport_ofi_get_poll_limit ||
+           shmem_transport_ofi_get_poll_limit < 0) {
+        success = fi_cntr_read(ctx->get_cntr);
+        fail = fi_cntr_readerr(ctx->get_cntr);
+        cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
+
+        shmem_transport_probe();
+
+        if (success < cnt && fail == 0) {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+            SPINLOCK_BODY();
+            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        } else if (fail) {
+            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
+        } else {
+            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+            return;
+        }
+        poll_count++;
+    }
     cnt_new = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_get_cntr);
     do {
         cnt = cnt_new;

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -601,8 +601,8 @@ int shmem_transport_fence(shmem_transport_ctx_t* ctx)
      * guarantees subsequent operations see prior puts at the target. Skip
      * put_quiet poll for ~1-2µs latency improvement. Other providers require
      * explicit put_quiet to ensure remote visibility before fence returns. */
-    extern int shmem_transport_ofi_is_cxi;
-    if (!shmem_transport_ofi_is_cxi) {
+    extern int shmem_transport_ofi_check_provider(const char *name);
+    if (!shmem_transport_ofi_check_provider("cxi")) {
         /* Communication is unordered; must wait for puts and buffered (injected)
          * non-fetching atomics to be completed in order to ensure ordering. */
         shmem_transport_put_quiet(ctx);

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -66,6 +66,7 @@ extern struct fid_mr*                   shmem_transport_ofi_mrfd_list[3];
 extern uint64_t                         shmem_transport_ofi_max_poll;
 extern long                             shmem_transport_ofi_put_poll_limit;
 extern long                             shmem_transport_ofi_get_poll_limit;
+extern long                             shmem_transport_ofi_put_pipeline_depth;
 extern size_t                           shmem_transport_ofi_max_buffered_send;
 extern size_t                           shmem_transport_ofi_max_msg_size;
 extern size_t                           shmem_transport_ofi_bounce_buffer_size;
@@ -480,6 +481,27 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
     return buff;
 }
 
+/* Throttle in-flight puts to at most shmem_transport_ofi_put_pipeline_depth.
+ * Matches Cray SHMEM's "blocking SHEAP pipeline limit 512" behavior, which
+ * prevents TRS pool exhaustion and eliminates mst_stalled_waiting_put_crdts.
+ * Called with ctx lock already held; temporarily drops it while spinning. */
+static inline
+void shmem_transport_ofi_put_pipeline_throttle(shmem_transport_ctx_t *ctx)
+{
+    if (shmem_transport_ofi_put_pipeline_depth <= 0) return;
+
+    uint64_t pending = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
+    uint64_t completed = fi_cntr_read(ctx->put_cntr);
+
+    while ((long)(pending - completed) >= shmem_transport_ofi_put_pipeline_depth) {
+        SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+        shmem_transport_probe();
+        SPINLOCK_BODY();
+        SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        completed = fi_cntr_read(ctx->put_cntr);
+    }
+}
+
 static inline
 void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
 {
@@ -660,6 +682,7 @@ void shmem_transport_ofi_put_large(shmem_transport_ctx_t* ctx, void *target, con
     /* operation generates counting events and must be completed by
      * quiet. */
     SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+    shmem_transport_ofi_put_pipeline_throttle(ctx);
     while (frag_source < ((uint8_t *) source) + len) {
         frag_len = MIN(shmem_transport_ofi_max_msg_size,
                        (size_t) (((uint8_t *) source) + len - frag_source));
@@ -700,6 +723,7 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
     } else if (len <= shmem_transport_ofi_bounce_buffer_size && ctx->bounce_buffers) {
 
         SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+        shmem_transport_ofi_put_pipeline_throttle(ctx);
         SHMEM_TRANSPORT_OFI_CNTR_INC(&ctx->pending_put_cntr);
         shmem_transport_ofi_get_mr(target, pe, &addr, &key);
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -71,7 +71,7 @@ extern long                             shmem_transport_ofi_amo_pipeline_depth;
 extern size_t                           shmem_transport_ofi_max_buffered_send;
 extern size_t                           shmem_transport_ofi_max_msg_size;
 extern size_t                           shmem_transport_ofi_bounce_buffer_size;
-extern long                             shmem_transport_ofi_max_bounce_buffers;
+extern size_t                             shmem_transport_ofi_max_bounce_buffers;
 
 extern pthread_mutex_t                  shmem_transport_ofi_progress_lock;
 
@@ -438,7 +438,7 @@ void shmem_transport_ofi_drain_cq(shmem_transport_ctx_t *ctx)
                                      (shmem_transport_ofi_bounce_buffer_t *) frag);
                 ctx->completed_bb_cntr++;
             } else {
-                RAISE_ERROR_STR("Unrecognized completion object");
+                RAISE_ERROR_MSG("[%d] Unrecognized completion object %p %x mtofs %p\n", shmem_internal_my_pe, frag, frag->mytype, &frag->mytype);
             }
         }
 
@@ -474,6 +474,10 @@ shmem_transport_ofi_bounce_buffer_t * create_bounce_buffer(shmem_transport_ctx_t
 
     if (NULL == buff)
         RAISE_ERROR_STR("Bounce buffer allocation failed");
+
+    if (buff->frag.mytype != SHMEM_TRANSPORT_OFI_TYPE_BOUNCE) {
+	RAISE_ERROR_STR("Bounce buffer allocation failed");
+    }
 
     shmem_internal_assert(buff->frag.mytype == SHMEM_TRANSPORT_OFI_TYPE_BOUNCE);
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -131,13 +131,19 @@ extern int shmem_transport_ofi_single_ep;
 static inline
 int shmem_transport_ofi_get_mr_desc_index(const void *addr) {
     int ret = -1;
+#ifdef ENABLE_REMOTE_VIRTUAL_ADDRESSING
+    ret = 0;
+#else
     if ((void*) addr >= shmem_internal_data_base &&
         (uint8_t*) addr < (uint8_t*) shmem_internal_data_base + shmem_internal_data_length) {
         ret = 0;
     } else if ((void*) addr >= shmem_internal_heap_base &&
                (uint8_t*) addr < (uint8_t*) shmem_internal_heap_base + shmem_internal_heap_length) {
         ret = 1;
+    } else {
+        ret = -1;
     }
+#endif /* ENABLE_REMOTE_VIRTUAL_ADDRESSING */
     return ret;
 }
 #else

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -779,6 +779,8 @@ void shmem_transport_put_nb(shmem_transport_ctx_t* ctx, void *target, const void
         do {
             ret = fi_writemsg(ctx->ep, &msg, FI_COMPLETION | FI_TRANSMIT_COMPLETE);
         } while (try_again(ctx, ret, &polled));
+        if (completion)
+            *completion = (long) SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
         SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
 
     } else {

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -446,11 +446,13 @@ shmem_transport_init(void)
     shmem_transport_portals4_bounce_buffers =
         shmem_free_list_init(sizeof(shmem_transport_portals4_bounce_buffer_t) +
                              shmem_transport_portals4_bounce_buffer_size,
-                             init_bounce_buffer);
+                             init_bounce_buffer,
+                             0);
 
     shmem_transport_portals4_long_frags =
         shmem_free_list_init(sizeof(shmem_transport_portals4_long_frag_t),
-                             init_long_frag);
+                             init_long_frag,
+                             0);
 
     /* Initialize network */
     ni_req_limits.max_entries = 1024;

--- a/src/transport_portals4.c
+++ b/src/transport_portals4.c
@@ -446,13 +446,11 @@ shmem_transport_init(void)
     shmem_transport_portals4_bounce_buffers =
         shmem_free_list_init(sizeof(shmem_transport_portals4_bounce_buffer_t) +
                              shmem_transport_portals4_bounce_buffer_size,
-                             init_bounce_buffer,
-                             0);
+                             init_bounce_buffer);
 
     shmem_transport_portals4_long_frags =
         shmem_free_list_init(sizeof(shmem_transport_portals4_long_frag_t),
-                             init_long_frag,
-                             0);
+                             init_long_frag);
 
     /* Initialize network */
     ni_req_limits.max_entries = 1024;


### PR DESCRIPTION
  This PR includes three changes targeting CXI/Slingshot performance on systems like Perlmutter.

  **Changes**

  1. Skip put_quiet in Fence for CXI Provider (7880ab43)

  The CXI provider doesn't require explicit quiet operations before fences since fences are already ordering operations. Skipping the redundant put_quiet() reduces fence overhead.

  2. Anonymous MAP_HUGETLB for Symmetric Heap (0e985e7e)

  Enables allocation of the symmetric heap using 2MB huge pages via anonymous MAP_HUGETLB, which works with kernel nr_overcommit_hugepages without requiring mounted hugetlbfs. Falls back to transparent huge pages (THP) via madvise() if explicit huge pages are unavailable.

  Usage:
  export SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1

  3. Explicitly Request 2MB Pages with MAP_HUGE_SHIFT (99b900ac)

  Adds (21 << MAP_HUGE_SHIFT) to the MAP_HUGETLB mmap call to explicitly request 2MB pages (2^21 = 2MB). This matches the allocation strategy used by the CXI libfabric provider for its internal buffers.

  **Performance Impact**

  When combined with scalable MR mode (--enable-ofi-mr=scalable), the huge page changes enable the CXI NIC's ATU (Address Translation Unit) to use 2MB page granularity instead of 4KB, dramatically reducing translation overhead:

  - ATU cache hit rate: 74-84% → 98.3%
  - ATU cache misses: ~10-15M per node → <300 per node
  - 2MB page translations: 0 → ~450K-490K per node

  Additional benefits:
  - Reduced CPU TLB misses for symmetric heap accesses
  - Eliminated credit stall cycles (260M → 0)
  - Improved latency distribution (96% in fastest bucket)

  **Configuration Requirements**

  The ATU benefits require scalable MR mode (recommended for CXI/Slingshot):
  ./configure --enable-ofi-mr=scalable --enable-mr-endpoint ...

  With scalable MR, fi_mr_reg() registers the entire address space, allowing the CXI provider to detect 2MB backing pages and configure the ATU accordingly. Also eliminates ASLR sensitivity (no setarch --addr-no-randomize needed).

  **Testing**

  Verified on NERSC Perlmutter with 2-node and 256-PE jobs using CXI telemetry counters to confirm ATU derivative (2MB) page activity.

  ---