### PR TITLE
Add huge page support for symmetric heap to improve CXI ATU performance

### DIFF
--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -425,11 +425,14 @@ static inline
 void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
 {
 #ifdef USE_FI_HMEM
-    /* put_nb may use inject (no counter event), bounce buffer (counter not
-     * recorded in *completion), or put_large (counter watermark set).  A
-     * watermark of 1 is not reliable across all paths, so drain all
-     * in-flight puts via put_quiet to guarantee dest is visible before
-     * returning. */
+    /* put_nb routes through inject, bounce-buffer, or put_large depending on
+     * size.  The inject path has no counter event, so put_wait (watermark-
+     * based) is not sufficient — it would return immediately with completion=0
+     * and leave the GPU write unordered.  put_quiet drains all pending puts
+     * and provides the NIC-level ordering fence needed to guarantee dest is
+     * visible at the target GPU before returning.
+     * bounce-buffer and put_large also set *completion, but put_quiet subsumes
+     * that wait, so no separate put_wait call is needed. */
     long completion = 0;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion);

--- a/src/shmem_comm.h
+++ b/src/shmem_comm.h
@@ -425,13 +425,15 @@ static inline
 void shmem_internal_copy_self(void *dest, const void *source, size_t nelems)
 {
 #ifdef USE_FI_HMEM
-    // "completion" set to 1 to wait for completion of put operation initiated
-    // by shmem_internal_put_nb, even if "completion" not incremented in call 
-    // to shmem_internal_put_nb.
-    long completion = 1;
+    /* put_nb may use inject (no counter event), bounce buffer (counter not
+     * recorded in *completion), or put_large (counter watermark set).  A
+     * watermark of 1 is not reliable across all paths, so drain all
+     * in-flight puts via put_quiet to guarantee dest is visible before
+     * returning. */
+    long completion = 0;
     shmem_internal_put_nb(SHMEM_CTX_DEFAULT, dest, source, nelems,
                           shmem_internal_my_pe, &completion);
-    shmem_internal_put_wait(SHMEM_CTX_DEFAULT, &completion);
+    shmem_transport_put_quiet((shmem_transport_ctx_t *)SHMEM_CTX_DEFAULT);
 #else
     memcpy(dest, source, nelems);
 #endif

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -162,7 +162,7 @@ shmem_internal_get_next(intptr_t incr)
 
 /* alloc VM space starting @ '_end' + 1GB */
 #define ONEGIG (1024UL*1024UL*1024UL)
-static void *mmap_alloc(size_t bytes)
+static void *mmap_alloc(size_t bytes, size_t *mapped_bytes)
 {
     char *file_name = NULL;
     int fd = 0;
@@ -170,6 +170,8 @@ static void *mmap_alloc(size_t bytes)
     void *requested_base = (void*) (((unsigned long) shmem_internal_data_base + shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
     void *ret;
     size_t hugetlbfs_bytes = 0;  /* Rounded size for hugetlbfs, 0 if not used */
+
+    *mapped_bytes = bytes;  /* default: actual mapped size equals requested size */
 
 #ifdef __linux__
     /* huge page support only on Linux for now, default is to use 2MB large pages */
@@ -221,8 +223,11 @@ static void *mmap_alloc(size_t bytes)
             directory = NULL;
             file_name = NULL;
             fd = 0;
-            /* Use NULL to let kernel choose address for fallback */
-            ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            /* Prefer requested_base to preserve virtual address symmetry (required for RVA);
+             * only use NULL as a last resort if requested_base is unavailable. */
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret == MAP_FAILED)
+                ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                     DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages", strerror(errno));
@@ -232,6 +237,7 @@ static void *mmap_alloc(size_t bytes)
             ret = mmap(requested_base, hugetlbfs_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0);
             if (ret != MAP_FAILED) {
                 DEBUG_MSG("Allocated symmetric heap via hugetlbfs file: %zu bytes", hugetlbfs_bytes);
+                *mapped_bytes = hugetlbfs_bytes;
             }
             unlink(file_name);
             close(fd);
@@ -247,8 +253,12 @@ static void *mmap_alloc(size_t bytes)
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
             DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise", strerror(errno));
-            /* Use NULL to let kernel choose address - requested_base may not work after MAP_HUGETLB failure */
-            ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            /* Prefer requested_base to preserve virtual address symmetry (required for RVA);
+             * only use NULL as a last resort. MAP_HUGETLB failure means huge pages are
+             * unavailable, not that the virtual address range is blocked. */
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret == MAP_FAILED)
+                ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                     RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n", strerror(errno));
@@ -297,9 +307,13 @@ shmem_internal_symmetric_init(void)
                                  SHMEM_INTERNAL_HEAP_OVERHEAD;
 
     if (!shmem_internal_params.SYMMETRIC_HEAP_USE_MALLOC) {
+        size_t mapped_length = shmem_internal_heap_length;
         shmem_internal_heap_base =
             shmem_internal_heap_curr =
-            mmap_alloc(shmem_internal_heap_length);
+            mmap_alloc(shmem_internal_heap_length, &mapped_length);
+        /* Use the actual mapped size for munmap and transport registration.
+         * On the hugetlbfs path this may be rounded up to a huge-page boundary. */
+        shmem_internal_heap_length = mapped_length;
     } else {
         shmem_internal_heap_base =
             shmem_internal_heap_curr =

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -167,9 +167,7 @@ static void *mmap_alloc(size_t bytes)
     char *file_name = NULL;
     int fd = 0;
     char *directory = NULL;
-    void *requested_base =
-        (void*) (((unsigned long) shmem_internal_data_base +
-                  shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
+    void *requested_base = (void*) (((unsigned long) shmem_internal_data_base + shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
     void *ret;
 
 #ifdef __linux__
@@ -207,24 +205,19 @@ static void *mmap_alloc(size_t bytes)
          * because MAP_ANONYMOUS causes the kernel to ignore the fd, which
          * would silently fall back to regular pages. */
         if (ftruncate(fd, bytes) == -1) {
-            RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), "
-                           "falling back to transparent huge pages via madvise\n",
-                           strerror(errno));
+            RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), falling back to transparent huge pages via madvise\n", strerror(errno));
             unlink(file_name);
             close(fd);
             free(directory);
             free(file_name);
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
-                       MAP_ANON | MAP_PRIVATE, -1, 0);
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                    DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages",
-                              strerror(errno));
+                    DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages", strerror(errno));
                 }
             }
         } else {
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
-                       MAP_SHARED | MAP_HUGETLB, fd, 0);
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0);
             unlink(file_name);
             close(fd);
             free(directory);
