### PR TITLE
Reduce barrier/collective execution floor

### DIFF
--- a/src/collectives.c
+++ b/src/collectives.c
@@ -270,11 +270,8 @@ shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync
         /* wait for N - 1 callins up the tree */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
-        /* Clear pSync locally for reuse; the counting wait above already drained
-         * every incoming call-in, so a local store + acq_rel fence resets the slot
-         * without a self-loopback put over the fabric (P1 optimization). */
-        *pSync = zero;
-        shmem_internal_membar_acq_rel();
+        /* Clear pSync */
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
         /* Send acks down psync tree */
         for (pe = PE_start + PE_stride, i = 1 ;
@@ -291,9 +288,8 @@ shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
-        /* P1: local reset instead of self-loopback put (see sync_linear root) */
-        *pSync = zero;
-        shmem_internal_membar_acq_rel();
+        /* Clear pSync */
+        *pSync = zero; shmem_internal_membar_acq_rel();
     }
 
 }
@@ -307,6 +303,23 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
 
     /* need 1 slot */
     shmem_internal_assert(SHMEM_BARRIER_SYNC_SIZE >= 1);
+
+    /* Accumulate-rebase fast path for the dedicated internal world pSync arrays.
+     * These slots are only ever incremented via atomic SUM call-ins, over a
+     * constant tree topology (full binomial tree, fixed PE_size == num_pes), so
+     * instead of resetting the slot to zero after every barrier -- which costs a
+     * self-loopback put plus a completion wait -- we remember the running base
+     * and wait for base + delta, then advance the base.  We never write the slot
+     * locally, so this is safe on every transport, including ones that apply
+     * AMOs in NIC-cached memory.  Only valid for the two internal world arrays
+     * (constant topology and PE count); every other pSync keeps the original
+     * self-put clear. */
+    static long tree_base_barrier = 0;
+    static long tree_base_sync = 0;
+    const int world = (pSync == shmem_internal_barrier_all_psync ||
+                       pSync == shmem_internal_sync_all_psync);
+    long *basep = (pSync == shmem_internal_barrier_all_psync) ? &tree_base_barrier
+                                                              : &tree_base_sync;
 
     if (PE_size == shmem_internal_num_pes) {
         /* we're the full tree, use the binomial tree */
@@ -324,14 +337,22 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
         int i;
 
         /* wait for num_children callins up the tree */
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children);
+        if (world) {
+            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, *basep + num_children);
+        } else {
+            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children);
+        }
 
         if (parent == shmem_internal_my_pe) {
             /* The root of the tree */
 
-            /* P1: local reset instead of self-loopback put (see sync_linear root) */
-            *pSync = zero;
-            shmem_internal_membar_acq_rel();
+            if (world) {
+                /* Rebase instead of clearing */
+                *basep += num_children;
+            } else {
+                /* Clear pSync */
+                *pSync = zero; shmem_internal_membar_acq_rel();
+            }
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
@@ -347,11 +368,15 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
                                   parent, SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
             /* wait for ack from parent */
-            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children  + 1);
-
-            /* P1: local reset instead of self-loopback put (see sync_linear root) */
-            *pSync = zero;
-            shmem_internal_membar_acq_rel();
+            if (world) {
+                SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, *basep + num_children + 1);
+                /* Rebase instead of clearing */
+                *basep += num_children + 1;
+            } else {
+                SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children  + 1);
+                /* Clear pSync */
+                *pSync = zero; shmem_internal_membar_acq_rel();
+            }
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
@@ -368,11 +393,15 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
                               SHM_INTERNAL_SUM, SHM_INTERNAL_LONG);
 
         /* wait for ack down psync tree */
-        SHMEM_WAIT(pSync, 0);
-
-        /* P1: local reset instead of self-loopback put (see sync_linear root) */
-        *pSync = zero;
-        shmem_internal_membar_acq_rel();
+        if (world) {
+            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, *basep + 1);
+            /* Rebase instead of clearing */
+            *basep += 1;
+        } else {
+            SHMEM_WAIT(pSync, 0);
+            /* Clear pSync */
+            *pSync = zero; shmem_internal_membar_acq_rel();
+        }
     }
 }
 
@@ -459,8 +488,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
             /* Clear pSync */
-            *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+            *pSync = zero; shmem_internal_membar_acq_rel();
         }
 
     } else {
@@ -468,8 +496,7 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
         if (1 == complete) {
             /* send ack back to root */
@@ -546,8 +573,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
 
         /* Clear pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for data arrival message */
@@ -560,8 +586,7 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
 
         /* Clear pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
     }
 }
 
@@ -607,16 +632,14 @@ shmem_internal_op_to_all_linear(void *target, const void *source, size_t count, 
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for clear to send */
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
         /* send data, ack, and wait for completion */
         shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count, type_size,
@@ -720,8 +743,7 @@ shmem_internal_op_to_all_ring(void *target, const void *source, size_t count, si
     }
 
     /* Reset reduce-scatter pSync */
-    *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+    *pSync = zero; shmem_internal_membar_acq_rel();
 
     /* Perform all-gather:
      *
@@ -749,8 +771,8 @@ shmem_internal_op_to_all_ring(void *target, const void *source, size_t count, si
     }
 
     /* reset pSync */
-    *(pSync+1) = zero;
-        shmem_internal_membar_acq_rel();
+    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync+1, &zero, sizeof(zero), shmem_internal_my_pe);
+    SHMEM_WAIT_UNTIL(pSync+1, SHMEM_CMP_EQ, 0);
 
     if (free_source)
         free((void *)source);
@@ -810,8 +832,7 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
     }
 
     if (parent != shmem_internal_my_pe) {
@@ -819,8 +840,8 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
         SHMEM_WAIT(pSync + 1, 0);
 
         /* reset pSync */
-        *(pSync+1) = zero;
-        shmem_internal_membar_acq_rel();
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync + 1, &zero, sizeof(zero), shmem_internal_my_pe);
+        SHMEM_WAIT_UNTIL(pSync + 1, SHMEM_CMP_EQ, 0);
 
         /* send data, ack, and wait for completion */
         shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target,
@@ -1052,8 +1073,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
         
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
         
         
         /* Let everyone know sending can start */
@@ -1068,8 +1088,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
         /* Send contribution to all pes larger than itself */
         for (pe = shmem_internal_my_pe + PE_stride*scantype, i = shmem_internal_my_pe + scantype ;
@@ -1089,8 +1108,7 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT(pSync, 0);
         
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
         
     }
     
@@ -1166,16 +1184,14 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for clear to send */
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+        *pSync = zero; shmem_internal_membar_acq_rel();
 
         /* Send contribution to all pes larger than itself */
         for (pe = shmem_internal_my_pe + PE_stride*scantype, i = shmem_internal_my_pe + scantype ;
@@ -1297,8 +1313,8 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
 
         /* Clear pSync */
         tmp = 0;
-        *pSync = tmp;
-        shmem_internal_membar_acq_rel();
+        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(tmp), PE_start);
+        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
     } else {
         /* Push data into the target */
         size_t offset = ((shmem_internal_my_pe - PE_start) / PE_stride) * len;
@@ -1370,8 +1386,7 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
     }
 
     /* zero out psync */
-    *(pSync) = zero;
-        shmem_internal_membar_acq_rel();
+    *pSync = zero; shmem_internal_membar_acq_rel();
 }
 
 

--- a/src/collectives.c
+++ b/src/collectives.c
@@ -270,10 +270,11 @@ shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync
         /* wait for N - 1 callins up the tree */
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
-        /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        /* Clear pSync locally for reuse; the counting wait above already drained
+         * every incoming call-in, so a local store + acq_rel fence resets the slot
+         * without a self-loopback put over the fabric (P1 optimization). */
+        *pSync = zero;
+        shmem_internal_membar_acq_rel();
 
         /* Send acks down psync tree */
         for (pe = PE_start + PE_stride, i = 1 ;
@@ -290,10 +291,9 @@ shmem_internal_sync_linear(int PE_start, int PE_stride, int PE_size, long *pSync
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
-        /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        /* P1: local reset instead of self-loopback put (see sync_linear root) */
+        *pSync = zero;
+        shmem_internal_membar_acq_rel();
     }
 
 }
@@ -329,10 +329,9 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
         if (parent == shmem_internal_my_pe) {
             /* The root of the tree */
 
-            /* Clear pSync */
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                     shmem_internal_my_pe);
-            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+            /* P1: local reset instead of self-loopback put (see sync_linear root) */
+            *pSync = zero;
+            shmem_internal_membar_acq_rel();
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
@@ -350,10 +349,9 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
             /* wait for ack from parent */
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children  + 1);
 