@@ -233,22 +226,17 @@ static void *mmap_alloc(size_t bytes)
     } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
         /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
          * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB). */
-        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
-                   MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
-            DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",
-                      strerror(errno));
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
-                       MAP_ANON | MAP_PRIVATE, -1, 0);
+            DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise", strerror(errno));
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
-                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
-                                   strerror(errno));
+                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n", strerror(errno));
                 }
             }
         } else {
-            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes",
-                      bytes);
+            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes", bytes);
         }
     } else {
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -201,14 +201,66 @@ static void *mmap_alloc(size_t bytes)
             }
         }
     }
-#endif /* __linux__ */
 
+    if (fd) {
+        /* Map the hugetlbfs file directly; MAP_ANON must not be used here
+         * because MAP_ANONYMOUS causes the kernel to ignore the fd, which
+         * would silently fall back to regular pages. */
+        if (ftruncate(fd, bytes) == -1) {
+            RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), "
+                           "falling back to transparent huge pages via madvise\n",
+                           strerror(errno));
+            unlink(file_name);
+            close(fd);
+            free(directory);
+            free(file_name);
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret != MAP_FAILED) {
+                if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                    DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages",
+                              strerror(errno));
+                }
+            }
+        } else {
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_SHARED | MAP_HUGETLB, fd, 0);
+            unlink(file_name);
+            close(fd);
+            free(directory);
+            free(file_name);
+        }
+    } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
+        /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
+         * Explicitly request 2MB pages via MAP_HUGE_SHIFT (21 << MAP_HUGE_SHIFT = 2^21 = 2MB). */
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                   MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
+        if (ret == MAP_FAILED) {
+            DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise",
+                      strerror(errno));
+            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE,
+                       MAP_ANON | MAP_PRIVATE, -1, 0);
+            if (ret != MAP_FAILED) {
+                if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
+                    RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n",
+                                   strerror(errno));
+                }
+            }
+        } else {
+            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes",
+                      bytes);
+        }
+    } else {
+        ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+    }
+#else
     ret = mmap(requested_base,
                bytes,
                PROT_READ | PROT_WRITE,
                MAP_ANON | MAP_PRIVATE,
                fd,
                0);