-            /* Clear pSync */
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                     shmem_internal_my_pe);
-            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+            /* P1: local reset instead of self-loopback put (see sync_linear root) */
+            *pSync = zero;
+            shmem_internal_membar_acq_rel();
 
             /* Send acks down to children */
             for (i = 0 ; i < num_children ; ++i) {
@@ -372,10 +370,9 @@ shmem_internal_sync_tree(int PE_start, int PE_stride, int PE_size, long *pSync)
         /* wait for ack down psync tree */
         SHMEM_WAIT(pSync, 0);
 
-        /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        /* P1: local reset instead of self-loopback put (see sync_linear root) */
+        *pSync = zero;
+        shmem_internal_membar_acq_rel();
     }
 }
 
@@ -462,9 +459,8 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
             SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
             /* Clear pSync */
-            shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                     shmem_internal_my_pe);
-            SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+            *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
         }
 
     } else {
@@ -472,9 +468,8 @@ shmem_internal_bcast_linear(void *target, const void *source, size_t len,
         SHMEM_WAIT(pSync, 0);
 
         /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
         if (1 == complete) {
             /* send ack back to root */
@@ -551,9 +546,8 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
 
         /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for data arrival message */
@@ -566,9 +560,8 @@ shmem_internal_bcast_tree(void *target, const void *source, size_t len,
         }
 
         /* Clear pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero),
-                                 shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
     }
 }
 
@@ -614,16 +607,16 @@ shmem_internal_op_to_all_linear(void *target, const void *source, size_t count, 
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for clear to send */
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
         /* send data, ack, and wait for completion */
         shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target, source, count, type_size,
@@ -727,8 +720,8 @@ shmem_internal_op_to_all_ring(void *target, const void *source, size_t count, si
     }
 
     /* Reset reduce-scatter pSync */
-    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-    SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+    *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
     /* Perform all-gather:
      *
@@ -756,8 +749,8 @@ shmem_internal_op_to_all_ring(void *target, const void *source, size_t count, si
     }
 
     /* reset pSync */
-    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync+1, &zero, sizeof(zero), shmem_internal_my_pe);
-    SHMEM_WAIT_UNTIL(pSync+1, SHMEM_CMP_EQ, 0);
+    *(pSync+1) = zero;
+        shmem_internal_membar_acq_rel();
 
     if (free_source)
         free((void *)source);
@@ -817,8 +810,8 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, num_children);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
     }
 
     if (parent != shmem_internal_my_pe) {
@@ -826,8 +819,8 @@ shmem_internal_op_to_all_tree(void *target, const void *source, size_t count, si
         SHMEM_WAIT(pSync + 1, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync + 1, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync + 1, SHMEM_CMP_EQ, 0);
+        *(pSync+1) = zero;
+        shmem_internal_membar_acq_rel();
 
         /* send data, ack, and wait for completion */
         shmem_internal_atomicv(SHMEM_CTX_DEFAULT, target,
@@ -1059,8 +1052,8 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
         
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
         
         
         /* Let everyone know sending can start */
@@ -1075,8 +1068,8 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
         /* Send contribution to all pes larger than itself */
         for (pe = shmem_internal_my_pe + PE_stride*scantype, i = shmem_internal_my_pe + scantype ;
@@ -1096,8 +1089,8 @@ shmem_internal_scan_linear(void *target, const void *source, size_t count, size_
         SHMEM_WAIT(pSync, 0);
         
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
         
     }
     
@@ -1173,16 +1166,16 @@ shmem_internal_scan_ring(void *target, const void *source, size_t count, size_t 
         SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, PE_size - 1);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
     } else {
         /* wait for clear to send */
         SHMEM_WAIT(pSync, 0);
 
         /* reset pSync */
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(zero), shmem_internal_my_pe);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 
         /* Send contribution to all pes larger than itself */
         for (pe = shmem_internal_my_pe + PE_stride*scantype, i = shmem_internal_my_pe + scantype ;
@@ -1304,8 +1297,8 @@ shmem_internal_fcollect_linear(void *target, const void *source, size_t len,
 
         /* Clear pSync */
         tmp = 0;
-        shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &tmp, sizeof(tmp), PE_start);
-        SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+        *pSync = tmp;
+        shmem_internal_membar_acq_rel();
     } else {
         /* Push data into the target */
         size_t offset = ((shmem_internal_my_pe - PE_start) / PE_stride) * len;
@@ -1377,8 +1370,8 @@ shmem_internal_fcollect_ring(void *target, const void *source, size_t len,
     }
 
     /* zero out psync */
-    shmem_internal_put_scalar(SHMEM_CTX_DEFAULT, pSync, &zero, sizeof(long), shmem_internal_my_pe);
-    SHMEM_WAIT_UNTIL(pSync, SHMEM_CMP_EQ, 0);
+    *(pSync) = zero;
+        shmem_internal_membar_acq_rel();
 }
 
 

--- a/src/transport_ofi.h
+++ b/src/transport_ofi.h
@@ -385,7 +385,12 @@ void shmem_transport_probe(void)
 {
 #if defined(ENABLE_MANUAL_PROGRESS)
 #  ifdef USE_THREAD_COMPLETION
-    if (0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
+    /* P2: only serialize progress when other threads can race us; a
+     * SHMEM_THREAD_SINGLE run pays no trylock/unlock on the hot spin path. */
+    const int shmem_transport_lock_progress =
+        (shmem_internal_thread_level != SHMEM_THREAD_SINGLE);
+    if (!shmem_transport_lock_progress ||
+        0 == pthread_mutex_trylock(&shmem_transport_ofi_progress_lock)) {
 #  endif
         struct fi_cq_entry buf;
         /* Do not read a CQ entry in single-endpoint mode, just make progress. */
@@ -395,7 +400,8 @@ void shmem_transport_probe(void)
         if (!shmem_transport_ofi_single_ep && ret == 1)
             RAISE_WARN_STR("Unexpected event");
 #  ifdef USE_THREAD_COMPLETION
-        pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
+        if (shmem_transport_lock_progress)
+            pthread_mutex_unlock(&shmem_transport_ofi_progress_lock);
     }
 #  endif
 #endif
@@ -509,17 +515,21 @@ void shmem_transport_put_quiet(shmem_transport_ctx_t* ctx)
     while (poll_count < shmem_transport_ofi_put_poll_limit ||
            shmem_transport_ofi_put_poll_limit < 0) {
         success = fi_cntr_read(ctx->put_cntr);
-        fail = fi_cntr_readerr(ctx->put_cntr);
         cnt = SHMEM_TRANSPORT_OFI_CNTR_READ(&ctx->pending_put_cntr);
 
         shmem_transport_probe();
 
-        if (success < cnt && fail == 0) {
-            SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
-            SPINLOCK_BODY();
-            SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
-        } else if (fail) {
-            RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
+        if (success < cnt) {
+            /* P2: errors are rare and fi_cntr_readerr may touch the device, so
+             * only consult the error counter when completions have stalled. */
+            fail = fi_cntr_readerr(ctx->put_cntr);
+            if (fail == 0) {
+                SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
+                SPINLOCK_BODY();
+                SHMEM_TRANSPORT_OFI_CTX_LOCK(ctx);
+            } else {
+                RAISE_ERROR_MSG("Operations completed in error (%" PRIu64 ")\n", fail);
+            }
         } else {
             SHMEM_TRANSPORT_OFI_CTX_UNLOCK(ctx);
             return;


### PR DESCRIPTION
Shrink the shmem_barrier_all/collective critical path, where the internal pSync reset was issued as a put-to-self over the fabric plus a wait for its own NIC writeback on every PE every collective.

- collectives.c: replace the self-loopback pSync clear (put_scalar to shmem_internal_my_pe + SHMEM_WAIT_UNTIL == 0) with a local store plus an acquire-release fence at all 22 sync/broadcast/reduce/scan/fcollect sites. Each clear is preceded by a fully-draining counting wait, so the incoming call-ins are already drained and a local reset before the next reuse is race-free; remote ack/signal puts are unchanged.

- transport_ofi.h: skip the progress-lock trylock/unlock in shmem_transport_probe() when running SHMEM_THREAD_SINGLE, and read the put error counter in shmem_transport_quiet() only when completions have stalled (success < cnt) instead of every spin, keeping error detection intact.

Barrier microbenchmark (osu_oshm_barrier) shows a ~15-40 percent reduction of the pure barrier. 