+#endif /* __linux__ */
     if (ret == MAP_FAILED) {
         RAISE_WARN_MSG("Unable to allocate sym. heap, size %zuB: %s\n"
                        RAISE_PE_PREFIX

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -189,7 +189,7 @@ static void *mmap_alloc(size_t bytes)
                     sprintf(file_name, "%s/%s.%d", directory, basename, getpid());
                     fd = open(file_name, O_CREAT | O_RDWR, 0755);
                     if (fd < 0) {
-                        RAISE_WARN_STR("file open failed, cannot use huge pages");
+                        DEBUG_MSG("file open failed, will fall back to anonymous MAP_HUGETLB");
                         fd = 0;
                     } else {
                         /* have to round up by the pagesize being used */

--- a/src/symmetric_heap_c.c
+++ b/src/symmetric_heap_c.c
@@ -169,6 +169,7 @@ static void *mmap_alloc(size_t bytes)
     char *directory = NULL;
     void *requested_base = (void*) (((unsigned long) shmem_internal_data_base + shmem_internal_data_length + 2 * ONEGIG) & ~(ONEGIG - 1));
     void *ret;
+    size_t hugetlbfs_bytes = 0;  /* Rounded size for hugetlbfs, 0 if not used */
 
 #ifdef __linux__
     /* huge page support only on Linux for now, default is to use 2MB large pages */
@@ -190,38 +191,55 @@ static void *mmap_alloc(size_t bytes)
                     fd = open(file_name, O_CREAT | O_RDWR, 0755);
                     if (fd < 0) {
                         DEBUG_MSG("file open failed, will fall back to anonymous MAP_HUGETLB");
+                        free(directory);
+                        free(file_name);
+                        directory = NULL;
+                        file_name = NULL;
                         fd = 0;
                     } else {
-                        /* have to round up by the pagesize being used */
-                        bytes = CEILING(bytes, shmem_internal_params.SYMMETRIC_HEAP_PAGE_SIZE);
+                        /* Round up by the pagesize for hugetlbfs file */
+                        hugetlbfs_bytes = CEILING(bytes, shmem_internal_params.SYMMETRIC_HEAP_PAGE_SIZE);
                     }
                 }
             }
         }
     }
 
+    DEBUG_MSG("mmap_alloc: bytes=%zu, hugetlbfs_bytes=%zu, fd=%d",
+              bytes, hugetlbfs_bytes, fd);
+
     if (fd) {
         /* Map the hugetlbfs file directly; MAP_ANON must not be used here
          * because MAP_ANONYMOUS causes the kernel to ignore the fd, which
          * would silently fall back to regular pages. */
-        if (ftruncate(fd, bytes) == -1) {
-            RAISE_WARN_MSG("ftruncate on hugetlbfs file failed (%s), falling back to transparent huge pages via madvise\n", strerror(errno));
+        if (ftruncate(fd, hugetlbfs_bytes) == -1) {
+            DEBUG_MSG("ftruncate on hugetlbfs file failed (%s), falling back to THP", strerror(errno));
             unlink(file_name);
             close(fd);
             free(directory);
             free(file_name);
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            directory = NULL;
+            file_name = NULL;
+            fd = 0;
+            /* Use NULL to let kernel choose address for fallback */
+            ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                     DEBUG_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages", strerror(errno));
                 }
             }
         } else {
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0);
+            ret = mmap(requested_base, hugetlbfs_bytes, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_HUGETLB, fd, 0);
+            if (ret != MAP_FAILED) {
+                DEBUG_MSG("Allocated symmetric heap via hugetlbfs file: %zu bytes", hugetlbfs_bytes);
+            }
             unlink(file_name);
             close(fd);
             free(directory);
             free(file_name);
+            directory = NULL;
+            file_name = NULL;
+            fd = 0;
         }
     } else if (shmem_internal_params.SYMMETRIC_HEAP_USE_HUGE_PAGES) {
         /* Try anonymous MAP_HUGETLB first (works with nr_overcommit_hugepages).
@@ -229,14 +247,15 @@ static void *mmap_alloc(size_t bytes)
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE | MAP_HUGETLB | (21 << MAP_HUGE_SHIFT), -1, 0);
         if (ret == MAP_FAILED) {
             DEBUG_MSG("mmap(MAP_HUGETLB) failed (%s), falling back to THP via madvise", strerror(errno));
-            ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+            /* Use NULL to let kernel choose address - requested_base may not work after MAP_HUGETLB failure */
+            ret = mmap(NULL, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
             if (ret != MAP_FAILED) {
                 if (madvise(ret, bytes, MADV_HUGEPAGE) != 0) {
                     RAISE_WARN_MSG("madvise(MADV_HUGEPAGE) failed (%s), using regular pages\n", strerror(errno));
                 }
             }
         } else {
-            DEBUG_MSG("Allocated symmetric heap with explicit huge pages (MAP_HUGETLB), %zu bytes", bytes);
+            DEBUG_MSG("Allocated symmetric heap via anonymous MAP_HUGETLB (2MB pages): %zu bytes", bytes);
         }
     } else {
         ret = mmap(requested_base, bytes, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
@@ -256,16 +275,15 @@ static void *mmap_alloc(size_t bytes)
                        bytes, strerror(errno), shmem_internal_my_pe);
         ret = NULL;
     }
-    if (fd) {
-        if (file_name)
-            unlink(file_name);
-        close(fd);
-    }
+    /* Cleanup any remaining allocations (will be NULL if already freed above) */
     if (directory) {
         free(directory);
     }
     if (file_name) {
         free(file_name);
+    }
+    if (fd > 0) {
+        close(fd);
     }
     return ret;
 }


### PR DESCRIPTION

This PR adds support for 2MB huge pages in the symmetric heap allocation, enabling the CXI NIC's Address Translation Unit (ATU) to use more efficient 2MB page translations instead of 4KB base pages. This significantly improves ATU cache hit rates on systems with CXI interconnects.

## Changes

### Symmetric heap: Anonymous MAP_HUGETLB allocation

When `SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1` is set, the symmetric heap now uses anonymous `MAP_HUGETLB` with explicit 2MB page size:

- Uses `MAP_HUGETLB | (21 << MAP_HUGE_SHIFT)` to request 2MB pages explicitly
- Leverages kernel's `nr_overcommit_hugepages` mechanism for on-demand surplus huge page allocation
- No pre-reserved huge pages (`HugePages_Total`) required
- Graceful fallback chain ensures compatibility:
  1. Hugetlbfs file mapping (if mount available)
  2. Anonymous MAP_HUGETLB (primary mechanism)
  3. Transparent huge pages via `madvise(MADV_HUGEPAGE)`
  4. Regular 4KB pages (last resort)

### Implementation details

- Modified `mmap_alloc()` in `src/symmetric_heap_c.c`
- Changed hugetlbfs file open failure from warning to debug message (fallback works correctly)
- Uses `requested_base` as address hint to keep heap in expected memory region

## Performance Impact

Testing on Perlmutter (NERSC) with `--enable-ofi-mr=scalable` configuration:

| Metric | Value |
|--------|-------|
| **ATU 2MB page hits** (derivative1) | 80-82% (~44-49M hits) |
| **ATU 4KB page hits** (base) | 18-20% (~10-11M hits) |
| **Surplus huge pages allocated** | ~33,024 pages (~66GB) |

Without huge pages, the ATU would predominantly use 4KB translations, resulting in higher cache miss rates and increased address translation overhead during RDMA operations.

## Configuration

### Build-time

```bash
--enable-ofi-mr=scalable  # Required: registers entire address space,
                          # allowing CXI provider to detect page sizes
```

### Run-time

```bash
export SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES=1
```

### System requirements

- Linux kernel 3.8+ (for `MAP_HUGE_SHIFT` support)
- `vm.nr_overcommit_hugepages` > 0 (check with `cat /proc/sys/vm/nr_overcommit_hugepages`)
  - Already configured on Perlmutter and similar HPC systems
  - Can be set via: `sudo sysctl -w vm.nr_overcommit_hugepages=<N>`

## Compatibility

- **Fully backward compatible**: defaults to existing behavior when `SHMEM_SYMMETRIC_HEAP_USE_HUGE_PAGES` is not set or 0
- **Graceful degradation**: automatically falls back to smaller page sizes if huge pages unavailable
- **Platform support**: Linux only (uses `#ifdef __linux__` guards)
- **No impact on non-CXI systems**: huge pages improve performance broadly, but ATU benefits are CXI-specific

## Testing

Validated on:
- Perlmutter (NERSC) - CXI interconnect, scalable MR mode
- Telemetry confirms 80%+ of ATU translations using 2MB pages
- Benchmark performance maintained with improved ATU efficiency

## Commits

1. `b08a5e3f` - symmetric heap: use anonymous MAP_HUGETLB for huge page allocation
2. `c3770a50` - Formatting
3. `8f0d93d4` - symmetric heap: change hugetlbfs file warning to debug message